### PR TITLE
Feature ETP-80: Etendo Hook Binder: Add metadata module

### DIFF
--- a/packages/EtendoHookBinder/.env.template
+++ b/packages/EtendoHookBinder/.env.template
@@ -1,0 +1,3 @@
+VITE_API_BASE_URL="http://localhost:8080/etendo" # Etendo Classic URL
+VITE_API_TOKEN="YWRtaW46YWRtaW4=" # Buffer.from('admin:admin').to('base64')
+VITE_CACHE_DURATION="3600000" # miliseconds: 1 hour

--- a/packages/EtendoHookBinder/docs/USAGE.md
+++ b/packages/EtendoHookBinder/docs/USAGE.md
@@ -1,0 +1,75 @@
+## Etendo Hook Binder
+
+# Examples:
+
+You can use the metadata module by using the helpers provided by the Metadata Context Provider or you can directly access the metadata using the provided react hooks.
+
+In case you want to go with the context approach, you must wrap your main App like follows:
+
+```tsx
+import MetadataProvider from '@workspaceui/etendohookbinder/src/contexts/metadata';
+.
+.
+.
+export default function App() {
+  return (
+    <MetadataProvider>
+      <Home />
+    </MetadataProvider>
+  );
+}
+```
+
+Then, you can access the metadata using the getWindow and getColumns functions:
+```tsx
+import { useMetadataContext } from '@workspaceui/etendohookbinder/src/hooks/useMetadataContext';
+
+export default function Home() {
+  const { getWindow, getColumns } = useMetadataContext();
+
+  useEffect(() => {
+    getWindow('100').then(w => {
+      console.debug('Window Metadata for Window ID 100');
+      console.debug(w);
+    });
+    getColumns('100').then(cols => {
+      console.debug('Window Columns for Window ID 100');
+      console.debug(cols);
+    });
+  }, [getColumns, getWindow]);
+}
+ 
+```
+
+In case you want to use the 2nd approach and avoid using react contexts, you can use the hooks like follows:
+
+```tsx
+import { useWindow } from '@workspaceui/etendohookbinder/src/hooks/useWindow';
+
+export default function Home() {
+  const { data } = useWindow('100'); // windowId = 100
+
+  useEffect(() => {
+    console.debug('Window Metadata for Window ID 100');
+    console.debug(data); // data is an Etendo.WindowMetadata
+  }, [data]);
+}
+ 
+```
+
+The usage of useWindow and useColumns is pretty much lookalike:
+
+
+```tsx
+import { useColumns } from '@workspaceui/etendohookbinder/src/hooks/useColumns';
+
+export default function Home() {
+  const { data } = useColumns('100'); // windowId = 100
+
+  useEffect(() => {
+    console.debug('Window Columns Metadata for Window ID 100');
+    console.debug(data); // data is an array of Etendo.Field
+  }, [data]);
+}
+ 
+```

--- a/packages/EtendoHookBinder/package.json
+++ b/packages/EtendoHookBinder/package.json
@@ -11,13 +11,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.6.8",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.5",
-    "@mui/icons-material": "^5.15.19",
-    "@mui/material": "^5.15.19"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.75",
@@ -25,9 +20,12 @@
     "@typescript-eslint/eslint-plugin": "^7.6.0",
     "@typescript-eslint/parser": "^7.6.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "postcss": "^8.4.40",
+    "tailwindcss": "^3.4.7",
     "typescript": "^5.4.4",
     "vite": "^5.2.8"
   }

--- a/packages/EtendoHookBinder/postcss.config.js
+++ b/packages/EtendoHookBinder/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/packages/EtendoHookBinder/src/App.css
+++ b/packages/EtendoHookBinder/src/App.css
@@ -1,8 +1,10 @@
 #root {
   max-width: 1280px;
+  width: 100%;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+  font-family: sans-serif;
 }
 
 .logo {

--- a/packages/EtendoHookBinder/src/App.tsx
+++ b/packages/EtendoHookBinder/src/App.tsx
@@ -1,10 +1,33 @@
-import './App.css'
+import { useMemo, useState } from 'react';
+import MetadataTest from './screens/Metadata';
+import DatasourceTest from './screens/Datasource';
+import './App.css';
 
 function App() {
+  const [tab, setTab] = useState<'metadata' | 'datasource'>('metadata');
+
+  const handle = useMemo(() => {
+    return {
+      metadataClick: () => setTab('metadata'),
+      datasourceClick: () => setTab('datasource'),
+    };
+  }, []);
 
   return (
-      <h1>Etendo Hook Binder</h1>
-  )
+    <main>
+      <div className="p-2 text-3xl font-bold">Etendo Hook Binder</div>
+      <div className="flex flex-1 p-2 gap-2 justify-center">
+        <button onClick={handle.metadataClick} className="bg-purple-700 border-0">
+          METADATA TEST
+        </button>
+        <button onClick={handle.datasourceClick} className="bg-yellow-500 text-black border-0">
+          DATASOURCE TEST
+        </button>
+      </div>
+      {tab === 'metadata' ? <MetadataTest /> : <DatasourceTest />}
+    </main>
+  );
 }
 
-export default App
+export default App;
+ 

--- a/packages/EtendoHookBinder/src/Models.ts
+++ b/packages/EtendoHookBinder/src/Models.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 // To parse this data:
 //
 //   import { Convert, Models } from "./file";
@@ -807,7 +808,7 @@ function transform(val: any, typ: any, getProps: any, key: any = '', parent: any
             const typ = typs[i];
             try {
                 return transform(val, typ, getProps);
-            } catch (_) {}
+            } catch (_) { /* empty */ }
         }
         return invalidValue(typs, val, key, parent);
     }
@@ -865,9 +866,9 @@ function transform(val: any, typ: any, getProps: any, key: any = '', parent: any
     }
     if (Array.isArray(typ)) return transformEnum(typ, val);
     if (typeof typ === "object") {
-        return typ.hasOwnProperty("unionMembers") ? transformUnion(typ.unionMembers, val)
-            : typ.hasOwnProperty("arrayItems")    ? transformArray(typ.arrayItems, val)
-            : typ.hasOwnProperty("props")         ? transformObject(getProps(typ), typ.additional, val)
+        return Object.prototype.hasOwnProperty.call(typ, "unionMembers") ? transformUnion(typ.unionMembers, val)
+            : Object.prototype.hasOwnProperty.call(typ, "arrayItems")    ? transformArray(typ.arrayItems, val)
+            : Object.prototype.hasOwnProperty.call(typ, "props")         ? transformObject(getProps(typ), typ.additional, val)
             : invalidValue(typ, val, key, parent);
     }
     // Numbers can be parsed by Date but shouldn't be.

--- a/packages/EtendoHookBinder/src/api/cache.ts
+++ b/packages/EtendoHookBinder/src/api/cache.ts
@@ -1,0 +1,44 @@
+import type { Etendo } from "./metadata";
+
+export class CacheStore<T> {
+  private store: Etendo.CacheStore<T>;
+  private duration: number;
+
+  constructor(duration: number) {
+    this.duration = duration;
+    this.store = new Map<string, Etendo.CachedData<T>>();
+  }
+
+  public has(id: string) {
+    const item = this.store.get(id);
+
+    if (item) {
+      return Date.now() - item.updatedAt < this.duration;
+    }
+
+    return false;
+  }
+
+  public get(id: string) {
+    if (this.store.has(id)) {
+      return this.store.get(id)?.value;
+    }
+  }
+
+  public set(id: string, value: T) {
+    this.store.set(id, {
+      updatedAt: Date.now(),
+      value,
+    });
+
+    return this;
+  }
+
+  public delete(id: string) {
+    return this.store.delete(id);
+  }
+
+  public clear() {
+    return this.store.clear();
+  }
+}

--- a/packages/EtendoHookBinder/src/api/client.ts
+++ b/packages/EtendoHookBinder/src/api/client.ts
@@ -1,0 +1,89 @@
+import { TOKEN } from './constants';
+interface ClientOptions extends RequestInit {
+  headers?: Record<string, string>;
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+}
+
+export class Client {
+  private baseHeaders: HeadersInit;
+  private baseUrl: string;
+  private readonly JSON_CONTENT_TYPE = 'application/json'!;
+  private readonly FORM_CONTENT_TYPE = 'application/x-www-form-urlencoded'!;
+
+  constructor(url: string, baseHeaders: ClientOptions['headers'] = {}) {
+    this.baseUrl = url.endsWith('/') ? url : url + '/';
+    this.baseHeaders = {
+      ...baseHeaders,
+      Authorization: `Basic ${TOKEN}`,
+    };
+  }
+
+  private cleanUrl(url: string) {
+    return url.startsWith('/') ? url.substring(1) : url;
+  }
+
+  private isJson(response: Response) {
+    return (
+      response.headers.get('Content-Type')?.includes('application/json') ??
+      false
+    );
+  }
+
+  private setContentType(options: ClientOptions) {
+    const { headers = {}, body } = options;
+
+    if (!headers['Content-Type']) {
+      headers['Content-Type'] =
+        body instanceof URLSearchParams || typeof body === 'string'
+          ? this.FORM_CONTENT_TYPE
+          : this.JSON_CONTENT_TYPE;
+    }
+
+    options.headers = headers;
+  }
+
+  private async request(url: string, options: ClientOptions = {}) {
+    try {
+      const response = await fetch(`${this.baseUrl}${this.cleanUrl(url)}`, {
+        ...options,
+        headers: {
+          ...this.baseHeaders,
+          ...options.headers,
+        },
+      });
+
+      if (options.method !== 'GET') {
+        this.setContentType(options);
+      }
+
+      const data = await (this.isJson(response)
+        ? response.json()
+        : response.text());
+
+      return {
+        ...response,
+        data,
+      };
+    } catch (error) {
+      console.error('API client request failed', {
+        url,
+        options,
+        error: (error as Error).message,
+      });
+
+      throw error;
+    }
+  }
+
+  public async get(url: string, options: ClientOptions = {}) {
+    return this.request(url, { ...options, method: 'GET' });
+  }
+
+  public async post(
+    url: string,
+    payload: ClientOptions['body'],
+    options: ClientOptions = {},
+  ) {
+    return this.request(url, { ...options, body: payload, method: 'POST' });
+  }
+}

--- a/packages/EtendoHookBinder/src/api/constants.ts
+++ b/packages/EtendoHookBinder/src/api/constants.ts
@@ -1,0 +1,5 @@
+export const TOKEN = import.meta.env['VITE_API_TOKEN'];
+export const API_BASE_URL = import.meta.env['VITE_API_BASE_URL'];
+export const API_DATASOURCE_URL = `${API_BASE_URL}/org.openbravo.service.datasource`;
+export const API_METADATA_URL = `${API_BASE_URL}/org.openbravo.client.kernel`;
+export const API_DEFAULT_CACHE_DURATION = parseInt(import.meta.env['VITE_API_BASE_URL']);

--- a/packages/EtendoHookBinder/src/api/datasource.ts
+++ b/packages/EtendoHookBinder/src/api/datasource.ts
@@ -1,0 +1,25 @@
+import { API_DATASOURCE_URL } from './constants';
+import { Client } from './client';
+import { MetadataParams } from './types';
+
+export class Datasource {
+  private static client = new Client(API_DATASOURCE_URL);
+
+  public static async get(entity: string, options: MetadataParams = {}) {
+    try {
+      options._operationType = 'fetch';
+
+      const result = await this.client.post(
+        entity,
+        //@ts-expect-error Update Metadata params definition
+        new URLSearchParams(options),
+      );
+
+      return result.data;
+    } catch (error) {
+      throw new Error(
+        `Error fetching from datasource for entity ${entity}: ${error}`,
+      );
+    }
+  }
+}

--- a/packages/EtendoHookBinder/src/api/helpers.ts
+++ b/packages/EtendoHookBinder/src/api/helpers.ts
@@ -1,0 +1,5 @@
+export const onChange =
+  (caller: string) =>
+  (item: unknown, view: unknown, form: unknown, grid: unknown) => {
+    console.debug(caller, { item, view, form, grid });
+  };

--- a/packages/EtendoHookBinder/src/api/metadata.ts
+++ b/packages/EtendoHookBinder/src/api/metadata.ts
@@ -1,0 +1,166 @@
+import { API_DEFAULT_CACHE_DURATION, API_METADATA_URL } from './constants';
+import { Client } from './client';
+import { onChange } from './helpers';
+import { CacheStore } from './cache';
+import * as Etendo from './types';
+
+export type { Etendo };
+
+export class Metadata {
+  private static client = new Client(API_METADATA_URL);
+  private static cache = new CacheStore<Etendo.WindowMetadata>(
+    API_DEFAULT_CACHE_DURATION,
+  );
+  private static initialized = false;
+
+  public static isc = {
+    classes: {} as Etendo.WindowMetadataMap,
+    ClassFactory: {
+      defineClass: (className: string, superClass: string) => ({
+        addProperties: (properties: Etendo.WindowMetadataProperties) => {
+          const cn = className.split('_');
+          const newClassName = '_' + cn[1].toString();
+
+          if (!Metadata.isc.classes[newClassName]) {
+            Metadata.isc.classes[newClassName] = {
+              name: className,
+              superClass: superClass,
+              properties: {} as Etendo.WindowMetadataProperties,
+            };
+          }
+
+          Metadata.isc.classes[newClassName].properties = {
+            ...Metadata.isc.classes[newClassName].properties,
+            ...properties,
+          };
+
+          return Metadata.isc.ClassFactory;
+        },
+      }),
+    },
+  };
+
+  private static createProxy(obj: Record<string, unknown>) {
+    return new Proxy(obj, {
+      get(target, prop: string) {
+        if (!(prop in target)) {
+          target[prop] = Metadata.createProxy({});
+        }
+        return target[prop];
+      },
+    });
+  }
+
+  public static OB = Metadata.createProxy({
+    KernelUtilities: Metadata.createProxy({
+      handleSystemException: (err: unknown) => {
+        throw err;
+      },
+    }),
+    PropertyStore: Metadata.createProxy({
+      get: (...args: unknown[]) => {
+        console.log(
+          'OB.PropertyStore.get called with the following args: ',
+          args,
+        );
+
+        return args;
+      },
+    }),
+    OnChange: Metadata.createProxy({
+      organizationCurrency: onChange('organizationCurrency'),
+      processDefinitionUIPattern: onChange('processDefinitionUIPattern'),
+      agingProcessDefinitionOverdue: onChange('agingProcessDefinitionOverdue'),
+      colorSelection: onChange('colorSelection'),
+      agingProcessDefinitionOrganization: onChange(
+        'agingProcessDefinitionOrganization',
+      ),
+    }),
+    Application: Metadata.createProxy({}),
+  });
+
+  private static setup = async () => {
+    if (Metadata.initialized) {
+      return;
+    } else {
+      Metadata.initialized = true;
+    }
+
+    Object.defineProperty(window, 'OB', { value: Metadata.OB });
+    Object.defineProperty(window, 'isc', { value: Metadata.isc });
+    Object.defineProperty(Array.prototype, 'sortByProperty', {
+      value: () => null,
+    });
+
+    return Metadata.getSession();
+  };
+
+  // TODO: Remove empty object and update with the right value
+  public static standardWindow = {};
+
+  private static async _getWindow(
+    windowId: Etendo.WindowId,
+  ): Promise<Etendo.WindowMetadata> {
+    try {
+      const response = await Metadata.client.get(
+        `OBUIAPP_MainLayout/View?viewId=_${windowId}`,
+      );
+      const script = document.createElement('script');
+
+      script.type = 'text/javascript';
+      script.textContent = response.data;
+      document.head.appendChild(script);
+      document.head.removeChild(script);
+
+      const value = Metadata.isc.classes[`_${windowId}`];
+
+      Metadata.cache.set(windowId, value);
+
+      return value;
+    } catch (error) {
+      throw new Error(
+        `Error fetching metadata for window ${windowId}:\n${(error as Error).message}`,
+      );
+    }
+  }
+
+  public static async getWindow(
+    windowId: Etendo.WindowId,
+  ): Promise<Etendo.WindowMetadata> {
+    await Metadata.setup();
+
+    const cached = Metadata.cache.get(windowId);
+
+    if (cached) {
+      return cached;
+    } else {
+      return Metadata._getWindow(windowId);
+    }
+  }
+
+  public static async getColumns(tabId: string) {
+    const item = Object.values(Metadata.isc.classes).find(
+      windowObj =>
+        windowObj.properties.viewProperties.tabId.toString() ===
+        tabId.toString(),
+    );
+
+    if (!item) {
+      return [];
+    }
+
+    return item.properties.viewProperties.fields;
+  }
+
+  public static async getSession() {
+    const response = await Metadata.client.get(
+      `/OBCLKER_Kernel/SessionDynamic`,
+    );
+    const script = document.createElement('script');
+
+    script.type = 'text/javascript';
+    script.textContent = response.data;
+    document.head.appendChild(script);
+    document.head.removeChild(script);
+  }
+}

--- a/packages/EtendoHookBinder/src/api/types.ts
+++ b/packages/EtendoHookBinder/src/api/types.ts
@@ -1,0 +1,96 @@
+export type WindowId = string;
+export type ColumnId = string;
+export type Metadata = string;
+
+export interface CachedData<T> {
+  updatedAt: number;
+  value: T;
+}
+
+export interface CacheStore<T> extends Map<string, CachedData<T>> {}
+
+export interface Criteria {
+  fieldName: string;
+  operator: string;
+  value: string;
+}
+
+export interface MetadataParams extends Record<string, unknown> {
+  _windowId?: string;
+  _columns?: string[];
+  _startRow?: string;
+  _endRow?: string;
+  _targetRecordId?: string;
+  _sortBy?: string;
+  _writeToFile?: boolean;
+  _criteria?: Criteria[];
+  _mode?: 'SHOW_COLUMNS' | 'GET_DATA';
+  _operationType?: 'fetch' | 'add' | 'update' | 'remove';
+}
+
+export interface GridProps {
+  sort: number;
+  autoExpand: boolean;
+  editorProps: {
+    displayField: string;
+    valueField: string;
+  };
+  displaylength: number;
+  fkField: boolean;
+  selectOnClick: boolean;
+  canSort: boolean;
+  canFilter: boolean;
+  showHover: boolean;
+  filterEditorProperties: {
+    keyProperty: string;
+  };
+  showIf: string;
+}
+
+export interface Field {
+  name: string;
+  id: string;
+  title: string;
+  required: boolean;
+  hasDefaultValue: boolean;
+  columnName: string;
+  inpColumnName: string;
+  refColumnName: string;
+  targetEntity: string;
+  gridProps: GridProps;
+  type: string; // Consider specifying possible values if known
+}
+
+export interface ViewStandardProperties extends Record<string, unknown> {
+  // Define known properties if possible
+}
+
+export interface WindowMetadataProperties {
+  windowId: string;
+  multiDocumentEnabled: boolean;
+  viewProperties: {
+    fields: Field[];
+    tabTitle: string;
+    entity: string;
+    statusBarFields: unknown[];
+    iconToolbarButtons: unknown[];
+    actionToolbarButtons: unknown[];
+    isDeleteableTable: boolean;
+    tabId: string;
+    moduleId: string;
+    showCloneButton: boolean;
+    askToCloneChildren: boolean;
+    standardProperties: ViewStandardProperties;
+    showParentButtons: boolean;
+    buttonsHaveSessionLogic: boolean;
+    initialPropertyToColumns: unknown[]; // Define if known
+  };
+}
+
+export interface WindowMetadata {
+  name: string;
+  superClass?: string;
+  properties: WindowMetadataProperties;
+}
+
+export interface WindowMetadataMap extends Record<string, WindowMetadata> {}

--- a/packages/EtendoHookBinder/src/contexts/metadata.tsx
+++ b/packages/EtendoHookBinder/src/contexts/metadata.tsx
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { Metadata } from '../api/metadata';
+
+const ctx = { getWindow: Metadata.getWindow, getColumns: Metadata.getColumns };
+
+export const MetadataContext = createContext(ctx);
+
+export default function MetadataProvider(props: React.PropsWithChildren) {
+  return (
+    <MetadataContext.Provider value={ctx}>
+      {props.children}
+    </MetadataContext.Provider>
+  );
+}

--- a/packages/EtendoHookBinder/src/hooks/useColumns.ts
+++ b/packages/EtendoHookBinder/src/hooks/useColumns.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Metadata } from '../api/metadata';
+import { Field } from '../api/types';
+
+export function useColumns(
+  tabId: string | undefined,
+) {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<Field[]>();
+  const [error, setError] = useState<Error>();
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(() => {
+    const f = async () => {
+      if (!tabId) {
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(undefined);
+        setData(await Metadata.getColumns(tabId));
+        setLoaded(true);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    return f();
+  }, [tabId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return useMemo(
+    () => ({ loading, data, error, loaded, load }),
+    [data, error, loading, loaded, load],
+  );
+}

--- a/packages/EtendoHookBinder/src/hooks/useDatasource.ts
+++ b/packages/EtendoHookBinder/src/hooks/useDatasource.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Datasource } from '../api/datasource';
+
+export function useDatasource(entity?: string) {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<Record<string, unknown>[]>([]);
+  const [error, setError] = useState<Error>();
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(() => {
+    const f = async () => {
+      try {
+        if (!entity) {
+          return;
+        }
+
+        setLoading(true);
+        setError(undefined);
+        const result = await Datasource.get(entity, {
+          _startRow: '0',
+          _endRow: '10',
+        });
+        setData(result.response.data);
+        setLoaded(true);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    return f();
+  }, [entity]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return useMemo(
+    () => ({ loading, data, error, loaded, load }),
+    [data, error, loading, loaded, load],
+  );
+}

--- a/packages/EtendoHookBinder/src/hooks/useMetadataContext.ts
+++ b/packages/EtendoHookBinder/src/hooks/useMetadataContext.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { MetadataContext } from '../contexts/metadata';
+
+export const useMetadataContext = () => useContext(MetadataContext);
+

--- a/packages/EtendoHookBinder/src/hooks/useWindow.ts
+++ b/packages/EtendoHookBinder/src/hooks/useWindow.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Metadata } from '../api/metadata';
+import { WindowMetadata } from '../api/types';
+
+export function useWindow(windowId: string) {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<WindowMetadata>();
+  const [error, setError] = useState<Error>();
+  const [loaded, setLoaded] = useState(false);
+
+  const load = useCallback(() => {
+    const f = async () => {
+      try {
+        setLoading(true);
+        setError(undefined);
+        setData(await Metadata.getWindow(windowId));
+        setLoaded(true);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    return f();
+  }, [windowId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return useMemo(
+    () => ({ loading, data, error, loaded, load }),
+    [data, error, loading, loaded, load],
+  );
+}

--- a/packages/EtendoHookBinder/src/index.css
+++ b/packages/EtendoHookBinder/src/index.css
@@ -1,8 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
@@ -35,32 +38,25 @@ h1 {
 }
 
 button {
+  @apply font-bold uppercase shadow-sm border-0;
   border-radius: 8px;
-  border: 1px solid transparent;
   padding: 0.6em 1.2em;
   font-size: 1em;
-  font-weight: 500;
   background-color: #1a1a1a;
   cursor: pointer;
   transition: border-color 0.25s;
 }
+
 button:hover {
   border-color: #646cff;
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: none;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+input, select, textarea {
+  background-color: #444444;
+  border: 1px solid #ffffff50;
+  outline: none;
 }

--- a/packages/EtendoHookBinder/src/screens/Datasource.tsx
+++ b/packages/EtendoHookBinder/src/screens/Datasource.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useState } from 'react';
+import { Datasource } from '../api/datasource';
+import styles from './styles.module.css';
+
+export default function DatasourceTest() {
+  const [entity, setEntity] = useState('Order');
+  const [page, setPage] = useState<number>(1);
+  const [size, setSize] = useState<number>(1);
+  const [data, setData] = useState<Record<string, unknown | { data: [] }>>();
+
+  const handleEntityChange = useCallback(
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      setEntity(e.currentTarget.value);
+    },
+    [],
+  );
+
+  const handleSizeChange = useCallback(
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      const _size = parseInt(e.currentTarget.value);
+
+      if (_size > 0) {
+        setSize(_size);
+      }
+    },
+    [],
+  );
+
+  const handlePageChange = useCallback(
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      const _page = parseInt(e.currentTarget.value);
+
+      if (_page > 0) {
+        setPage(_page);
+      }
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.SyntheticEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const f = async () => {
+        const _startRow = (page - 1) * size;
+        const _endRow = page * size - 1;
+        const { response } = await Datasource.get(entity, {
+          _startRow: _startRow.toString(),
+          _endRow: _endRow.toString(),
+        });
+
+        setData(response);
+      };
+
+      return f().catch(console.warn);
+    },
+    [entity, page, size],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.container}>
+      <div className={styles.field}>
+        <label htmlFor="entity">Entity</label>
+        <input
+          className={styles.input}
+          type="text"
+          value={entity}
+          onChange={handleEntityChange}
+        />
+      </div>
+      <div className={styles.field}>
+        <label htmlFor="page">Page</label>
+        <input
+          className={styles.input}
+          type="text"
+          value={page}
+          onChange={handlePageChange}
+        />
+      </div>
+      <div className={styles.field}>
+        <label htmlFor="size">Size</label>
+        <input
+          type="text"
+          className={styles.input}
+          value={size}
+          onChange={handleSizeChange}
+        />
+      </div>
+      <button type="submit" className={styles.button}>
+        Load records
+      </button>
+      {data?.data instanceof Array ? (
+        <div className={styles.summary}>
+          Total results: {data?.data?.length}
+        </div>
+      ) : null}
+      <textarea
+        className={styles.code}
+        value={data ? JSON.stringify(data, null, 2) : ''}
+        rows={16}
+        readOnly
+      />
+    </form>
+  );
+}

--- a/packages/EtendoHookBinder/src/screens/Metadata.tsx
+++ b/packages/EtendoHookBinder/src/screens/Metadata.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+import styles from './styles.module.css';
+import { useWindow } from '../hooks/useWindow';
+
+export default function MetadataTest() {
+  const [windowId, setWindowId] = useState('143');
+  const { loading, data, error, load } = useWindow(windowId);
+
+  const handleWindowIdChange = useCallback(
+    (e: React.SyntheticEvent<HTMLInputElement>) => {
+      setWindowId(e.currentTarget.value);
+    },
+    [],
+  );
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.field}>
+        <label htmlFor="windowId">Window ID</label>
+        <input
+          className={styles.input}
+          type="text"
+          value={windowId}
+          onChange={handleWindowIdChange}
+        />
+      </div>
+      {error ? <div className={styles.error}>{error.message}</div> : null}
+      <button onClick={load} className="" disabled={loading}>
+        {loading ? 'Loading...' : 'Load Window'}
+      </button>
+      <textarea
+        className={styles.code}
+        value={data ? JSON.stringify(data, null, 2) : ''}
+        rows={16}
+        readOnly
+      />
+    </div>
+  );
+}

--- a/packages/EtendoHookBinder/src/screens/styles.module.css
+++ b/packages/EtendoHookBinder/src/screens/styles.module.css
@@ -1,0 +1,68 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  flex: 1;
+  gap: 0.5rem;
+}
+
+.field label {
+  flex: 0;
+  min-width: fit-content;
+}
+
+.input, .select {
+  flex: 1;
+  outline: 0 !important;
+  border: none ;
+  min-height: 2.5rem;
+  padding: 0 0.5rem;
+  border-radius: 0.5rem;
+}
+
+.input {
+  min-height: 2.5rem;
+  padding: 0 0.5rem;
+  outline: 0 !important;
+  appearance: none;
+  border: none;
+}
+
+.select option {
+  outline: 0 !important;
+}
+
+.button {
+  font-size: small;
+  font-weight: bold;
+  height: 2.5rem;
+  text-transform: uppercase;
+  border-radius: 0.2rem;
+}
+
+.summary {
+  font-size: small;
+  text-align: left;
+}
+
+.code {
+  text-align: left;
+  padding: 0.25rem;
+  margin: 0;
+  font-size: smaller;
+  font-family: 'Ubuntu Mono', 'SF Mono', 'Courier New', Courier, monospace;
+  border: none;
+  outline: none;
+}
+
+.error {
+  white-space: pre;
+}

--- a/packages/EtendoHookBinder/tailwind.config.js
+++ b/packages/EtendoHookBinder/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+

--- a/packages/EtendoHookBinder/vite.config.ts
+++ b/packages/EtendoHookBinder/vite.config.ts
@@ -5,8 +5,11 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   build: {
+    cssMinify: true,
+    minify: true,
     rollupOptions: {
-      external: ['@mui/material']
+      strictDeprecations: true,
+      treeshake: true,
     }
   }
 })


### PR DESCRIPTION
## Etendo Hook Binder

# Examples:

You can use the metadata module by using the helpers provided by the Metadata Context Provider or you can directly access the metadata using the provided react hooks.

In case you want to go with the context approach, you must wrap your main App like follows:

```tsx
import MetadataProvider from '@workspaceui/etendohookbinder/src/contexts/metadata';
.
.
.
export default function App() {
  return (
    <MetadataProvider>
      <Home />
    </MetadataProvider>
  );
}
```

Then, you can access the metadata using the getWindow and getColumns functions:
```tsx
import { useMetadataContext } from '@workspaceui/etendohookbinder/src/hooks/useMetadataContext';

export default function Home() {
  const { getWindow, getColumns } = useMetadataContext();

  useEffect(() => {
    getWindow('143').then((w: Etendo.WindowMetadata) => {
      console.debug('Window Metadata for Window ID 143');
      console.debug(w);

      const tabId = w.properties.viewProperties.tabId;

      getColumns(tabId).then(cols => {
        console.debug('Window Columns for Tab ID' + tabId);
        console.debug(cols);
      });
    });
  }, [getColumns, getWindow]);
}
 
```

In case you want to use the 2nd approach and avoid using react contexts, you can use the hooks like follows:

```tsx
import { useWindow } from '@workspaceui/etendohookbinder/src/hooks/useWindow';

export default function Home() {
  const { data } = useWindow('100'); // windowId = 100

  useEffect(() => {
    console.debug('Window Metadata for Window ID 100');
    console.debug(data); // data is an Etendo.WindowMetadata
  }, [data]);
}
 
```

The usage of useWindow and useColumns is pretty much lookalike:


```tsx
import { useColumns } from '@workspaceui/etendohookbinder/src/hooks/useColumns';

export default function Home() {
  const { data } = useColumns('186'); // tabId = 186

  useEffect(() => {
    console.debug('Window Columns Metadata for Tab ID 186');
    console.debug(data); // data is an array of Etendo.Field
  }, [data]);
}
 
```


## You need to copy the .env.template to .env and make sure the `VITE_API_BASE_URL` and `VITE_API_TOKEN` are correctly defined


Example of dynamic table generated using the metadata, based on the provided window ID:

![image](https://github.com/user-attachments/assets/034b452d-cf57-4eaf-b3b5-f9811de8028b)

In the provided example, the table and the records has been loaded from the Metadata and Datasource modules 
