### PR TITLE
Feature ETP-3757: Implement dynamic selector out-fields for callout i…

### DIFF
--- a/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
@@ -336,22 +336,25 @@ const BaseSelectorComp = ({
           _gridVisibleProperties: gridVisibleProperties,
         } as Record<string, any>;
 
-        //TODO: This will imply the evaluation of out fiels inside the fieldBuilder an it's implementation in metadata module
-        if (field.inputName === "inpmProductId" && optionData) {
-          // Pricing fields (for order/invoice windows)
-          calloutData.inpmProductId_CURR =
-            optionData.product$currency$id || optionData.currency || session.$C_Currency_ID;
-          calloutData.inpmProductId_UOM = optionData.product$uOM$id || optionData.uOM || session["#C_UOM_ID"];
-          calloutData.inpmProductId_PSTD = String(optionData.standardPrice || optionData.netListPrice || 0);
-          calloutData.inpmProductId_PLIST = String(optionData.netListPrice || 0);
-          calloutData.inpmProductId_PLIM = String(optionData.priceLimit || 0);
-
-          // Inventory/warehouse fields (from ProductStockView data)
-          calloutData.inpmProductId_ATR = String(optionData.attributeSetValue || optionData.attributeSetValue$id || "");
-          calloutData.inpmProductId_LOC = String(optionData.storageBin || optionData.storageBin$id || "");
-          calloutData.inpmProductId_QTY = String(optionData.quantityOnHand || 0);
-          calloutData.inpmProductId_PUOM = "";
-          calloutData.inpmProductId_PQTY = "";
+        // Populate callout inputs from selector out-fields metadata.
+        // For type "calloutInput": append the suffix to the field's inputName so the
+        // backend callout receives the hidden input (e.g. inpmProductId_CURR).
+        // For type "field": directly set the target form field value from the selected record.
+        const outFields = field.selector?.outFields;
+        if (outFields?.length && optionData) {
+          for (const outField of outFields) {
+            const rawValue = optionData[outField.selectorFieldProperty];
+            if (outField.type === "calloutInput" && outField.suffix) {
+              calloutData[`${field.inputName}${outField.suffix}`] = String(rawValue ?? "");
+            } else if (outField.type === "field" && outField.targetHqlName) {
+              const val = rawValue ?? "";
+              setValue(outField.targetHqlName, val, { shouldDirty: false });
+              const identifierKey = `${outField.selectorFieldProperty}$_identifier`;
+              if (optionData[identifierKey]) {
+                setValue(`${outField.targetHqlName}$_identifier`, optionData[identifierKey], { shouldDirty: false });
+              }
+            }
+          }
         }
 
         const data = skipDebounce ? await executeCalloutBase(calloutData) : await debouncedCallout(calloutData);

--- a/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
@@ -134,6 +134,49 @@ const isImmediateCalloutField = (reference: string) => {
   return fieldEntry?.calloutTrigger === CALLOUT_TRIGGERS.ON_CHANGE;
 };
 
+// Build _gridVisibleProperties so that the FIC in CHANGE mode can identify
+// property fields and compute their values from DB when a related FK field
+// changes (e.g. selecting a new "file" populates the read-only "Type" field).
+// Classic always sends this list in callout payloads.
+const buildGridVisibleProperties = (tab: { fields: Record<string, Field> }) =>
+  Object.values(tab.fields)
+    .filter((f) => f.displayed && f.columnName)
+    .flatMap((f) => {
+      const propertyPath = f.column?.propertyPath;
+      if (propertyPath) {
+        return [f.columnName, propertyPath.replace(/\./g, "$")];
+      }
+      return [f.columnName];
+    });
+
+// Populate callout inputs from selector out-fields metadata.
+// For type "calloutInput": append the suffix to the field's inputName so the
+// backend callout receives the hidden input (e.g. inpmProductId_CURR).
+// For type "field": directly set the target form field value from the selected record.
+const applyOutFields = (
+  field: Field,
+  optionData: Record<string, unknown> | undefined,
+  calloutData: Record<string, any>,
+  setValue: (name: string, value: unknown, options?: { shouldDirty: boolean }) => void
+) => {
+  const outFields = field.selector?.outFields;
+  if (!outFields?.length || !optionData) return;
+
+  for (const outField of outFields) {
+    const rawValue = optionData[outField.selectorFieldProperty];
+    if (outField.type === "calloutInput" && outField.suffix) {
+      calloutData[`${field.inputName}${outField.suffix}`] = String(rawValue ?? "");
+    } else if (outField.type === "field" && outField.targetHqlName) {
+      const val = rawValue ?? "";
+      setValue(outField.targetHqlName, val, { shouldDirty: false });
+      const identifierKey = `${outField.selectorFieldProperty}$_identifier`;
+      if (optionData[identifierKey]) {
+        setValue(`${outField.targetHqlName}$_identifier`, optionData[identifierKey], { shouldDirty: false });
+      }
+    }
+  }
+};
+
 const BaseSelectorComp = ({
   field,
   formMode = FormMode.EDIT,
@@ -309,19 +352,7 @@ const BaseSelectorComp = ({
           payload[standardChangedColumn] = payload[field.inputName];
         }
 
-        // Build _gridVisibleProperties so that the FIC in CHANGE mode can identify
-        // property fields and compute their values from DB when a related FK field
-        // changes (e.g. selecting a new "file" populates the read-only "Type" field).
-        // Classic always sends this list in callout payloads.
-        const gridVisibleProperties = Object.values(tab.fields)
-          .filter((f) => f.displayed && f.columnName)
-          .flatMap((f) => {
-            const propertyPath = f.column?.propertyPath;
-            if (propertyPath) {
-              return [f.columnName, propertyPath.replace(/\./g, "$")];
-            }
-            return [f.columnName];
-          });
+        const gridVisibleProperties = buildGridVisibleProperties(tab);
 
         const calloutData = {
           ...session,
@@ -336,26 +367,7 @@ const BaseSelectorComp = ({
           _gridVisibleProperties: gridVisibleProperties,
         } as Record<string, any>;
 
-        // Populate callout inputs from selector out-fields metadata.
-        // For type "calloutInput": append the suffix to the field's inputName so the
-        // backend callout receives the hidden input (e.g. inpmProductId_CURR).
-        // For type "field": directly set the target form field value from the selected record.
-        const outFields = field.selector?.outFields;
-        if (outFields?.length && optionData) {
-          for (const outField of outFields) {
-            const rawValue = optionData[outField.selectorFieldProperty];
-            if (outField.type === "calloutInput" && outField.suffix) {
-              calloutData[`${field.inputName}${outField.suffix}`] = String(rawValue ?? "");
-            } else if (outField.type === "field" && outField.targetHqlName) {
-              const val = rawValue ?? "";
-              setValue(outField.targetHqlName, val, { shouldDirty: false });
-              const identifierKey = `${outField.selectorFieldProperty}$_identifier`;
-              if (optionData[identifierKey]) {
-                setValue(`${outField.targetHqlName}$_identifier`, optionData[identifierKey], { shouldDirty: false });
-              }
-            }
-          }
-        }
+        applyOutFields(field, optionData, calloutData, setValue);
 
         const data = skipDebounce ? await executeCalloutBase(calloutData) : await debouncedCallout(calloutData);
 
@@ -384,8 +396,10 @@ const BaseSelectorComp = ({
       field.column.callout,
       field.inputName,
       field.hqlName,
+      field.selector,
       tab,
       getValues,
+      setValue,
       fieldsByHqlName,
       session,
       fieldsByColumnName,

--- a/packages/api-client/src/api/types.ts
+++ b/packages/api-client/src/api/types.ts
@@ -123,6 +123,14 @@ export interface SelectorColumn {
   [key: string]: unknown;
 }
 
+export interface SelectorOutField {
+  type: "field" | "calloutInput";
+  selectorFieldProperty: string;
+  targetColumnName?: string | null;
+  targetHqlName?: string | null;
+  suffix?: string | null;
+}
+
 export interface Field {
   hqlName: string;
   inputName: string;
@@ -151,6 +159,7 @@ export interface Field {
     hasTableRelated?: boolean;
     hasProcessDefinitionRelated?: boolean;
     gridColumns?: SelectorColumn[];
+    outFields?: SelectorOutField[];
     [key: string]: unknown;
   };
   refList: RefListField[];


### PR DESCRIPTION
Replace hardcoded inpmProductId suffix mappings in BaseSelector with a generic loop over field.selector.outFields metadata from the backend. Callout input suffixes (_CURR, _UOM, _PSTD, etc.) are now built dynamically from OBUISEL_SelectorField.isOutfield configuration, enabling all 190 OBUISEL selectors to populate callout hidden inputs without per-field hardcoding.

Add SelectorOutField type and outFields to the Field selector interface.