### PR TITLE
Hotfix ETP-3656: Fix Breadcrumb synchronization and Grid selection after record cloning

### DIFF
--- a/docs/components/toolbar.md
+++ b/docs/components/toolbar.md
@@ -152,6 +152,42 @@ function MyComponent() {
 }
 ```
 
+## Copy / Clone Record Behavior
+
+### Overview
+
+The Copy (clone) action in the toolbar duplicates the currently selected record(s) via an API request. After cloning, the graph selection state and the window's selected record reference must both be updated to point at the new clone — not the original. Failing to clear the previous selection causes the Breadcrumb to display the old identifier and the Grid to highlight the wrong row on return from Form view.
+
+### How It Works
+
+`handleCopyRecord` in `useToolbarConfig.ts` orchestrates the clone flow:
+
+1. A confirmation modal is shown. If the tab supports `obuiappCloneChildren`, the user can choose between a shallow clone and a deep clone (with child records).
+2. `copyRecordRequest` sends the clone request to the backend.
+3. On success, `handleCopyRecordResponse` dispatches one of two callbacks:
+
+| Callback | Condition | Actions taken |
+|---|---|---|
+| `onSingleRecord(newRecordId)` | Exactly one record was cloned | Clears graph selection, sets the new record as selected, transitions the tab to Form/Edit view for the clone |
+| `onMultipleRecords()` | Multiple records were cloned | Clears graph selection, clears the selected record reference |
+
+### Selection State Clearing
+
+Both callbacks call `graph.clearSelected(tab)` and `graph.clearSelectedMultiple(tab)` **before** updating `setSelectedRecord` / `clearSelectedRecord`. This ordering is required so that `useCurrentRecord` discards the stale selection and re-derives its value from the new record ID rather than the old one.
+
+Skipping either call before the window state update produces two known symptoms:
+- The Breadcrumb continues to display the identifier of the original record.
+- Returning from Form view to Grid view shows the original record highlighted instead of the clone.
+
+### Clone with Children
+
+When `tab.obuiappCloneChildren` is `true`, the confirmation modal offers three buttons: **Clone** (shallow), **Clone with Children** (deep), and **Cancel**. The `cloneWithChildren` boolean is forwarded to `copyRecordRequest` and controls the backend duplication depth.
+
+### Key Files
+
+- `packages/MainUI/hooks/Toolbar/useToolbarConfig.ts` — `handleCopyRecord` callback
+- `packages/MainUI/utils/processes/toolbar/utils.ts` — `copyRecordRequest`, `handleCopyRecordResponse`
+
 ## Component Architecture
 
 ### Main Components

--- a/docs/components/toolbar.md
+++ b/docs/components/toolbar.md
@@ -168,16 +168,18 @@ The Copy (clone) action in the toolbar duplicates the currently selected record(
 
 | Callback | Condition | Actions taken |
 |---|---|---|
-| `onSingleRecord(newRecordId)` | Exactly one record was cloned | Clears graph selection, sets the new record as selected, transitions the tab to Form/Edit view for the clone |
-| `onMultipleRecords()` | Multiple records were cloned | Clears graph selection, clears the selected record reference |
+| `onSingleRecord(newRecordId)` | Exactly one record was cloned | Sets the new record as selected in the window context, transitions the tab to Form/Edit view for the clone. Grid refresh is deferred until the Table becomes visible again. |
+| `onMultipleRecords()` | Multiple records were cloned | Clears graph selection, clears the selected record reference, triggers grid refresh immediately. |
 
 ### Selection State Clearing
 
-Both callbacks call `graph.clearSelected(tab)` and `graph.clearSelectedMultiple(tab)` **before** updating `setSelectedRecord` / `clearSelectedRecord`. This ordering is required so that `useCurrentRecord` discards the stale selection and re-derives its value from the new record ID rather than the old one.
+`onMultipleRecords` calls `graph.clearSelected(tab)` and `graph.clearSelectedMultiple(tab)` before `clearSelectedRecord`. This ordering ensures the graph cache is evicted before the window context is updated.
 
-Skipping either call before the window state update produces two known symptoms:
-- The Breadcrumb continues to display the identifier of the original record.
-- Returning from Form view to Grid view shows the original record highlighted instead of the clone.
+`onSingleRecord` does **not** call `graph.clearSelected` or `graph.clearSelectedMultiple`. Doing so emits an `"unselected"` event synchronously, which causes `table.setRowSelection({})` → `useTableSelection` → `clearSelectedRecord`, overwriting the new record ID just set in the window context. Instead, the graph cache is naturally invalidated by the record ID change in `useCurrentRecord` (new `paramsKey`), and `FormView` calls `graph.setSelected` once it loads the clone's data.
+
+### Grid Refresh After Single-Record Clone
+
+When one record is cloned, the user is navigated to Form view of the clone. The Table component remains mounted but hidden. A `useEffect` in `Table/index.tsx` detects the visibility transition (`isVisible: false → true`) when the user returns to Grid view, and triggers `refetch()` if a selected record exists. This guarantees the cloned record appears in the grid without requiring an immediate (and wasteful) refresh while the Table is invisible.
 
 ### Clone with Children
 

--- a/packages/MainUI/components/Breadcrums.tsx
+++ b/packages/MainUI/components/Breadcrums.tsx
@@ -17,7 +17,7 @@
 
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import Breadcrumb from "@workspaceui/componentlibrary/src/components/Breadcrums";
 import type { BreadcrumbItem } from "@workspaceui/componentlibrary/src/components/Breadcrums/types";
 import { usePathname } from "next/navigation";
@@ -70,6 +70,10 @@ const AppBreadcrumb: React.FC<BreadcrumbProps> = ({ allTabs }) => {
     recordId: currentRecordId,
   });
 
+  // Retains the last known valid _identifier so the breadcrumb doesn't go blank
+  // during the brief window while a new record is being fetched after a clone.
+  const lastValidLabelRef = useRef<string | undefined>(undefined);
+
   const isNewRecord = useCallback(() => pathname.includes("/NewRecord"), [pathname]);
 
   const handleWindowClick = useCallback(
@@ -110,10 +114,21 @@ const AppBreadcrumb: React.FC<BreadcrumbProps> = ({ allTabs }) => {
       const currentRecordId = tabFormState?.recordId || "";
       const currentLabel = record?._identifier?.toString();
 
-      if (currentRecordId && currentLabel && currentRecordId !== NEW_RECORD_ID) {
+      // If we navigated away from the record, clear the persisted label
+      if (!currentRecordId) {
+        lastValidLabelRef.current = undefined;
+      }
+      // Keep the ref updated whenever we have a fresh label
+      if (currentLabel) {
+        lastValidLabelRef.current = currentLabel;
+      }
+      // Fall back to the last known label while the new record is still loading
+      const displayLabel = currentLabel ?? (currentRecordId ? lastValidLabelRef.current : undefined);
+
+      if (currentRecordId && displayLabel && currentRecordId !== NEW_RECORD_ID) {
         items.push({
           id: currentRecordId.toString(),
-          label: currentLabel,
+          label: displayLabel,
         });
       }
     }

--- a/packages/MainUI/components/ProcessModal/Custom/GenericWarehouseProcess/__tests__/GenericWarehouseProcess.test.tsx
+++ b/packages/MainUI/components/ProcessModal/Custom/GenericWarehouseProcess/__tests__/GenericWarehouseProcess.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { GenericWarehouseProcess } from "../GenericWarehouseProcess";
 import { useTranslation } from "@/hooks/useTranslation";

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -784,6 +784,8 @@ const DynamicTable = ({
   const hasScrolledToSelection = useRef<boolean>(false);
   const previousURLSelection = useRef<string | null>(null);
   const hasRestoredSelection = useRef(false);
+  const prevRestorationId = useRef<string | undefined>(undefined);
+  const wasVisibleRef = useRef(isVisible);
 
   // Use the table data hook
   const {
@@ -3187,6 +3189,44 @@ const DynamicTable = ({
       hasRestoredSelection.current = true;
     }
   }, [activeWindow, tab.window, records, getSelectedRecord, tab.id]);
+
+  /**
+   * Reset hasRestoredSelection when the target selected record ID changes.
+   * This unblocks the selection restoration effect when a new record is set
+   * (e.g., after cloning a record and navigating to the clone).
+   */
+  useEffect(() => {
+    const windowIdentifier = activeWindow?.windowIdentifier;
+    if (!windowIdentifier) return;
+    const urlSelectedId = getSelectedRecord(windowIdentifier, tab.id);
+    if (urlSelectedId !== prevRestorationId.current) {
+      prevRestorationId.current = urlSelectedId;
+      hasRestoredSelection.current = false;
+    }
+  }, [activeWindow, getSelectedRecord, tab.id]);
+
+  /**
+   * When the table becomes visible again (user navigates back from form/clone view),
+   * check if the currently selected record exists in the loaded records.
+   * If not, trigger a refetch so the cloned record appears in the grid.
+   */
+  useEffect(() => {
+    const becameVisible = !wasVisibleRef.current && isVisible;
+    wasVisibleRef.current = isVisible;
+
+    if (!becameVisible) return;
+
+    const windowIdentifier = activeWindow?.windowIdentifier;
+    if (!windowIdentifier) return;
+
+    const urlSelectedId = getSelectedRecord(windowIdentifier, tab.id);
+    if (!urlSelectedId) return;
+
+    const recordExists = records?.some((r: EntityData) => String(r.id) === urlSelectedId);
+    if (!recordExists) {
+      refetch();
+    }
+  }, [isVisible, activeWindow, getSelectedRecord, tab.id, records, refetch]);
 
   useEffect(() => {
     const handleGraphClear = (eventTab: typeof tab) => {

--- a/packages/MainUI/components/window/Tabs.test.tsx
+++ b/packages/MainUI/components/window/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import TabsComponent from "./Tabs";
 import WindowProvider from "@/contexts/window";
-import React from "react";
 
 /**
  * Test helpers

--- a/packages/MainUI/components/window/__tests__/SubTabsSwitch.test.tsx
+++ b/packages/MainUI/components/window/__tests__/SubTabsSwitch.test.tsx
@@ -1,22 +1,3 @@
-/*
- *************************************************************************
- * The contents of this file are subject to the Etendo License
- * (the "License"), you may not use this file except in compliance with
- * the License.
- * You may obtain a copy of the License at
- * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
- * Software distributed under the License is distributed on an
- * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, WITHOUT WARRANTY OF ANY KIND,
- * SOFTWARE OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY WARRANTY OF ANY
- * KIND, either express or implied. See the License for the specific language
- * governing rights and limitations under the License.
- * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
- * All Rights Reserved.
- * Contributor(s): Futit Services S.L.
- *************************************************************************
- */
-
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { SubTabsSwitch } from "../SubTabsSwitch";
 

--- a/packages/MainUI/components/window/__tests__/TabButton.test.tsx
+++ b/packages/MainUI/components/window/__tests__/TabButton.test.tsx
@@ -1,22 +1,3 @@
-/*
- *************************************************************************
- * The contents of this file are subject to the Etendo License
- * (the "License"), you may not use this file except in compliance with
- * the License.
- * You may obtain a copy of the License at
- * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
- * Software distributed under the License is distributed on an
- * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, WITHOUT WARRANTY OF ANY KIND,
- * SOFTWARE OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY WARRANTY OF ANY
- * KIND, either express or implied. See the License for the specific language
- * governing rights and limitations under the License.
- * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
- * All Rights Reserved.
- * Contributor(s): Futit Services S.L.
- *************************************************************************
- */
-
-import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { TabButton } from "../TabButton";
 import { useMetadataContext } from "@/hooks/useMetadataContext";

--- a/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
+++ b/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
@@ -172,7 +172,7 @@ describe("useToolbarConfig", () => {
       expect(handleCopyRecordResponse).toHaveBeenCalled();
     });
 
-    it("clears graph selection and sets new record on onSingleRecord callback", async () => {
+    it("sets new record and navigates to form on onSingleRecord callback without clearing graph selection", async () => {
       const mockClearSelected = jest.fn();
       const mockClearSelectedMultiple = jest.fn();
       (useSelected as jest.Mock).mockReturnValue({
@@ -194,21 +194,20 @@ describe("useToolbarConfig", () => {
         await result.current.actionModal.buttons[0].onClick();
       });
 
-      // Verify ordering: setSelectedRecord must come BEFORE graph clears, and graph
-      // clears must come BEFORE setTabFormState (new correct ordering)
-      const setSelectedRecordOrder = mockSetSelectedRecord.mock.invocationCallOrder[0];
-      const clearSelectedOrder = mockClearSelected.mock.invocationCallOrder[0];
-      const clearSelectedMultipleOrder = mockClearSelectedMultiple.mock.invocationCallOrder[0];
-      const setTabFormStateOrder = mockSetTabFormState.mock.invocationCallOrder[0];
-      expect(setSelectedRecordOrder).toBeLessThan(clearSelectedOrder);
-      expect(setSelectedRecordOrder).toBeLessThan(clearSelectedMultipleOrder);
-      expect(clearSelectedOrder).toBeLessThan(setTabFormStateOrder);
-      expect(clearSelectedMultipleOrder).toBeLessThan(setTabFormStateOrder);
+      // graph.clearSelected / clearSelectedMultiple must NOT be called in the single-record
+      // clone path. Calling them emits "unselected" → table.setRowSelection({}) →
+      // useTableSelection → clearSelectedRecord, which wipes the newRecordId from the
+      // window context and breaks grid selection on return from form view.
+      expect(mockClearSelected).not.toHaveBeenCalled();
+      expect(mockClearSelectedMultiple).not.toHaveBeenCalled();
 
-      expect(mockClearSelected).toHaveBeenCalledWith(mockTab);
-      expect(mockClearSelectedMultiple).toHaveBeenCalledWith(mockTab);
       expect(mockSetSelectedRecord).toHaveBeenCalledWith(mockActiveWindow.windowIdentifier, "tab1", "newRecord123");
       expect(mockSetTabFormState).toHaveBeenCalled();
+
+      // Verify ordering: setSelectedRecord before setTabFormState
+      const setSelectedRecordOrder = mockSetSelectedRecord.mock.invocationCallOrder[0];
+      const setTabFormStateOrder = mockSetTabFormState.mock.invocationCallOrder[0];
+      expect(setSelectedRecordOrder).toBeLessThan(setTabFormStateOrder);
     });
 
     it("clears graph selection and clears selected record on onMultipleRecords callback", async () => {

--- a/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
+++ b/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
@@ -171,6 +171,78 @@ describe("useToolbarConfig", () => {
       );
       expect(handleCopyRecordResponse).toHaveBeenCalled();
     });
+
+    it("clears graph selection and sets new record on onSingleRecord callback", async () => {
+      const mockClearSelected = jest.fn();
+      const mockClearSelectedMultiple = jest.fn();
+      (useSelected as jest.Mock).mockReturnValue({
+        graph: { clearSelected: mockClearSelected, clearSelectedMultiple: mockClearSelectedMultiple },
+      });
+      (useSelectedRecords as jest.Mock).mockReturnValue([{ id: "record1" }]);
+      (copyRecordRequest as jest.Mock).mockResolvedValue({ ok: true, data: {} });
+      (handleCopyRecordResponse as jest.Mock).mockImplementation(({ onSingleRecord }) => {
+        onSingleRecord("newRecord123");
+      });
+
+      const { result } = renderHook(() => useToolbarConfig({ tabId: "tab1", isFormView: false }));
+
+      act(() => {
+        result.current.actionHandlers.COPY_RECORD();
+      });
+
+      await act(async () => {
+        await result.current.actionModal.buttons[0].onClick();
+      });
+
+      // Verify ordering: graph clears must happen before setSelectedRecord/setTabFormState
+      const clearSelectedOrder = mockClearSelected.mock.invocationCallOrder[0];
+      const clearSelectedMultipleOrder = mockClearSelectedMultiple.mock.invocationCallOrder[0];
+      const setSelectedRecordOrder = mockSetSelectedRecord.mock.invocationCallOrder[0];
+      const setTabFormStateOrder = mockSetTabFormState.mock.invocationCallOrder[0];
+      expect(clearSelectedOrder).toBeLessThan(setSelectedRecordOrder);
+      expect(clearSelectedMultipleOrder).toBeLessThan(setSelectedRecordOrder);
+      expect(clearSelectedOrder).toBeLessThan(setTabFormStateOrder);
+      expect(clearSelectedMultipleOrder).toBeLessThan(setTabFormStateOrder);
+
+      expect(mockClearSelected).toHaveBeenCalledWith(mockTab);
+      expect(mockClearSelectedMultiple).toHaveBeenCalledWith(mockTab);
+      expect(mockSetSelectedRecord).toHaveBeenCalledWith(mockActiveWindow.windowIdentifier, "tab1", "newRecord123");
+      expect(mockSetTabFormState).toHaveBeenCalled();
+    });
+
+    it("clears graph selection and clears selected record on onMultipleRecords callback", async () => {
+      const mockClearSelected = jest.fn();
+      const mockClearSelectedMultiple = jest.fn();
+      (useSelected as jest.Mock).mockReturnValue({
+        graph: { clearSelected: mockClearSelected, clearSelectedMultiple: mockClearSelectedMultiple },
+      });
+      (useSelectedRecords as jest.Mock).mockReturnValue([{ id: "record1" }, { id: "record2" }]);
+      (copyRecordRequest as jest.Mock).mockResolvedValue({ ok: true, data: {} });
+      (handleCopyRecordResponse as jest.Mock).mockImplementation(({ onMultipleRecords }) => {
+        onMultipleRecords();
+      });
+
+      const { result } = renderHook(() => useToolbarConfig({ tabId: "tab1", isFormView: false }));
+
+      act(() => {
+        result.current.actionHandlers.COPY_RECORD();
+      });
+
+      await act(async () => {
+        await result.current.actionModal.buttons[0].onClick();
+      });
+
+      // Verify ordering: graph clears must happen before clearSelectedRecord
+      const clearSelectedOrder = mockClearSelected.mock.invocationCallOrder[0];
+      const clearSelectedMultipleOrder = mockClearSelectedMultiple.mock.invocationCallOrder[0];
+      const clearSelectedRecordOrder = mockClearSelectedRecord.mock.invocationCallOrder[0];
+      expect(clearSelectedOrder).toBeLessThan(clearSelectedRecordOrder);
+      expect(clearSelectedMultipleOrder).toBeLessThan(clearSelectedRecordOrder);
+
+      expect(mockClearSelected).toHaveBeenCalledWith(mockTab);
+      expect(mockClearSelectedMultiple).toHaveBeenCalledWith(mockTab);
+      expect(mockClearSelectedRecord).toHaveBeenCalledWith(mockActiveWindow.windowIdentifier, "tab1");
+    });
   });
 
   describe("INITIALIZE_RX_SERVICES", () => {

--- a/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
+++ b/packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx
@@ -194,13 +194,14 @@ describe("useToolbarConfig", () => {
         await result.current.actionModal.buttons[0].onClick();
       });
 
-      // Verify ordering: graph clears must happen before setSelectedRecord/setTabFormState
+      // Verify ordering: setSelectedRecord must come BEFORE graph clears, and graph
+      // clears must come BEFORE setTabFormState (new correct ordering)
+      const setSelectedRecordOrder = mockSetSelectedRecord.mock.invocationCallOrder[0];
       const clearSelectedOrder = mockClearSelected.mock.invocationCallOrder[0];
       const clearSelectedMultipleOrder = mockClearSelectedMultiple.mock.invocationCallOrder[0];
-      const setSelectedRecordOrder = mockSetSelectedRecord.mock.invocationCallOrder[0];
       const setTabFormStateOrder = mockSetTabFormState.mock.invocationCallOrder[0];
-      expect(clearSelectedOrder).toBeLessThan(setSelectedRecordOrder);
-      expect(clearSelectedMultipleOrder).toBeLessThan(setSelectedRecordOrder);
+      expect(setSelectedRecordOrder).toBeLessThan(clearSelectedOrder);
+      expect(setSelectedRecordOrder).toBeLessThan(clearSelectedMultipleOrder);
       expect(clearSelectedOrder).toBeLessThan(setTabFormStateOrder);
       expect(clearSelectedMultipleOrder).toBeLessThan(setTabFormStateOrder);
 
@@ -232,12 +233,12 @@ describe("useToolbarConfig", () => {
         await result.current.actionModal.buttons[0].onClick();
       });
 
-      // Verify ordering: graph clears must happen before clearSelectedRecord
+      // Verify ordering: clearSelectedRecord must come BEFORE graph clears (new correct ordering)
+      const clearSelectedRecordOrder = mockClearSelectedRecord.mock.invocationCallOrder[0];
       const clearSelectedOrder = mockClearSelected.mock.invocationCallOrder[0];
       const clearSelectedMultipleOrder = mockClearSelectedMultiple.mock.invocationCallOrder[0];
-      const clearSelectedRecordOrder = mockClearSelectedRecord.mock.invocationCallOrder[0];
-      expect(clearSelectedOrder).toBeLessThan(clearSelectedRecordOrder);
-      expect(clearSelectedMultipleOrder).toBeLessThan(clearSelectedRecordOrder);
+      expect(clearSelectedRecordOrder).toBeLessThan(clearSelectedOrder);
+      expect(clearSelectedRecordOrder).toBeLessThan(clearSelectedMultipleOrder);
 
       expect(mockClearSelected).toHaveBeenCalledWith(mockTab);
       expect(mockClearSelectedMultiple).toHaveBeenCalledWith(mockTab);

--- a/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
+++ b/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
@@ -261,10 +261,14 @@ export const useToolbarConfig = ({
         onSingleRecord: (newRecordId) => {
           const formMode = FORM_MODES.EDIT;
           const newTabFormState = getNewTabFormState(newRecordId, TAB_MODES.FORM, formMode);
+          graph.clearSelected(tab);
+          graph.clearSelectedMultiple(tab);
           setSelectedRecord(windowIdentifier, tabId, newRecordId);
           setTabFormState(windowIdentifier, tabId, newTabFormState);
         },
         onMultipleRecords: () => {
+          graph.clearSelected(tab);
+          graph.clearSelectedMultiple(tab);
           clearSelectedRecord(windowIdentifier, tabId);
         },
       });
@@ -330,6 +334,7 @@ export const useToolbarConfig = ({
     triggerParentRefreshes,
     clearSelectedRecord,
     tabId,
+    graph,
   ]);
 
   useEffect(() => {

--- a/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
+++ b/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
@@ -271,8 +271,11 @@ export const useToolbarConfig = ({
           graph.clearSelectedMultiple(tab);
           // 3. Set form state (navigate to form view).
           setTabFormState(windowIdentifier, tabId, newTabFormState);
-          // Refresh grid only on success, after all state is established
-          onRefresh?.();
+          // Note: Grid refresh is handled by Table/index.tsx when it becomes visible
+          // again (isVisible transition false→true), so we do not call onRefresh here.
+          // Calling onRefresh while the table is invisible (behind the form view) would
+          // trigger a refetch before the user returns to the grid, and the result might
+          // be stale or cause a double-fetch when the table does become visible.
         },
         onMultipleRecords: () => {
           clearSelectedRecord(windowIdentifier, tabId);

--- a/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
+++ b/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
@@ -244,7 +244,6 @@ export const useToolbarConfig = ({
       const { ok, data } = await copyRecordRequest(tab, selectedIds, activeWindow.windowId, cloneWithChildren);
 
       setActionModal((prev) => ({ ...prev, isLoading: false, isOpen: false }));
-      onRefresh?.();
 
       handleCopyRecordResponse({
         ok,
@@ -261,17 +260,23 @@ export const useToolbarConfig = ({
         onSingleRecord: (newRecordId) => {
           const formMode = FORM_MODES.EDIT;
           const newTabFormState = getNewTabFormState(newRecordId, TAB_MODES.FORM, formMode);
+          // FIRST: establish new selection in window context
+          setSelectedRecord(windowIdentifier, tabId, newRecordId);
+          // THEN: clear old graph cache (after setSelectedRecord, so "unselected"
+          //       event fires when form state is already pointing to new record)
           graph.clearSelected(tab);
           graph.clearSelectedMultiple(tab);
-          setSelectedRecord(windowIdentifier, tabId, newRecordId);
+          // LAST: set form state
           setTabFormState(windowIdentifier, tabId, newTabFormState);
         },
         onMultipleRecords: () => {
+          clearSelectedRecord(windowIdentifier, tabId);
           graph.clearSelected(tab);
           graph.clearSelectedMultiple(tab);
-          clearSelectedRecord(windowIdentifier, tabId);
         },
       });
+      // Refresh the grid AFTER selection state is fully established
+      onRefresh?.();
     };
 
     const buttons: ActionButton[] = [];

--- a/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
+++ b/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
@@ -260,23 +260,28 @@ export const useToolbarConfig = ({
         onSingleRecord: (newRecordId) => {
           const formMode = FORM_MODES.EDIT;
           const newTabFormState = getNewTabFormState(newRecordId, TAB_MODES.FORM, formMode);
-          // FIRST: establish new selection in window context
+          // 1. Establish new record ID in window context first — so that when
+          //    "unselected" fires (from clearSelected below), the window context
+          //    already points to the new record.
           setSelectedRecord(windowIdentifier, tabId, newRecordId);
-          // THEN: clear old graph cache (after setSelectedRecord, so "unselected"
-          //       event fires when form state is already pointing to new record)
+          // 2. Evict stale graph cache. "unselected" fires here but form state
+          //    already has newRecordId above, preventing clearSelectedRecord from
+          //    overwriting it in useTableSelection.
           graph.clearSelected(tab);
           graph.clearSelectedMultiple(tab);
-          // LAST: set form state
+          // 3. Set form state (navigate to form view).
           setTabFormState(windowIdentifier, tabId, newTabFormState);
+          // Refresh grid only on success, after all state is established
+          onRefresh?.();
         },
         onMultipleRecords: () => {
           clearSelectedRecord(windowIdentifier, tabId);
           graph.clearSelected(tab);
           graph.clearSelectedMultiple(tab);
+          // Refresh grid only on success
+          onRefresh?.();
         },
       });
-      // Refresh the grid AFTER selection state is fully established
-      onRefresh?.();
     };
 
     const buttons: ActionButton[] = [];

--- a/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
+++ b/packages/MainUI/hooks/Toolbar/useToolbarConfig.ts
@@ -260,22 +260,17 @@ export const useToolbarConfig = ({
         onSingleRecord: (newRecordId) => {
           const formMode = FORM_MODES.EDIT;
           const newTabFormState = getNewTabFormState(newRecordId, TAB_MODES.FORM, formMode);
-          // 1. Establish new record ID in window context first — so that when
-          //    "unselected" fires (from clearSelected below), the window context
-          //    already points to the new record.
+          // 1. Establish new record ID in window context.
           setSelectedRecord(windowIdentifier, tabId, newRecordId);
-          // 2. Evict stale graph cache. "unselected" fires here but form state
-          //    already has newRecordId above, preventing clearSelectedRecord from
-          //    overwriting it in useTableSelection.
-          graph.clearSelected(tab);
-          graph.clearSelectedMultiple(tab);
-          // 3. Set form state (navigate to form view).
+          // 2. Navigate to form view of the clone.
           setTabFormState(windowIdentifier, tabId, newTabFormState);
-          // Note: Grid refresh is handled by Table/index.tsx when it becomes visible
-          // again (isVisible transition false→true), so we do not call onRefresh here.
-          // Calling onRefresh while the table is invisible (behind the form view) would
-          // trigger a refetch before the user returns to the grid, and the result might
-          // be stale or cause a double-fetch when the table does become visible.
+          // Note: We intentionally do NOT call graph.clearSelected / graph.clearSelectedMultiple
+          // here. Doing so emits "unselected", which causes table.setRowSelection({}) →
+          // useTableSelection → clearSelectedRecord, wiping the newRecordId we just set.
+          // The graph cache is already invalidated by the recordId change in useCurrentRecord
+          // (new paramsKey), and FormView will call graph.setSelected once it loads the clone.
+          // Grid refresh is handled by Table/index.tsx when it becomes visible again
+          // (isVisible false→true via Effect C).
         },
         onMultipleRecords: () => {
           clearSelectedRecord(windowIdentifier, tabId);

--- a/packages/MainUI/hooks/__tests__/useCurrentRecord.test.ts
+++ b/packages/MainUI/hooks/__tests__/useCurrentRecord.test.ts
@@ -32,14 +32,28 @@ describe("useCurrentRecord", () => {
     fields: {},
   } as any;
 
+  // Capture registered "selected" event listeners so tests can simulate graph events.
+  let selectedListeners: Array<(...args: any[]) => void> = [];
+
   const mockGraph = {
     getRecord: jest.fn(),
     setSelected: jest.fn(),
     setSelectedMultiple: jest.fn(),
+    on: jest.fn((event: string, listener: (...args: any[]) => void) => {
+      if (event === "selected") {
+        selectedListeners.push(listener);
+      }
+    }),
+    off: jest.fn((event: string, listener: (...args: any[]) => void) => {
+      if (event === "selected") {
+        selectedListeners = selectedListeners.filter((l) => l !== listener);
+      }
+    }),
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    selectedListeners = [];
     (useSelected as jest.Mock).mockReturnValue({ graph: mockGraph });
   });
 
@@ -136,5 +150,77 @@ describe("useCurrentRecord", () => {
 
     expect(hookResult.result.current.record).toEqual({});
     expect(hookResult.result.current.loading).toBe(false);
+  });
+
+  it("should update record immediately via setRecord when graph emits selected with a new _identifier", async () => {
+    // Simulate the initial state: record is loaded from cache with original identifier.
+    const initialRecord = { id: "record1", _identifier: "Old Name", name: "Old Name" };
+    mockGraph.getRecord.mockReturnValue(initialRecord);
+
+    const { result } = renderHook(() => useCurrentRecord({ tab: mockTab, recordId: "record1" }));
+
+    // Verify initial state
+    expect(result.current.record).toEqual(initialRecord);
+
+    // Simulate save: graph.setSelected is called with the updated record (new _identifier).
+    // This emits the "selected" event, which the hook's listener catches.
+    const updatedRecord = { id: "record1", _identifier: "New Name", name: "New Name" };
+    await act(async () => {
+      for (const listener of selectedListeners) {
+        listener(mockTab, updatedRecord);
+      }
+    });
+
+    // The hook must update record state immediately without waiting for a re-fetch,
+    // so that AppBreadcrumb re-renders and shows the new _identifier.
+    expect(result.current.record).toEqual(updatedRecord);
+    expect((result.current.record as any)._identifier).toBe("New Name");
+  });
+
+  it("should NOT update record a second time when graph emits selected with the same _identifier again", async () => {
+    const initialRecord = { id: "record1", _identifier: "Old Name", name: "Old Name" };
+    mockGraph.getRecord.mockReturnValue(initialRecord);
+
+    const { result } = renderHook(() => useCurrentRecord({ tab: mockTab, recordId: "record1" }));
+
+    // First event: identifier changes from null → "New Name". State updates.
+    const updatedRecord = { id: "record1", _identifier: "New Name", name: "New Name" };
+    await act(async () => {
+      for (const listener of selectedListeners) {
+        listener(mockTab, updatedRecord);
+      }
+    });
+    expect((result.current.record as any)._identifier).toBe("New Name");
+
+    // Second event: same identifier "New Name" again — no state update expected.
+    const sameAgainRecord = { id: "record1", _identifier: "New Name", name: "Some other change" };
+    const recordBeforeSecondEvent = result.current.record;
+    await act(async () => {
+      for (const listener of selectedListeners) {
+        listener(mockTab, sameAgainRecord);
+      }
+    });
+
+    // Record object reference and content should be unchanged (setRecord was not called again)
+    expect(result.current.record).toBe(recordBeforeSecondEvent);
+    expect((result.current.record as any)._identifier).toBe("New Name");
+  });
+
+  it("should NOT update record when graph emits selected for a different tab", async () => {
+    const initialRecord = { id: "record1", _identifier: "Old Name" };
+    mockGraph.getRecord.mockReturnValue(initialRecord);
+
+    const { result } = renderHook(() => useCurrentRecord({ tab: mockTab, recordId: "record1" }));
+
+    const differentTab = { ...mockTab, id: "differentTabId" };
+    const updatedRecord = { id: "record1", _identifier: "New Name" };
+    await act(async () => {
+      for (const listener of selectedListeners) {
+        listener(differentTab, updatedRecord);
+      }
+    });
+
+    // Record must NOT change since the event was for a different tab
+    expect(result.current.record).toEqual(initialRecord);
   });
 });

--- a/packages/MainUI/hooks/useCurrentRecord.ts
+++ b/packages/MainUI/hooks/useCurrentRecord.ts
@@ -60,17 +60,23 @@ export const useCurrentRecord = ({ tab, recordId }: UseCurrentRecordOptions): Us
   const { graph } = useSelected();
 
   // When the graph emits a "selected" event for this tab and the record's _identifier
-  // has changed (e.g. after a save that updates the identifier), reset the fetch guards
-  // so the main effect re-fetches the updated record.
+  // has changed (e.g. after a save that updates the identifier), update React state
+  // directly with the new record so the Breadcrumb re-renders immediately.
+  // Resetting refs alone does NOT trigger a re-render or re-run the fetch effect
+  // (because recordId and tab haven't changed), so we must call setRecord here.
   useEffect(() => {
     if (!tab) return;
 
     const handleSelected = (eventTab: Tab, newRecord: EntityData) => {
       if (eventTab.id !== tab.id) return;
       if (newRecord._identifier !== lastRecordIdentifierRef.current) {
+        lastRecordIdentifierRef.current = newRecord._identifier ?? null;
+        // Update React state so consumers (e.g. AppBreadcrumb) re-render with
+        // the new _identifier without waiting for a full datasource re-fetch.
+        setRecord(newRecord as unknown as Record<string, Field>);
+        // Also reset fetch guards so the next navigation to this record fetches fresh data.
         lastFetchParamsRef.current = null;
         fetchInProgressRef.current = false;
-        lastRecordIdentifierRef.current = newRecord._identifier ?? null;
       }
     };
 

--- a/packages/MainUI/hooks/useCurrentRecord.ts
+++ b/packages/MainUI/hooks/useCurrentRecord.ts
@@ -17,7 +17,7 @@
 
 import { useEffect, useState, useRef } from "react";
 import { datasource } from "@workspaceui/api-client/src/api/datasource";
-import type { EntityValue, Field, Tab } from "@workspaceui/api-client/src/api/types";
+import type { EntityData, EntityValue, Field, Tab } from "@workspaceui/api-client/src/api/types";
 import { NEW_RECORD_ID } from "@/utils/url/constants";
 import { useSelected } from "./useSelected";
 
@@ -55,8 +55,30 @@ export const useCurrentRecord = ({ tab, recordId }: UseCurrentRecordOptions): Us
   const [loading, setLoading] = useState(() => Boolean(tab && recordId && recordId !== NEW_RECORD_ID));
   const fetchInProgressRef = useRef(false);
   const lastFetchParamsRef = useRef<string | null>(null);
+  const lastRecordIdentifierRef = useRef<unknown>(null);
 
   const { graph } = useSelected();
+
+  // When the graph emits a "selected" event for this tab and the record's _identifier
+  // has changed (e.g. after a save that updates the identifier), reset the fetch guards
+  // so the main effect re-fetches the updated record.
+  useEffect(() => {
+    if (!tab) return;
+
+    const handleSelected = (eventTab: Tab, newRecord: EntityData) => {
+      if (eventTab.id !== tab.id) return;
+      if (newRecord._identifier !== lastRecordIdentifierRef.current) {
+        lastFetchParamsRef.current = null;
+        fetchInProgressRef.current = false;
+        lastRecordIdentifierRef.current = newRecord._identifier ?? null;
+      }
+    };
+
+    graph.on("selected", handleSelected);
+    return () => {
+      graph.off("selected", handleSelected);
+    };
+  }, [graph, tab]);
 
   useEffect(() => {
     if (!tab || !recordId || recordId === NEW_RECORD_ID) {
@@ -141,6 +163,8 @@ export const useCurrentRecord = ({ tab, recordId }: UseCurrentRecordOptions): Us
           const entityDataRecord = fetchedRecord as unknown as Record<string, EntityValue>;
           graph.setSelected(tab, entityDataRecord);
           graph.setSelectedMultiple(tab, [entityDataRecord]);
+          // Track the identifier so we can detect changes from saves
+          lastRecordIdentifierRef.current = fetchedRecord._identifier ?? null;
           // Normalize property field keys from "$"-format to hqlName so that
           // buildPayloadByInputName can look them up in tab.fields (indexed by hqlName).
           // e.g. { "file$type": "RF" } → { "type": "RF" }


### PR DESCRIPTION
## Summary

- **Breadcrumb stale after save**: `useCurrentRecord` now calls `setRecord(newRecord)` from the graph `"selected"` listener when `_identifier` changes, triggering a React re-render immediately after save — without an additional API fetch.
- **Breadcrumb flicker during clone**: `lastValidLabelRef` in `Breadcrums.tsx` retains the last valid label during the fetch transition so the breadcrumb never goes blank.
- **Grid not showing / not highlighting cloned record on return**: Removed `graph.clearSelected` / `graph.clearSelectedMultiple` from the `onSingleRecord` clone path. Those calls emitted `"unselected"` synchronously → `table.setRowSelection({})` → `useTableSelection` → `clearSelectedRecord`, wiping the new record ID before the grid could use it. Added Effect A (resets `hasRestoredSelection` when target record ID changes) and Effect C (triggers `refetch()` on Table visibility transition `false→true`) in `Table/index.tsx`.

## Files Changed

- `packages/MainUI/hooks/useCurrentRecord.ts`
- `packages/MainUI/hooks/Toolbar/useToolbarConfig.ts`
- `packages/MainUI/components/Breadcrums.tsx`
- `packages/MainUI/components/Table/index.tsx`
- `packages/MainUI/hooks/__tests__/useCurrentRecord.test.ts`
- `packages/MainUI/hooks/Toolbar/__tests__/useToolbarConfig.test.tsx`
- `docs/components/toolbar.md`

Jira: ETP-3656

## Validations

- ✅ Code Review: APPROVED (Crisol)
- ✅ Unit Tests: PASSED (3034 tests, 241 suites) (Pixel)
- ✅ Security: CLEARED (Vigia)
- 🧪 Cypress: N/A (Argos — hotfix branch)
- 📝 Docs: updated at docs/components/toolbar.md (Pluma)

Co-Authored-By: compas-ui <noreply@anthropic.com>