### PR TITLE
Feature ETP-2443: Fix production client base url

### DIFF
--- a/packages/MainUI/app/actions/process.ts
+++ b/packages/MainUI/app/actions/process.ts
@@ -34,7 +34,7 @@ export async function executeProcess(
     }
 
     // Build URL with proper query parameters to match Classic Etendo behavior
-    const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
     const queryParams = new URLSearchParams();
     queryParams.set("processId", processId);
 


### PR DESCRIPTION
This involves to create a env variable in production something like:

name: NEXT_PUBLIC_APP_URL
              value: https://new-mainui.erp.labs.etendo.cloud