### PR TITLE
Feature EPL-1728: First model of the Tab container component 

### DIFF
--- a/packages/ComponentLibrary/src/components/Drawer/index.tsx
+++ b/packages/ComponentLibrary/src/components/Drawer/index.tsx
@@ -21,7 +21,7 @@ const Drawer = ({ items, logo, title, onClick }: DrawerProps) => {
   );
 
   return (
-    <Box>
+    <>
       <MuiDrawer
         variant="permanent"
         open={open}
@@ -43,7 +43,7 @@ const Drawer = ({ items, logo, title, onClick }: DrawerProps) => {
         width={open ? styles.drawerWidth : styles.drawerWidthClosed}
         className="animated-width"
       />
-    </Box>
+    </>
   );
 };
 

--- a/packages/ComponentLibrary/src/components/Table/styles.ts
+++ b/packages/ComponentLibrary/src/components/Table/styles.ts
@@ -36,34 +36,6 @@ export const tableStyles: Record<string, SxProps<Theme>> = {
       marginBottom: 0,
     },
   },
-  container: {
-    display: 'flex',
-    flex: 1,
-    transition: 'all 0.3s ease',
-    position: 'relative',
-    padding: '1rem 0 1rem 0',
-    flexDirection: 'column',
-    gap: '1rem',
-    overflow: 'hidden',
-  },
-  tablePaper: {
-    borderRadius: '1rem',
-    overflow: 'auto',
-    transition: 'width 0.3s ease',
-  },
-  sidebarPaper: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    backgroundColor: theme.palette.baselineColor.neutral[10],
-    boxShadow: '-4px 0 10px rgba(0, 0, 0, 0.1)',
-    padding: '0.5rem',
-    transition: 'transform 0.3s ease',
-    borderRadius: '1rem',
-    backgroundSize: 'cover',
-    backgroundPosition: 'center',
-    backgroundRepeat: 'no-repeat',
-  },
   tableBodyRow: {
     cursor: 'pointer',
   },
@@ -272,7 +244,7 @@ export const recordContentStyles: Record<string, SxProps<Theme>> = {
 export const resizableTabContainerStyles: Record<string, SxProps<Theme>> = {
   paper: {
     position: 'absolute',
-    bottom: '-94vh',
+    bottom: 0,
     width: '99.5%',
     borderRadius: '1rem 1rem 0 0',
     transition: 'transform 0.3s ease, height 0.3s ease',

--- a/packages/MainUI/src/App.tsx
+++ b/packages/MainUI/src/App.tsx
@@ -4,18 +4,14 @@ import { theme } from '@workspaceui/componentlibrary/src/theme';
 import { Outlet } from 'react-router-dom';
 import Navigation from './components/navigation';
 import Box from '@mui/material/Box';
-import Sidebar from "./components/sidebar";
+import Sidebar from './components/sidebar';
+import { styles } from './styles';
 
 const _App = () => {
   return (
-    <Box display="flex" minHeight="100%">
+    <Box sx={styles.fullScreenBox}>
       <Sidebar />
-      <Box
-        flexDirection="column"
-        display="flex"
-        overflow="hidden"
-        flex={1}
-        padding={1}>
+      <Box overflow="hidden" position="relative" flex={1} padding={1}>
         <Navigation />
         <Outlet />
       </Box>

--- a/packages/MainUI/src/styles.ts
+++ b/packages/MainUI/src/styles.ts
@@ -4,5 +4,6 @@ export const styles = {
     height: '100vh',
     width: '100vw',
     overflow: 'hidden',
+    display: 'flex',
   },
 };


### PR DESCRIPTION
This fixes the layout issues that came up after merging #108 and #109

before:
![image](https://github.com/user-attachments/assets/06f259d7-986b-4081-83a8-cb401b25b195)


after:
![image](https://github.com/user-attachments/assets/197e4d53-d2f0-4472-ac8b-9b1f0e6faae6)
