### PR TITLE
Feature ETP-380: Add navigation funcionality to existing TableDir selector

### DIFF
--- a/packages/MainUI/src/components/FormView/selectors/index.tsx
+++ b/packages/MainUI/src/components/FormView/selectors/index.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useCallback } from 'react';
 import { Box, Link } from '@mui/material';
 import { TextInputBase } from '@workspaceui/componentlibrary/src/components';
-import { useNavigate } from 'react-router-dom';
 import { styles, sx } from '../styles';
 import { FieldLabelProps, FieldValue, FormFieldGroupProps } from '../types';
 import TableDirSelector from './TableDirSelector';
@@ -31,8 +30,6 @@ const FieldLabel: React.FC<FieldLabelProps> = ({
 
 const FormFieldGroup: React.FC<FormFieldGroupProps> = memo(
   ({ field, onChange, readOnly }) => {
-    const navigate = useNavigate();
-
     const handleLinkClick = useCallback(() => {
       if (
         field.type === 'tabledir' &&
@@ -42,9 +39,9 @@ const FormFieldGroup: React.FC<FormFieldGroupProps> = memo(
       ) {
         const recordId = field.value.id;
         const windowId = field.original.referencedWindowId;
-        navigate(`/window/${windowId}/${recordId}`);
+        location.href = `/window/${windowId}/${recordId}`;
       }
-    }, [field, navigate]);
+    }, [field]);
 
     const renderField = () => {
       switch (field.type) {

--- a/packages/MainUI/src/components/FormView/selectors/index.tsx
+++ b/packages/MainUI/src/components/FormView/selectors/index.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useCallback } from 'react';
 import { Box, Link } from '@mui/material';
 import { TextInputBase } from '@workspaceui/componentlibrary/src/components';
+import { useNavigate } from 'react-router-dom';
 import { styles, sx } from '../styles';
 import { FieldLabelProps, FieldValue, FormFieldGroupProps } from '../types';
 import TableDirSelector from './TableDirSelector';
@@ -30,9 +31,20 @@ const FieldLabel: React.FC<FieldLabelProps> = ({
 
 const FormFieldGroup: React.FC<FormFieldGroupProps> = memo(
   ({ field, onChange, readOnly }) => {
+    const navigate = useNavigate();
+
     const handleLinkClick = useCallback(() => {
-      console.log(`Clicked on link for ${field.label}`);
-    }, [field.label]);
+      if (
+        field.type === 'tabledir' &&
+        field.value &&
+        typeof field.value === 'object' &&
+        'id' in field.value
+      ) {
+        const recordId = field.value.id;
+        const windowId = field.original.referencedWindowId;
+        navigate(`/window/${windowId}/${recordId}`);
+      }
+    }, [field, navigate]);
 
     const renderField = () => {
       switch (field.type) {

--- a/packages/MainUI/src/screens/Form/types.ts
+++ b/packages/MainUI/src/screens/Form/types.ts
@@ -21,6 +21,7 @@ export interface BaseFieldDefinition<T> {
   required?: boolean;
   original: {
     referencedEntity: string;
+    referencedWindowId: string;
     fieldName: string;
   } & Field;
 }


### PR DESCRIPTION
Function to click the label of the table dir and navigate to the url of the referenced entity which mean getting the windowReferenced and the recordId to pass to the URL