### PR TITLE
Feature ETP-1122: Update API to use new delegated URL

### DIFF
--- a/packages/ComponentLibrary/src/components/Drawer/Search/index.tsx
+++ b/packages/ComponentLibrary/src/components/Drawer/Search/index.tsx
@@ -16,7 +16,7 @@ const DrawerItems: React.FC<DrawerItemsProps> = ({
 
   return (
     <>
-      {items.map(item => {
+      {Array.isArray(items) ? items.map(item => {
         refs.current[item.id] = refs.current[item.id] ? refs.current[item.id] : () => toggleItemExpansion(item.id);
 
         return (
@@ -35,7 +35,7 @@ const DrawerItems: React.FC<DrawerItemsProps> = ({
             />
           </React.Fragment>
         );
-      })}
+      }) : null}
     </>
   );
 };

--- a/packages/ComponentLibrary/src/components/FormView/Sections/DottedLine.tsx
+++ b/packages/ComponentLibrary/src/components/FormView/Sections/DottedLine.tsx
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { Box, useTheme } from '@mui/material';
+
+const useStyle = () => {
+  const theme = useTheme();
+
+  return useMemo(
+    () => ({
+      dottedLine: {
+        backgroundImage: `radial-gradient(circle, ${theme.palette.divider} 1px, transparent 1px)`,
+        backgroundSize: '8px 8px',
+        backgroundPosition: 'right',
+        backgroundRepeat: 'repeat-y',
+        width: '8px',
+        height: '100%',
+        margin: '0 1rem',
+      },
+    }),
+    [theme.palette.divider],
+  );
+};
+
+const DottedLine = ({
+  fields,
+  dottedLineInterval,
+  index,
+}: {
+  fields: unknown[];
+  dottedLineInterval: number;
+  index: number;
+}) => {
+  const { dottedLine } = useStyle();
+  const shouldRenderDottedLine = index < fields.length && (index + 1) % dottedLineInterval !== 0;
+
+  if (shouldRenderDottedLine) {
+    return <Box sx={dottedLine} />;
+  }
+
+  return null;
+};
+
+export default DottedLine;

--- a/packages/ComponentLibrary/src/components/FormView/Sections/FormSection.tsx
+++ b/packages/ComponentLibrary/src/components/FormView/Sections/FormSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { Fragment, useCallback } from 'react';
 import { Accordion, AccordionSummary, AccordionDetails, Typography, Box, Grid, useTheme } from '@mui/material';
 import ChevronDown from '../../../assets/icons/chevron-down.svg';
 import InfoIcon from '../../../assets/icons/info.svg';
@@ -6,6 +6,7 @@ import { defaultFill, useStyle } from '../styles';
 import { FormSectionProps } from '../types';
 import FormFieldGroup from '../selectors';
 import IconButton from '../../IconButton';
+import DottedLine from './DottedLine';
 
 const FormSection: React.FC<FormSectionProps> = ({
   sectionName,
@@ -23,7 +24,7 @@ const FormSection: React.FC<FormSectionProps> = ({
   onLabelClick,
   tab,
 }) => {
-  const { sx, styles } = useStyle();
+  const { sx } = useStyle();
   const theme = useTheme();
   const handleChange = useCallback(
     (_: unknown, isExpanded: boolean) => onAccordionChange(sectionData.id, isExpanded),
@@ -68,10 +69,10 @@ const FormSection: React.FC<FormSectionProps> = ({
           <Grid container>
             {fields.map(([key, field], index) => (
               <Grid item {...gridItemProps} key={field.original.id} sx={sx.gridItem}>
-                <>
+                <Fragment>
                   <FormFieldGroup name={key} field={field} readOnly={readOnly} onLabelClick={onLabelClick} tab={tab} />
-                  {index < fields.length && (index + 1) % dottedLineInterval !== 0 && <Box sx={styles.dottedLine} />}
-                </>
+                  <DottedLine fields={fields} dottedLineInterval={dottedLineInterval} index={index} />
+                </Fragment>
               </Grid>
             ))}
           </Grid>

--- a/packages/ComponentLibrary/src/components/FormView/Sections/FormSection.tsx
+++ b/packages/ComponentLibrary/src/components/FormView/Sections/FormSection.tsx
@@ -68,14 +68,10 @@ const FormSection: React.FC<FormSectionProps> = ({
           <Grid container>
             {fields.map(([key, field], index) => (
               <Grid item {...gridItemProps} key={field.original.id} sx={sx.gridItem}>
-                <FormFieldGroup
-                  name={key}
-                  field={field}
-                  readOnly={readOnly}
-                  onLabelClick={onLabelClick}
-                  tab={tab}
-                />
-                {index < fields.length && (index + 1) % dottedLineInterval !== 0 && <Box sx={styles.dottedLine} />}
+                <>
+                  <FormFieldGroup name={key} field={field} readOnly={readOnly} onLabelClick={onLabelClick} tab={tab} />
+                  {index < fields.length && (index + 1) % dottedLineInterval !== 0 && <Box sx={styles.dottedLine} />}
+                </>
               </Grid>
             ))}
           </Grid>

--- a/packages/ComponentLibrary/src/components/FormView/styles.ts
+++ b/packages/ComponentLibrary/src/components/FormView/styles.ts
@@ -16,15 +16,6 @@ export const useStyle = (): StylesType => {
   return useMemo(
     () => ({
       styles: {
-        dottedLine: {
-          backgroundImage: `radial-gradient(circle, ${theme.palette.divider} 1px, transparent 1px)`,
-          backgroundSize: '8px 8px',
-          backgroundPosition: 'right',
-          backgroundRepeat: 'repeat-y',
-          width: '8px',
-          height: '100%',
-          margin: '0 1rem',
-        },
         dottedSpacing: {
           flex: 1,
           backgroundImage: `radial-gradient(circle, ${theme.palette.text.secondary} 1px, transparent 1px)`,

--- a/packages/EtendoHookBinder/src/api/client.ts
+++ b/packages/EtendoHookBinder/src/api/client.ts
@@ -68,6 +68,12 @@ export class Client {
     return this;
   }
 
+  public addQueryParam(key: string, value: string) {
+    this.baseQueryParams.set(key, value);
+
+    return this;
+  }
+
   private async request(url: string, options: ClientOptions = {}) {
     try {
       if (options.method !== 'GET') {

--- a/packages/EtendoHookBinder/src/api/constants.ts
+++ b/packages/EtendoHookBinder/src/api/constants.ts
@@ -31,7 +31,7 @@ export const API_OBREST_URL = `${API_BASE_URL}/sws/com.smf.securewebservices.obR
 export const API_METADATA_URL = `${API_BASE_URL}/meta/`;
 export const API_DEFAULT_CACHE_DURATION = getDefaultCacheDuration();
 export const AUTH_HEADER_NAME = getAuthHeaderName();
-export const API_CLIENT_KERNEL_SWS_URL = `${API_BASE_URL}/meta/org.openbravo.client.kernel`;
+export const API_KERNEL_SERVLET = `${API_BASE_URL}/meta/servlets/org.openbravo.client.kernel.KernelServlet`;
 
 export enum HTTP_CODES {
   UNAUTHORIZED = 401,

--- a/packages/EtendoHookBinder/src/api/defaultConfig.ts
+++ b/packages/EtendoHookBinder/src/api/defaultConfig.ts
@@ -1,5 +1,5 @@
 import { Client } from './client';
-import { API_CLIENT_KERNEL_SWS_URL } from './constants';
+import { API_KERNEL_SERVLET } from './constants';
 import { DefaultConfiguration } from './types';
 
 const DEFAULT_CONFIG = {
@@ -12,7 +12,7 @@ const DEFAULT_CONFIG = {
 };
 
 export const setDefaultConfiguration = async (token: string, config: DefaultConfiguration): Promise<void> => {
-  const client = new Client(API_CLIENT_KERNEL_SWS_URL).setAuthHeader(token, 'Bearer');
+  const client = new Client(API_KERNEL_SERVLET).setAuthHeader(token, 'Bearer');
 
   const params = {
     language: (config.language || DEFAULT_CONFIG.language).toString(),

--- a/packages/EtendoHookBinder/src/api/getSession.ts
+++ b/packages/EtendoHookBinder/src/api/getSession.ts
@@ -2,7 +2,7 @@ import { API_BASE_URL } from './constants';
 import { SessionResponse } from './types';
 
 export const getSession = async (token: string): Promise<SessionResponse> => {
-  const response = await fetch(`${API_BASE_URL}/meta/session`, {
+  const response = await fetch(`${API_BASE_URL}/meta/session?stateless=true`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,

--- a/packages/EtendoHookBinder/src/api/metadata.ts
+++ b/packages/EtendoHookBinder/src/api/metadata.ts
@@ -2,7 +2,7 @@ import {
   API_DATASOURCE_URL,
   API_DEFAULT_CACHE_DURATION,
   API_METADATA_URL,
-  API_CLIENT_KERNEL_SWS_URL,
+  API_KERNEL_SERVLET,
 } from './constants';
 import { Client, Interceptor } from './client';
 import { CacheStore } from './cache';
@@ -13,7 +13,7 @@ export type { Etendo };
 
 export class Metadata {
   public static client = new Client(API_METADATA_URL);
-  public static kernelClient = new Client(API_CLIENT_KERNEL_SWS_URL);
+  public static kernelClient = new Client(API_KERNEL_SERVLET);
   public static datasourceClient = new Client(API_DATASOURCE_URL);
   private static cache = new CacheStore(API_DEFAULT_CACHE_DURATION);
   private static currentRoleId: string | null = null;
@@ -27,9 +27,9 @@ export class Metadata {
 
   public static setToken(token: string) {
     this.token = token;
-    this.client.setAuthHeader(token, 'Bearer');
-    this.datasourceClient.setAuthHeader(token, 'Bearer');
-    this.kernelClient.setAuthHeader(token, 'Bearer');
+    this.client.setAuthHeader(token, 'Bearer').addQueryParam("stateless", "true");
+    this.datasourceClient.setAuthHeader(token, 'Bearer').addQueryParam("stateless", "true");
+    this.kernelClient.setAuthHeader(token, 'Bearer').addQueryParam("stateless", "true");
   }
 
   public static getToken() {

--- a/packages/EtendoHookBinder/src/utils/metadata.ts
+++ b/packages/EtendoHookBinder/src/utils/metadata.ts
@@ -57,10 +57,6 @@ export const parseColumns = (columns?: Etendo.Field[]): Etendo.Column[] => {
 
 const inputNameCache: Record<string, string> = {};
 
-export function getInputName(field: Field) {
-  return field.fieldName;
-}
-
 export function getInpName(field: Field) {
   try {
     if (!inputNameCache[field.inpName]) {
@@ -78,7 +74,13 @@ export function getInpName(field: Field) {
 export const buildFormState = (fields: Tab['fields'], record: Record<string, unknown>) => {
   try {
     return Object.entries(fields).reduce((state, [fieldName, field]) => {
-      state[fieldName] = record[fieldName];
+      const inputName = getInpName(field);
+
+      if (inputName?.length) {
+        state[inputName] = record[fieldName];
+      } else {
+        console.warn('Missing field input name for', JSON.stringify(field, null, 2));
+      }
 
       return state;
     }, {} as Record<string, unknown>);
@@ -99,6 +101,20 @@ export const getFieldsByDBColumnName = (tab: Tab) => {
       if (!field.column.dBColumnName?.length) {
         console.error(JSON.stringify(field, null, 2));
       }
+
+      return acc;
+    }, {} as Record<string, Field>);
+  } catch (e) {
+    console.warn(e);
+
+    return {};
+  }
+};
+
+export const getFieldsByName = (tab: Tab) => {
+  try {
+    return Object.entries(tab.fields).reduce((acc, [f, field]) => {
+      acc[getInpName(field)] = field;
 
       return acc;
     }, {} as Record<string, Field>);

--- a/packages/MainUI/app/App.tsx
+++ b/packages/MainUI/app/App.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { RecordProvider } from '@/contexts/record';
 import SanityChecker from '../components/SanityChecker';
 import LanguageProvider from '../contexts/languageProvider';
 import MetadataProvider from '../contexts/metadata';
@@ -9,9 +10,11 @@ export default function App({ children }: React.PropsWithChildren) {
   return (
     <LanguageProvider>
       <SanityChecker>
-        <UserProvider>
-          <MetadataProvider>{children}</MetadataProvider>
-        </UserProvider>
+        <RecordProvider>
+          <UserProvider>
+            <MetadataProvider>{children}</MetadataProvider>
+          </UserProvider>
+        </RecordProvider>
       </SanityChecker>
     </LanguageProvider>
   );

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -3,7 +3,7 @@ import { MaterialReactTable, MRT_Row } from 'material-react-table';
 import { useStyle } from './styles';
 import type { DatasourceOptions, Tab } from '@workspaceui/etendohookbinder/src/api/types';
 import Spinner from '@workspaceui/componentlibrary/src/components/Spinner';
-import { memo, useCallback, useContext, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { useDatasource } from '@workspaceui/etendohookbinder/src/hooks/useDatasource';
 import { useParams, useRouter } from 'next/navigation';
 import { useMetadataContext } from '../../hooks/useMetadataContext';
@@ -11,7 +11,6 @@ import { parseColumns } from '@workspaceui/etendohookbinder/src/utils/metadata';
 import { Button } from '@mui/material';
 import DynamicFormView from '../../screens/Form/DynamicFormView';
 import { WindowParams } from '../../app/types';
-import { RecordContext } from '../../contexts/record';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useSearch } from '../../contexts/searchContext';
 
@@ -21,7 +20,6 @@ type DynamicTableProps = {
 
 const DynamicTableContent = memo(function DynamicTableContent({ tab }: DynamicTableProps) {
   const { selected, selectRecord } = useMetadataContext();
-  const { setSelectedRecord } = useContext(RecordContext);
   const { windowId } = useParams<WindowParams>();
   const parent = selected[tab.level - 1];
   const navigate = useRouter().push;
@@ -62,7 +60,6 @@ const DynamicTableContent = memo(function DynamicTableContent({ tab }: DynamicTa
     ({ row }: { row: MRT_Row<Record<string, unknown>> }) => ({
       onClick: () => {
         selectRecord(row.original as never, tab);
-        setSelectedRecord(row.original as never);
         row.toggleSelected();
       },
       onDoubleClick: () => {
@@ -74,7 +71,7 @@ const DynamicTableContent = memo(function DynamicTableContent({ tab }: DynamicTa
         setEditing(true);
       },
     }),
-    [navigate, selectRecord, setSelectedRecord, tab, windowId],
+    [navigate, selectRecord, tab, windowId],
   );
 
   const handleBack = useCallback(() => setEditing(false), []);

--- a/packages/MainUI/contexts/languageProvider.tsx
+++ b/packages/MainUI/contexts/languageProvider.tsx
@@ -11,9 +11,11 @@ export default function LanguageProvider({ children }: React.PropsWithChildren) 
   const [language, setLanguageValue] = useState<Language>(DEFAULT_LANGUAGE);
 
   const setLanguage = useCallback((lang: Language) => {
-    localStorage.setItem('currentLanguage', lang);
-    setLanguageValue(lang);
-    Metadata.setLanguage(lang);
+    if (lang) {
+      localStorage.setItem('currentLanguage', lang);
+      setLanguageValue(lang);
+      Metadata.setLanguage(lang);
+    }
   }, []);
 
   const value = useMemo(() => ({ language, setLanguage }), [language, setLanguage]);

--- a/packages/MainUI/contexts/languageProvider.tsx
+++ b/packages/MainUI/contexts/languageProvider.tsx
@@ -23,7 +23,7 @@ export default function LanguageProvider({ children }: React.PropsWithChildren) 
   useEffect(() => {
     const savedLanguage = localStorage.getItem('currentLanguage');
 
-    if (savedLanguage) {
+    if (savedLanguage && savedLanguage != 'null') {
       setLanguage(savedLanguage as Language);
     } else {
       setLanguage(DEFAULT_LANGUAGE);

--- a/packages/MainUI/contexts/languageProvider.tsx
+++ b/packages/MainUI/contexts/languageProvider.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import LanguageContext from './languageContext';
 import { Language } from './types';
 import { Metadata } from '@workspaceui/etendohookbinder/src/api/metadata';
 
-const DEFAULT_LANGUAGE: Language = 'en_US';
+export const DEFAULT_LANGUAGE: Language = 'en_US';
 
 export default function LanguageProvider({ children }: React.PropsWithChildren) {
   const [language, setLanguageValue] = useState<Language>(DEFAULT_LANGUAGE);
@@ -19,16 +19,6 @@ export default function LanguageProvider({ children }: React.PropsWithChildren) 
   }, []);
 
   const value = useMemo(() => ({ language, setLanguage }), [language, setLanguage]);
-
-  useEffect(() => {
-    const savedLanguage = localStorage.getItem('currentLanguage');
-
-    if (savedLanguage && savedLanguage != 'null') {
-      setLanguage(savedLanguage as Language);
-    } else {
-      setLanguage(DEFAULT_LANGUAGE);
-    }
-  }, [setLanguage]);
 
   if (!language) {
     return null;

--- a/packages/MainUI/contexts/metadata.tsx
+++ b/packages/MainUI/contexts/metadata.tsx
@@ -2,7 +2,11 @@
 
 import { createContext, useCallback, useEffect, useMemo, useState } from 'react';
 import { type Etendo, Metadata } from '@workspaceui/etendohookbinder/src/api/metadata';
-import { groupTabsByLevel } from '@workspaceui/etendohookbinder/src/utils/metadata';
+import {
+  getFieldsByDBColumnName,
+  getFieldsByName,
+  groupTabsByLevel,
+} from '@workspaceui/etendohookbinder/src/utils/metadata';
 import { Field, Tab } from '@workspaceui/etendohookbinder/src/api/types';
 import { useParams } from 'next/navigation';
 import { WindowParams } from '../app/types';
@@ -22,6 +26,8 @@ interface IMetadataContext {
   tabs: Tab[];
   tab?: Tab;
   columns?: Record<string, Field>;
+  fieldsByColumnName: Record<string, Field>;
+  fieldsByInputName: Record<string, Field>;
 }
 
 export const MetadataContext = createContext({} as IMetadataContext);
@@ -79,6 +85,8 @@ export default function MetadataProvider({ children }: React.PropsWithChildren) 
 
   const tab = useMemo(() => windowData?.tabs?.find(t => t.id === tabId), [tabId, windowData?.tabs]);
   const tabs = useMemo<Tab[]>(() => windowData?.tabs ?? [], [windowData]);
+  const fieldsByColumnName = useMemo(() => (tab ? getFieldsByDBColumnName(tab) : {}), [tab]);
+  const fieldsByInputName = useMemo(() => (tab ? getFieldsByName(tab) : {}), [tab]);
 
   const value = useMemo(
     () => ({
@@ -94,8 +102,23 @@ export default function MetadataProvider({ children }: React.PropsWithChildren) 
       selected,
       tabs,
       tab,
+      fieldsByColumnName,
+      fieldsByInputName,
     }),
-    [windowId, recordId, loading, error, groupedTabs, windowData, selectRecord, selected, tabs, tab],
+    [
+      windowId,
+      recordId,
+      loading,
+      error,
+      groupedTabs,
+      windowData,
+      selectRecord,
+      selected,
+      tabs,
+      tab,
+      fieldsByColumnName,
+      fieldsByInputName,
+    ],
   );
 
   useEffect(() => {

--- a/packages/MainUI/contexts/user.tsx
+++ b/packages/MainUI/contexts/user.tsx
@@ -21,7 +21,7 @@ export const UserContext = createContext({} as IUserContext);
 export default function UserProvider(props: React.PropsWithChildren) {
   const [token, setToken] = useState<string | null>(localStorage.getItem('token'));
   const [ready, setReady] = useState(false);
-  const { language, setLanguage: setLanguageContext } = useLanguage();
+  const { setLanguage } = useLanguage();
   const pathname = usePathname();
   const router = useRouter();
   const navigate = router.push;
@@ -52,16 +52,8 @@ export default function UserProvider(props: React.PropsWithChildren) {
     }
   }, []);
 
-  const setLanguage = useCallback(
-    (language: Language) => {
-      localStorage.setItem('currentLanguage', language);
-      setLanguageContext(language);
-    },
-    [setLanguageContext],
-  );
-
   const updateSessionInfo = useCallback(
-    (sessionResponse: SessionResponse, skipLanguage: boolean = false) => {
+    (sessionResponse: SessionResponse) => {
       const currentRole: Role = {
         id: sessionResponse.role.id,
         name: sessionResponse.role.name,
@@ -70,7 +62,7 @@ export default function UserProvider(props: React.PropsWithChildren) {
       localStorage.setItem('currentRole', JSON.stringify(currentRole));
       localStorage.setItem('currentRoleId', currentRole.id);
 
-      if (!skipLanguage) {
+      if (sessionResponse.user.defaultLanguage) {
         setLanguage(sessionResponse.user.defaultLanguage as Language);
       }
 
@@ -216,7 +208,7 @@ export default function UserProvider(props: React.PropsWithChildren) {
           Metadata.setToken(token);
           Datasource.authorize(token);
           const sessionResponse = await getSession(token);
-          updateSessionInfo(sessionResponse, language != null);
+          updateSessionInfo(sessionResponse);
         } catch (error) {
           clearUserData();
           navigate('/login');
@@ -224,7 +216,7 @@ export default function UserProvider(props: React.PropsWithChildren) {
       };
       verifySession();
     }
-  }, [clearUserData, language, navigate, token, updateSessionInfo]);
+  }, [clearUserData, navigate, token, updateSessionInfo]);
 
   useLayoutEffect(() => {
     if (token || pathname === '/login') {

--- a/packages/MainUI/contexts/user.tsx
+++ b/packages/MainUI/contexts/user.tsx
@@ -15,6 +15,7 @@ import { setDefaultConfiguration as apiSetDefaultConfiguration } from '@workspac
 import { usePathname, useRouter } from 'next/navigation';
 import Spinner from '@workspaceui/componentlibrary/src/components/Spinner';
 import { useLanguage } from '../hooks/useLanguage';
+import { DEFAULT_LANGUAGE } from './languageProvider';
 
 export const UserContext = createContext({} as IUserContext);
 
@@ -252,6 +253,21 @@ export default function UserProvider(props: React.PropsWithChildren) {
       };
     }
   }, [navigate, token]);
+
+  useEffect(() => {
+    if (!languages.length) {
+      return;
+    }
+
+    const savedLanguage = localStorage.getItem('currentLanguage');
+    const givenLanguage = languages.find(lang => lang.language == savedLanguage);
+
+    if (givenLanguage) {
+      setLanguage(givenLanguage.language as Language);
+    } else {
+      setLanguage(DEFAULT_LANGUAGE);
+    }
+  }, [languages, languages.length, setLanguage]);
 
   return <UserContext.Provider value={value}>{ready ? props.children : <Spinner />}</UserContext.Provider>;
 }

--- a/packages/MainUI/hooks/Toolbar/useProcessExecution.ts
+++ b/packages/MainUI/hooks/Toolbar/useProcessExecution.ts
@@ -1,8 +1,8 @@
-import { API_BASE_URL } from '@workspaceui/etendohookbinder/src/api/constants';
 import { useState, useContext, useCallback } from 'react';
 import { UserContext } from '../../contexts/user';
 import { ProcessResponse } from '../../components/Toolbar/types';
 import { ExecuteProcessParams } from './types';
+import { Metadata } from '@workspaceui/etendohookbinder/src/api/metadata';
 
 export function useProcessExecution() {
   const [loading, setLoading] = useState(false);
@@ -19,11 +19,9 @@ export function useProcessExecution() {
         setLoading(true);
         setError(null);
 
-        const actionUrl = `${API_BASE_URL}/org.openbravo.client.kernel`;
         const queryParams = new URLSearchParams({
           _action: button.processInfo.javaClassName,
           processId: button.processId,
-          stateless: 'true',
         });
 
         const processParams: Record<string, unknown> = {};
@@ -40,20 +38,14 @@ export function useProcessExecution() {
           _entityName: button.processInfo?._entityName || '',
         };
 
-        const response = await fetch(`${actionUrl}?${queryParams}`, {
+        const { ok, data, status } = await Metadata.kernelClient.post(`?${queryParams}`, {
           method: 'POST',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
           body: JSON.stringify(payload),
         });
 
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+        if (!ok) {
+          throw new Error(`HTTP error! status: ${status}`);
         }
-
-        const data = await response.json();
 
         if (data.response?.status === -1) {
           throw new Error(data.response.error?.message || 'Unknown server error');

--- a/packages/MainUI/hooks/useCallout.ts
+++ b/packages/MainUI/hooks/useCallout.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { Field, Tab } from '@workspaceui/etendohookbinder/src/api/types';
 import { Metadata } from '@workspaceui/etendohookbinder/src/api/metadata';
-import { getInputName } from '@workspaceui/etendohookbinder/src/utils/metadata';
+import { getInpName } from '@workspaceui/etendohookbinder/src/utils/metadata';
 import { FieldValues } from 'react-hook-form';
 
 export interface UseCalloutProps {
@@ -20,7 +20,7 @@ export const useCallout = ({ field, tab, parentId, rowId }: UseCalloutProps) => 
       _action,
       MODE,
       TAB_ID: tab.id,
-      CHANGED_COLUMN: getInputName(field),
+      CHANGED_COLUMN: getInpName(field),
     });
 
     if (rowId) {

--- a/packages/MainUI/screens/Form/DynamicFormView.tsx
+++ b/packages/MainUI/screens/Form/DynamicFormView.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { adaptFormData, mapWindowMetadata } from '../../utils/FormUtils';
 import FormView from '@workspaceui/componentlibrary/src/components/FormView';
 import { useMetadataContext } from '../../hooks/useMetadataContext';
-import { useForm, FormProvider } from 'react-hook-form';
+import { useForm, FormProvider, UseFormProps } from 'react-hook-form';
 import { buildFormState } from '@workspaceui/etendohookbinder/src/utils/metadata';
 import { FormInitializationResponse } from '../../hooks/useFormInitialValues';
 
@@ -31,12 +31,18 @@ function DynamicFormView({
     [navigate],
   );
 
-  const methods = useForm({
-    defaultValues: buildFormState(tab.fields, record),
-    criteriaMode: 'all',
-    mode: 'onSubmit',
-    reValidateMode: 'onSubmit',
-  });
+  const formOptions = useMemo<UseFormProps>(
+    () => ({
+      defaultValues: buildFormState(tab.fields, record),
+      criteriaMode: 'all',
+      mode: 'onSubmit',
+      reValidateMode: 'onSubmit',
+      progressive: true,
+    }),
+    [record, tab.fields],
+  );
+
+  const methods = useForm(formOptions);
 
   if (!formData || !mappedMetadata) return <div>No form data available</div>;
 


### PR DESCRIPTION
Following the changes in MetadataServlet to properly initialize sessions when delegating requests to KernelServlet, as requested in [ETP-1121](https://etendoproject.atlassian.net/browse/ETP-1121), I have updated the URL for the affected requests and added the stateless query parameter where necessary to ensure proper session handling as requested in [ETP-1122](https://etendoproject.atlassian.net/browse/ETP-1122)



[ETP-1121]: https://etendoproject.atlassian.net/browse/ETP-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ETP-1122]: https://etendoproject.atlassian.net/browse/ETP-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ