### PR TITLE
Feature ETP-4044: Add auth retry on 401/403

### DIFF
--- a/packages/MainUI/app/api/auth/recover/route.ts
+++ b/packages/MainUI/app/api/auth/recover/route.ts
@@ -1,0 +1,43 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { type NextRequest, NextResponse } from "next/server";
+export const runtime = "nodejs";
+import { recoverSession } from "@/app/api/_utils/sessionRecovery";
+import { extractBearerToken } from "@/lib/auth";
+
+/**
+ * POST /api/auth/recover
+ *
+ * Attempts to refresh the ERP JSESSIONID using the current JWT.
+ * Called by the client-side auth retry handler when a 401/403 is received.
+ * Returns 200 on success (with optional newToken if JWT was rotated),
+ * or 503 if recovery failed (e.g., SWSConfig not yet initialized).
+ */
+export async function POST(request: NextRequest) {
+  const token = extractBearerToken(request);
+  if (!token) {
+    return NextResponse.json({ error: "No token" }, { status: 401 });
+  }
+
+  const result = await recoverSession(token);
+  if (result.success) {
+    return NextResponse.json({ success: true, newToken: result.newToken ?? null });
+  }
+
+  return NextResponse.json({ error: result.error ?? "Recovery failed" }, { status: 503 });
+}

--- a/packages/MainUI/contexts/user.tsx
+++ b/packages/MainUI/contexts/user.tsx
@@ -374,18 +374,48 @@ export default function UserProvider(props: React.PropsWithChildren) {
       return response;
     };
 
+    const authRetryHandler = async () => {
+      try {
+        const res = await fetch("/api/auth/recover", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+          credentials: "include",
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.newToken) {
+            setToken(data.newToken);
+            Metadata.setToken(data.newToken);
+            datasource.setToken(data.newToken);
+            CopilotClient.setToken(data.newToken);
+          }
+          return true;
+        }
+      } catch (_e) {
+        // recovery fetch failed — fall through to interceptor
+      }
+      return false;
+    };
+
     if (token) {
       const unregisterMetadataInterceptor = Metadata.registerInterceptor(interceptor);
       const unregisterDatasourceInterceptor = datasource.registerInterceptor(interceptor);
       const unregisterCopilotInterceptor = CopilotClient.registerInterceptor(interceptor);
 
+      Metadata.setAuthRetryHandler(authRetryHandler);
+      datasource.setAuthRetryHandler(authRetryHandler);
+      CopilotClient.setAuthRetryHandler(authRetryHandler);
+
       return () => {
         unregisterMetadataInterceptor();
         unregisterDatasourceInterceptor();
         unregisterCopilotInterceptor();
+        Metadata.setAuthRetryHandler(null);
+        datasource.setAuthRetryHandler(null);
+        CopilotClient.setAuthRetryHandler(null);
       };
     }
-  }, [logout, t, token]);
+  }, [logout, setToken, t, token]);
 
   useEffect(() => {
     if (ready && prevRole && prevRole?.id !== currentRole?.id) {

--- a/packages/api-client/src/api/client.ts
+++ b/packages/api-client/src/api/client.ts
@@ -24,6 +24,7 @@ export interface ClientOptions extends Omit<RequestInit, "body"> {
 }
 
 export type Interceptor = (response: Response) => Promise<Response> | Response;
+export type AuthRetryHandler = () => Promise<boolean>;
 
 export class UnauthorizedError extends Error {
   public response: Response;
@@ -39,6 +40,7 @@ export class Client {
   private baseQueryParams: URLSearchParams;
   private baseUrl: string;
   private interceptor: Interceptor | null;
+  private authRetryHandler: AuthRetryHandler | null;
   private readonly JSON_CONTENT_TYPE = "application/json";
   private readonly FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
 
@@ -46,6 +48,7 @@ export class Client {
     this.baseUrl = url || "";
     this.baseHeaders = {};
     this.interceptor = null;
+    this.authRetryHandler = null;
     this.baseQueryParams = new URLSearchParams();
   }
 
@@ -167,6 +170,21 @@ export class Client {
         },
       });
 
+      if ((response.status === 401 || response.status === 403) && this.authRetryHandler) {
+        const recovered = await this.authRetryHandler();
+        if (recovered) {
+          response = await fetch(destination, {
+            ...options,
+            credentials: "include",
+            body: this.getFormattedBody(options.body),
+            headers: {
+              ...this.baseHeaders,
+              ...options.headers,
+            },
+          });
+        }
+      }
+
       if (typeof this.interceptor === "function") {
         response = await this.interceptor(response);
       }
@@ -198,6 +216,10 @@ export class Client {
     return () => {
       this.interceptor = null;
     };
+  }
+
+  public setAuthRetryHandler(handler: AuthRetryHandler | null) {
+    this.authRetryHandler = handler;
   }
 
   public async post(url: string, payload: ClientOptions["body"] = null, options: ClientOptions = {}) {

--- a/packages/api-client/src/api/constants.ts
+++ b/packages/api-client/src/api/constants.ts
@@ -45,6 +45,7 @@ export const API_DATASOURCE_PROXY = "/api/datasource";
 
 export enum HTTP_CODES {
   UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
   NOT_FOUND = 404,
   INTERNAL_SERVER_ERROR = 500,
 }

--- a/packages/api-client/src/api/copilot/client.ts
+++ b/packages/api-client/src/api/copilot/client.ts
@@ -15,7 +15,7 @@
  *************************************************************************
  */
 
-import { Client, type Interceptor, type ClientOptions } from "../client";
+import { Client, type Interceptor, type ClientOptions, type AuthRetryHandler } from "../client";
 import { COPILOT_ENDPOINTS, COPILOT_METHODS, isProduction } from "./constants";
 import type {
   ConversationMutationResponse,
@@ -139,6 +139,10 @@ export class CopilotClient {
    */
   public static registerInterceptor(interceptor: Interceptor) {
     return CopilotClient.client.registerInterceptor(interceptor);
+  }
+
+  public static setAuthRetryHandler(handler: AuthRetryHandler | null) {
+    CopilotClient.client.setAuthRetryHandler(handler);
   }
 
   /**

--- a/packages/api-client/src/api/datasource.ts
+++ b/packages/api-client/src/api/datasource.ts
@@ -15,7 +15,7 @@
  *************************************************************************
  */
 
-import { Client, type Interceptor } from "./client";
+import { Client, type Interceptor, type AuthRetryHandler } from "./client";
 import type { DatasourceParams } from "./types";
 
 export class Datasource {
@@ -48,6 +48,10 @@ export class Datasource {
 
   public registerInterceptor(interceptor: Interceptor) {
     return this.client.registerInterceptor(interceptor);
+  }
+
+  public setAuthRetryHandler(handler: AuthRetryHandler | null) {
+    this.client.setAuthRetryHandler(handler);
   }
 
   /**

--- a/packages/api-client/src/api/metadata.ts
+++ b/packages/api-client/src/api/metadata.ts
@@ -16,7 +16,7 @@
  */
 
 import { CacheStore } from "./cache";
-import { Client, type Interceptor } from "./client";
+import { Client, type Interceptor, type AuthRetryHandler } from "./client";
 import { API_DEFAULT_CACHE_DURATION, API_KERNEL_SERVLET, API_ERP_PROXY, API_DATASOURCE_PROXY } from "./constants";
 import { LocationClient } from "./location";
 import { joinUrl } from "./utils";
@@ -89,6 +89,17 @@ export class Metadata {
       listener3();
       listener4();
     };
+  }
+
+  public static setAuthRetryHandler(handler: AuthRetryHandler | null) {
+    for (const client of [
+      Metadata.client,
+      Metadata.kernelClient,
+      Metadata.datasourceServletClient,
+      Metadata.locationClient,
+    ]) {
+      client.setAuthRetryHandler(handler);
+    }
   }
 
   public static getDatasource(id: string, body: BodyInit | Record<string, unknown> | null | undefined) {


### PR DESCRIPTION
## Summary

- **Option A — Transparent session recovery on 401/403**: Instead of immediately logging out on 401/403, the frontend now attempts to recover the session (refresh ERP JSESSIONID via BFF) and transparently retries the original request. Only logs out if recovery also fails.
- New `POST /api/auth/recover` BFF endpoint that calls the existing `recoverSession()` utility.
- `AuthRetryHandler` type and `setAuthRetryHandler()` added to `Client`; retry fires once per request on 401/403 before the response interceptor.
- `setAuthRetryHandler()` wrapper added to `Metadata`, `Datasource` and `CopilotClient` following the `registerInterceptor()` pattern.
- `HTTP_CODES.FORBIDDEN = 403` added to constants enum.

**Works together with ETP-4044 backend (Option C)**: the readiness check blocks ALB routing until the JWT subsystem is initialized, eliminating the F8 window. Option A handles residual transient 401/403 from legitimate session expiry.

## Test plan

- [ ] Invalidate a session cookie while the app is open; confirm the next API call recovers transparently without logout
- [ ] Confirm no regression on deliberate 403 (permission denied): user should NOT be logged out

🤖 Generated with [Claude Code](https://claude.com/claude-code)