### PR TITLE
Feature ETP-3754: Implements remaining fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,56 @@ Current testing approach uses Jest with React Testing Library:
 - Hook testing for MainUI
 - API client unit tests
 - See `TESTING.md` for detailed testing guidelines and coverage requirements
+
+## Git Conventions (Git Police)
+
+This repository is enforced by the Git Police bot. All branches, commits, and PRs MUST follow these rules.
+
+### Branch Naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feature/<JIRA_ID>` | `feature/ETP-1234` |
+| Feature (backport) | `feature/<JIRA_ID>-Y<yy>` | `feature/ETP-1234-Y25` |
+| Hotfix | `hotfix/<JIRA_ID>` | `hotfix/ETP-1234` |
+| Hotfix (with issue) | `hotfix/#<issue>-<JIRA_ID>` | `hotfix/#12-ETP-1234` |
+| Hotfix (backport) | `hotfix/#<issue>-<JIRA_ID>-Y<yy>` | `hotfix/#12-ETP-1234-Y25` |
+| Epic | `epic/<JIRA_ID>` | `epic/ETP-1234` |
+| Epic (backport) | `epic/<JIRA_ID>-Y<yy>` | `epic/ETP-1234-Y25` |
+
+JIRA_ID format: 2-4 uppercase letters + hyphen + 1-4 digit number (e.g. `ETP-1234`, `ABC-56`).
+
+### Commit Messages
+
+**First line MUST be ≤80 characters.** Format depends on branch type:
+
+| Branch type | Commit format | Example |
+|-------------|---------------|---------|
+| `feature/*` | `Feature <JIRA_ID>: <description>` | `Feature ETP-1234: Add user login` |
+| `hotfix/*` | `Hotfix <JIRA_ID>: <description>` | `Hotfix ETP-1234: Fix null pointer` |
+| `hotfix/#N-*` | `Issue #<N>: <description>` | `Issue #12: Fix null pointer` |
+| `epic/*` | `Epic <JIRA_ID>: <description>` | `Epic ETP-1234: Add auth module` |
+
+For `Issue #N:` commits, the second line must contain the JIRA ID (e.g. `ETP-789`).
+
+### PR Titles
+
+PR title must match the branch type and include the JIRA ID:
+
+| Branch | PR title prefix |
+|--------|----------------|
+| `feature/ETP-123` | `Feature ETP-123: ...` |
+| `hotfix/ETP-123` | `Hotfix ETP-123: ...` |
+| `hotfix/#10-ETP-123` | `Issue #10: ...` |
+| `epic/ETP-123` | `Epic ETP-123: ...` |
+
+### PR Destination Branches
+
+| Source branch | Allowed targets |
+|---------------|----------------|
+| `feature/*` | `develop`, `feature/*`, `epic/*` |
+| `feature/*-Y*` | `epic/*-Y*`, `release/*` |
+| `hotfix/*` | `main`, `master` |
+| `hotfix/*-Y*` | `release/*` |
+| `epic/*` | `develop` |
+| `epic/*-Y*` | `release/*` |

--- a/docs/superpowers/plans/2026-05-27-missing-reference-types.md
+++ b/docs/superpowers/plans/2026-05-27-missing-reference-types.md
@@ -1,0 +1,1190 @@
+# Missing Reference Types & Existing Type Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete field/column reference type coverage by fixing gaps in existing types (Phase 1), adding missing frequently-used types (Phase 2), and adding isolated types pending manual verification (Phase 3).
+
+**Architecture:** All changes are frontend-only. Reference types are routed in `GenericSelector.tsx` (form view) and `getFieldReference()` (grid view). New selectors follow existing patterns: react-hook-form integration, Tailwind styling, Field prop interface.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS 4, react-hook-form, Jest + React Testing Library
+
+**Spec:** `docs/superpowers/specs/2026-05-27-missing-reference-types-design.md`
+
+**Note:** Spec section 1.2 (Upload File — Form Save Pipeline) is excluded from this plan. It requires endpoint discovery (inspecting Classic network traffic) before implementation can begin. It will be addressed in a follow-up plan once the endpoint is identified.
+
+---
+
+## File Structure
+
+### Phase 1 — Fixes to Existing Types
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/MainUI/components/Form/FormView/selectors/NumericSelector.tsx` | Modify | Add min/max validation with clamping on blur |
+| `packages/MainUI/components/Form/FormView/selectors/__tests__/NumericSelector.minmax.test.tsx` | Create | Tests for min/max clamping behavior |
+| `packages/MainUI/utils/tableColumns.tsx` | Modify | Add `renderTextCell` with truncation + tooltip |
+| `packages/MainUI/hooks/table/useColumns.tsx` | Modify | Apply `renderTextCell` for Text/Memo/RichText reference IDs |
+| `packages/MainUI/utils/__tests__/tableColumns.test.tsx` | Modify | Add tests for `renderTextCell` |
+| `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceModal.tsx` | Modify | Add mandatory lot/serial validation in `hasRequiredFields` |
+| `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx` | Modify | Add clear (X) button |
+| `packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx` | Modify | Add show/hide toggle via endAdornment |
+| `packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx` | Create | Tests for toggle behavior |
+
+### Phase 2 — New Reference Types
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/MainUI/utils/form/constants.ts` | Modify | Add MEMO, LINK, PRODUCT_CHARACTERISTICS constants |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Modify | Add switch cases for Memo, Link, Product Characteristics |
+| `packages/MainUI/utils/index.ts` | Modify | Add `getFieldReference()` mappings for new IDs |
+| `packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx` | Create | Dual-mode link/input selector |
+| `packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx` | Create | Tests for link rendering and edit mode |
+
+### Phase 3 — Isolated Types (blocked on manual testing)
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/MainUI/utils/form/constants.ts` | Modify | Add ASSIGNMENT, TREE_REFERENCE constants |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Modify | Add switch cases |
+| `packages/MainUI/utils/index.ts` | Modify | Add `getFieldReference()` mappings |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeSelector.tsx` | Create | Tree reference field + modal trigger |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeModal.tsx` | Create | Modal with expandable tree |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/index.ts` | Create | Barrel export |
+| `packages/MainUI/hooks/useTreeData.ts` | Create | Fetch tree datasource, build hierarchy |
+
+---
+
+## Phase 1: Fixes to Existing Types
+
+### Task 1: NumericSelector min/max Validation
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/NumericSelector.tsx`
+- Create: `packages/MainUI/components/Form/FormView/selectors/__tests__/NumericSelector.minmax.test.tsx`
+
+- [ ] **Step 1: Write failing tests for min/max clamping**
+
+Create `packages/MainUI/components/Form/FormView/selectors/__tests__/NumericSelector.minmax.test.tsx`:
+
+```tsx
+import { fireEvent, screen } from "@testing-library/react";
+import { NumericSelector } from "../NumericSelector";
+import { createMockField, renderWithWrapper } from "../test-utils/decimal-test-helpers";
+
+const createFieldWithMinMax = (reference: string, minValue?: number, maxValue?: number) => {
+  const field = createMockField(reference);
+  field.column = { ...field.column, minValue, maxValue };
+  return field;
+};
+
+describe("NumericSelector - min/max validation", () => {
+  it("should clamp value to minValue on blur when below minimum", () => {
+    const field = createFieldWithMinMax("11", 0, 100);
+    renderWithWrapper(<NumericSelector field={field} type="integer" />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "-5" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("0");
+  });
+
+  it("should clamp value to maxValue on blur when above maximum", () => {
+    const field = createFieldWithMinMax("11", 0, 100);
+    renderWithWrapper(<NumericSelector field={field} type="integer" />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "150" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("100");
+  });
+
+  it("should not clamp when value is within range", () => {
+    const field = createFieldWithMinMax("11", 0, 100);
+    renderWithWrapper(<NumericSelector field={field} type="integer" />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "50" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("50");
+  });
+
+  it("should skip validation when no min/max defined", () => {
+    const field = createMockField("11");
+    renderWithWrapper(<NumericSelector field={field} type="integer" />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "-999" } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue("-999");
+  });
+
+  it("should clamp decimal values to minValue", () => {
+    const field = createFieldWithMinMax("800008", 0.5, 99.9);
+    renderWithWrapper(<NumericSelector field={field} type="decimal" />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: "0.1" } });
+    fireEvent.blur(input);
+
+    // getNumericFormatOptions("800008", undefined) returns { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+    // so 0.5 is formatted as "0.50"
+    expect(input).toHaveValue("0.50");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="NumericSelector.minmax" --no-coverage`
+Expected: FAIL — clamping does not exist yet
+
+- [ ] **Step 3: Implement min/max validation in NumericSelector**
+
+Modify `packages/MainUI/components/Form/FormView/selectors/NumericSelector.tsx`:
+
+In `handleBlur`, after `parseValue(localValue)`, add clamping logic. Note: the spec mentions using `validateNumber` for the validity check and a `hasError` state for visual feedback. However, since we clamp immediately on blur, the invalid value is never displayed — making visual feedback unnecessary. Direct clamping is simpler and matches `QuantitySelector`'s approach:
+
+```tsx
+// After: const parsedValue = parseValue(localValue);
+// Add:
+const minValue = field.column?.minValue != null ? Number(field.column.minValue) : undefined;
+const maxValue = field.column?.maxValue != null ? Number(field.column.maxValue) : undefined;
+
+let clampedValue = parsedValue;
+if (clampedValue !== null) {
+  if (minValue !== undefined && clampedValue < minValue) {
+    clampedValue = minValue;
+  }
+  if (maxValue !== undefined && clampedValue > maxValue) {
+    clampedValue = maxValue;
+  }
+}
+
+// Then use clampedValue instead of parsedValue for setValue and formatDisplayValue
+setValue(field.hqlName, clampedValue);
+
+if (clampedValue === null) {
+  setLocalValue("");
+} else {
+  setLocalValue(formatDisplayValue(clampedValue));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="NumericSelector.minmax" --no-coverage`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="NumericSelector|QuantitySelector" --no-coverage`
+Expected: All existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/NumericSelector.tsx \
+       packages/MainUI/components/Form/FormView/selectors/__tests__/NumericSelector.minmax.test.tsx
+git commit -m "Feature ETP-3931: Add min/max validation to NumericSelector"
+```
+
+---
+
+### Task 2: Text/Memo Grid Truncation
+
+**Files:**
+- Modify: `packages/MainUI/utils/tableColumns.tsx`
+- Modify: `packages/MainUI/hooks/table/useColumns.tsx`
+- Modify: `packages/MainUI/utils/__tests__/tableColumns.test.tsx`
+
+- [ ] **Step 1: Write failing test for renderTextCell**
+
+Add to `packages/MainUI/utils/__tests__/tableColumns.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { renderTextCell } from "../tableColumns";
+
+describe("renderTextCell", () => {
+  it("should render the value in a span with truncate class", () => {
+    const result = renderTextCell("A very long text that should be truncated");
+    render(<div>{result}</div>);
+    const span = screen.getByText("A very long text that should be truncated");
+    expect(span).toBeInTheDocument();
+    expect(span.className).toContain("truncate");
+  });
+
+  it("should return empty string for null/undefined", () => {
+    expect(renderTextCell(null)).toBe("");
+    expect(renderTextCell(undefined)).toBe("");
+  });
+
+  it("should handle empty string", () => {
+    expect(renderTextCell("")).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="tableColumns" --no-coverage`
+Expected: FAIL — `renderTextCell` does not exist
+
+- [ ] **Step 3: Implement renderTextCell**
+
+Add to `packages/MainUI/utils/tableColumns.tsx`:
+
+```tsx
+import Tooltip from "@workspaceui/componentlibrary/src/components/Tooltip";
+
+export const renderTextCell = (value: unknown): React.ReactNode => {
+  if (value === null || value === undefined || value === "") return "";
+  const text = String(value);
+  return (
+    <Tooltip title={text} position="top">
+      <span className="block truncate max-w-full">{text}</span>
+    </Tooltip>
+  );
+};
+```
+
+- [ ] **Step 4: Apply renderTextCell in useColumns for Text/Memo/RichText reference IDs**
+
+Modify `packages/MainUI/hooks/table/useColumns.tsx` — in the column definition logic, add a `cell` renderer for columns whose `column.reference` matches:
+- `"14"` (Text)
+- `"34"` (Memo)
+- `"7CB371C13D204EB69BF370217F692999"` (Rich Text)
+
+The exact integration point depends on how `useColumns` builds column definitions — look for where `accessorFn` or `cell` is set per column and add the text cell renderer for these reference IDs.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="tableColumns" --no-coverage`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/MainUI/utils/tableColumns.tsx \
+       packages/MainUI/hooks/table/useColumns.tsx \
+       packages/MainUI/utils/__tests__/tableColumns.test.tsx
+git commit -m "Feature ETP-3931: Add grid truncation with tooltip for Text fields"
+```
+
+---
+
+### Task 3: PAttribute Mandatory Validation & Clear Button
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceModal.tsx`
+- Modify: `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx`
+
+- [ ] **Step 1: Check if backend sends isMandatoryLot/isMandatorySerNo**
+
+Before implementing, inspect the backend response. In the browser devtools, open a window with a PAttribute field (e.g., Sales Order Lines), trigger the attribute modal, and check the network response from the CONFIG action. Look for `isMandatoryLot`/`isMandatorySerNo` fields.
+
+If these fields exist: proceed with Steps 2-5 below.
+If not: skip steps 2-3 and proceed directly to Step 4 (clear button only).
+
+- [ ] **Step 2: Add mandatory lot/serial validation (conditional)**
+
+Modify `AttributeSetInstanceModal.tsx` — extend the `hasRequiredFields` useMemo:
+
+```tsx
+const hasRequiredFields = useMemo(() => {
+  if (!config) return false;
+  // Validate mandatory lot
+  if (config.isMandatoryLot && !formData.lot) return false;
+  // Validate mandatory serial number
+  if (config.isMandatorySerNo && !formData.serialNo) return false;
+  // Existing custom attribute validation
+  for (const attr of customAttributes) {
+    if (attr.isMandatory && !formData.customAttributes[attr.id]) {
+      return false;
+    }
+  }
+  return true;
+}, [config, customAttributes, formData]);
+```
+
+Also update `types.ts` to add the new fields to `AttributeSetConfig`, and `useAttributeSetConfig.ts` to parse them from the response.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="AttributeSet" --no-coverage`
+Expected: PASS (no existing tests should break)
+
+- [ ] **Step 4: Add clear button to AttributeSetInstanceSelector**
+
+Modify `AttributeSetInstanceSelector.tsx` — add an X icon button visible when `value` is set and `!isReadOnly`:
+
+```tsx
+import X from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+
+// Inside the component, add a clear handler:
+const handleClear = useCallback(
+  (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent opening the modal
+    setValue(fieldName, null, { shouldDirty: true, shouldTouch: true });
+    setValue(`${fieldName}$_identifier`, null, { shouldDirty: true });
+    setValue(`${fieldName}_data`, null, { shouldDirty: true });
+    setDisplayValue("");
+    setLastSavedInstanceId(null);
+  },
+  [fieldName, setValue]
+);
+
+// In the JSX, next to the SearchOutlined icon:
+{value && !isReadOnly && (
+  <button
+    type="button"
+    onClick={handleClear}
+    className="p-0.5 hover:text-gray-600 transition-colors"
+  >
+    <X className="w-3.5 h-3.5 text-gray-400" />
+  </button>
+)}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/
+git commit -m "Feature ETP-3931: Improve PAttribute mandatory validation and clear"
+```
+
+---
+
+### Task 4: Password Show/Hide Toggle
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx`
+- Create: `packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { PasswordSelector } from "../PasswordSelector";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+
+// Mock context dependencies that TextInput may transitively import
+jest.mock("@/contexts/language", () => ({
+  useLanguage: () => ({ language: "en_US" }),
+}));
+
+const mockField: Field = {
+  id: "pwd-1",
+  name: "Password",
+  hqlName: "password",
+  columnName: "password",
+  isMandatory: false,
+  column: { reference: "C5C21C28B39E4683A91779F16C112E40", length: 60 },
+} as Field;
+
+const Wrapper = ({ defaultValue = "" }: { defaultValue?: string }) => {
+  const methods = useForm({ defaultValues: { password: defaultValue } });
+  return (
+    <FormProvider {...methods}>
+      <PasswordSelector field={mockField} />
+    </FormProvider>
+  );
+};
+
+describe("PasswordSelector", () => {
+  it("should render as password type by default", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("should toggle to text type when eye icon is clicked", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const toggle = screen.getByTestId(/eye-toggle/);
+    fireEvent.click(toggle);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("should toggle back to password on second click", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const toggle = screen.getByTestId(/eye-toggle/);
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("should not show toggle when value is placeholder ***", () => {
+    render(<Wrapper defaultValue="***" />);
+    expect(screen.queryByTestId(/eye-toggle/)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="PasswordSelector" --no-coverage`
+Expected: FAIL — no toggle exists
+
+- [ ] **Step 3: Implement show/hide toggle**
+
+Modify `packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx`:
+
+```tsx
+import { useState } from "react";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import { TextInput } from "./components/TextInput";
+import { useFormContext, type FieldValues } from "react-hook-form";
+import { PASSWORD_PLACEHOLDER } from "@/utils/form/constants";
+
+const EyeIcon = ({ open }: { open: boolean }) => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    {open ? (
+      <>
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+        <circle cx="12" cy="12" r="3" />
+      </>
+    ) : (
+      <>
+        <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+        <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+        <line x1="1" y1="1" x2="23" y2="23" />
+      </>
+    )}
+  </svg>
+);
+
+export const PasswordSelector = (props: { field: Field } & React.ComponentProps<typeof TextInput>) => {
+  const { register, watch, setValue } = useFormContext<FieldValues>();
+  const fieldName = props.field.hqlName;
+  const currentValue = watch(fieldName);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleSetValue = (value: string) => {
+    setValue(fieldName, value, { shouldValidate: true });
+  };
+
+  const isPlaceholder = currentValue === PASSWORD_PLACEHOLDER;
+
+  const eyeToggle = !isPlaceholder && currentValue ? (
+    <button
+      type="button"
+      data-testid={`eye-toggle__${props.field.id}`}
+      onClick={() => setShowPassword((prev) => !prev)}
+      className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 transition-colors z-10"
+    >
+      <EyeIcon open={showPassword} />
+    </button>
+  ) : null;
+
+  return (
+    <TextInput
+      {...register(fieldName)}
+      field={props.field}
+      setValue={handleSetValue}
+      showClearButton={false}
+      endAdornment={eyeToggle}
+      value={currentValue}
+      type={showPassword ? "text" : "password"}
+      maxLength={Number(props.field.column.length)}
+      autoComplete="new-password"
+      data-testid="TextInput__1b1414"
+    />
+  );
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="PasswordSelector" --no-coverage`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx \
+       packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx
+git commit -m "Feature ETP-3931: Add show/hide toggle to PasswordSelector"
+```
+
+---
+
+## Phase 2: New Reference Types
+
+### Task 5: Add Memo, Link, Product Characteristics Constants
+
+**Files:**
+- Modify: `packages/MainUI/utils/form/constants.ts`
+- Modify: `packages/MainUI/utils/index.ts`
+
+- [ ] **Step 1: Add constants to FIELD_REFERENCE_CODES**
+
+Add to `packages/MainUI/utils/form/constants.ts` inside `FIELD_REFERENCE_CODES`:
+
+```typescript
+// Memo — large text area (same rendering as Text)
+MEMO: { id: "34", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+
+// Link — URL field, renders as clickable hyperlink in read-only
+LINK: { id: "800101", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+
+// Product Characteristics — always read-only concatenated description
+PRODUCT_CHARACTERISTICS: { id: "C632F1CFF5A1453EB28BDF44A70478F8", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+```
+
+- [ ] **Step 2: Add getFieldReference mappings**
+
+Add cases to `getFieldReference()` in `packages/MainUI/utils/index.ts`:
+
+```typescript
+case FIELD_REFERENCE_CODES.MEMO.id:
+case FIELD_REFERENCE_CODES.TEXT_LONG.id:
+  return FieldType.TEXT;
+case FIELD_REFERENCE_CODES.LINK.id:
+  return FieldType.TEXT;
+case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
+  return FieldType.TEXT;
+```
+
+Note: `TEXT_LONG` (14) already falls through to the default `FieldType.TEXT`, but adding it explicitly alongside MEMO makes the intent clear and prevents issues if the default ever changes.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="constants|tableColumns" --no-coverage`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/MainUI/utils/form/constants.ts packages/MainUI/utils/index.ts
+git commit -m "Feature ETP-3931: Add Memo, Link, Product Characteristics reference constants"
+```
+
+---
+
+### Task 6: Route Memo to TextLongSelector
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+- [ ] **Step 1: Add Memo case in GenericSelector**
+
+In the switch statement inside `GenericSelector.tsx`, add a case for MEMO alongside TEXT_LONG:
+
+```tsx
+case FIELD_REFERENCE_CODES.MEMO.id:
+case FIELD_REFERENCE_CODES.TEXT_LONG.id:
+  return <TextLongSelector field={effectiveField} readOnly={isReadOnly} data-testid="TextLongSelector__6e80fa" />;
+```
+
+Replace the existing `TEXT_LONG` case with this combined block.
+
+- [ ] **Step 2: Verify manually**
+
+Open a window with a Memo field (e.g., Tables and Columns > Table > Observation field, or Report and Process > Parameter > Default Value) and confirm it renders as a textarea, not a single-line input.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3931: Route Memo reference type to TextLongSelector"
+```
+
+---
+
+### Task 7: LinkSelector Component
+
+**Files:**
+- Create: `packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx`
+- Create: `packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx`
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { LinkSelector } from "../LinkSelector";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+
+const mockField: Field = {
+  id: "link-1",
+  name: "URL",
+  hqlName: "url",
+  columnName: "url",
+  isMandatory: false,
+  column: { reference: "800101" },
+} as Field;
+
+const Wrapper = ({ defaultValue = "", readOnly = false }: { defaultValue?: string; readOnly?: boolean }) => {
+  const methods = useForm({ defaultValues: { url: defaultValue } });
+  return (
+    <FormProvider {...methods}>
+      <LinkSelector field={mockField} isReadOnly={readOnly} />
+    </FormProvider>
+  );
+};
+
+describe("LinkSelector", () => {
+  it("should render as text input in edit mode", () => {
+    render(<Wrapper defaultValue="https://example.com" />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("https://example.com");
+  });
+
+  it("should render as clickable link in read-only mode", () => {
+    render(<Wrapper defaultValue="https://example.com" readOnly />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("should render empty in read-only mode when no value", () => {
+    render(<Wrapper defaultValue="" readOnly />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="LinkSelector" --no-coverage`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement LinkSelector**
+
+Create `packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx`:
+
+```tsx
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import { TextInput } from "./components/TextInput";
+import { useFormContext, type FieldValues } from "react-hook-form";
+
+interface LinkSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+
+export const LinkSelector = ({ field, isReadOnly }: LinkSelectorProps) => {
+  const { register, watch, setValue } = useFormContext<FieldValues>();
+  const fieldName = field.hqlName;
+  const currentValue = watch(fieldName);
+
+  if (isReadOnly) {
+    if (!currentValue) {
+      return <span className="text-sm text-gray-400 h-10.5 flex items-center px-3">—</span>;
+    }
+
+    return (
+      <a
+        href={currentValue}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-blue-600 underline hover:text-blue-800 truncate block h-10.5 flex items-center px-3 max-w-full"
+        title={currentValue}
+      >
+        {currentValue}
+      </a>
+    );
+  }
+
+  const handleSetValue = (value: string) => {
+    setValue(fieldName, value, { shouldValidate: true });
+  };
+
+  return (
+    <TextInput
+      {...register(fieldName)}
+      field={field}
+      setValue={handleSetValue}
+      showClearButton={true}
+      value={currentValue}
+      placeholder="https://..."
+      data-testid={`LinkSelector__${field.id}`}
+    />
+  );
+};
+```
+
+- [ ] **Step 4: Route in GenericSelector**
+
+Add to `GenericSelector.tsx` switch:
+
+```tsx
+case FIELD_REFERENCE_CODES.LINK.id:
+  return <LinkSelector field={effectiveField} isReadOnly={isReadOnly} />;
+```
+
+Add the import at the top:
+
+```tsx
+import { LinkSelector } from "./LinkSelector";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/MainUI && pnpm jest --testPathPattern="LinkSelector" --no-coverage`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx \
+       packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx \
+       packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3931: Add LinkSelector for URL reference fields"
+```
+
+---
+
+### Task 8: Route Product Characteristics as Read-Only
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+- [ ] **Step 1: Add Product Characteristics case**
+
+Add to `GenericSelector.tsx` switch:
+
+```tsx
+// Product Characteristics: always read-only — composed from Product Characteristics window, not editable inline.
+// This hardcoded readOnly={true} intentionally overrides the isReadOnly prop from GenericSelector.
+case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
+  return <StringSelector field={effectiveField} readOnly={true} data-testid={`StringSelector__prodchar__${field.id}`} />;
+```
+
+- [ ] **Step 2: Verify manually**
+
+Find a Product with characteristics and confirm the field shows the concatenated description as read-only text in both new and edit modes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3931: Route Product Characteristics as read-only string"
+```
+
+---
+
+## Phase 3: Isolated Types (Blocked on Manual Testing)
+
+> **STOP**: Do not start Phase 3 until manual verification of metadata responses is complete. See prerequisites in spec sections 3.1 and 3.2.
+
+### Task 9: Assignment Reference Type
+
+**Files:**
+- Modify: `packages/MainUI/utils/form/constants.ts`
+- Modify: `packages/MainUI/utils/index.ts`
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+**Prerequisites** (verify before implementing):
+1. Open a window with an Assignment field (S_ResourceAssignment_ID) in the new UI
+2. Check browser devtools: does the metadata response include `referencedEntity: "ResourceAssignment"`?
+3. If yes → route to `TableDirSelector` (Option A below)
+4. If no → create a custom `AssignmentSelector` wrapper (Option B — details in spec)
+
+- [ ] **Step 1: Add constant**
+
+Add to `packages/MainUI/utils/form/constants.ts`:
+
+```typescript
+ASSIGNMENT: { id: "33", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+```
+
+- [ ] **Step 2: Add getFieldReference mapping**
+
+Add to `getFieldReference()` in `packages/MainUI/utils/index.ts`:
+
+```typescript
+case FIELD_REFERENCE_CODES.ASSIGNMENT.id:
+  return FieldType.TABLEDIR;
+```
+
+- [ ] **Step 3: Route in GenericSelector (Option A — TableDirSelector)**
+
+Add to `GenericSelector.tsx` switch, alongside the existing TABLEDIR cases:
+
+```tsx
+case FIELD_REFERENCE_CODES.ASSIGNMENT.id:
+```
+
+This falls into the existing block that routes to `TableDirSelector`.
+
+- [ ] **Step 4: Test manually**
+
+Open a window with `S_ResourceAssignment_ID` and verify the selector loads options and allows selection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/utils/form/constants.ts \
+       packages/MainUI/utils/index.ts \
+       packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3931: Add Assignment reference type support"
+```
+
+---
+
+### Task 10: Tree Reference Selector
+
+**Files:**
+- Create: `packages/MainUI/hooks/useTreeData.ts`
+- Create: `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeSelector.tsx`
+- Create: `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeModal.tsx`
+- Create: `packages/MainUI/components/Form/FormView/selectors/TreeSelector/index.ts`
+- Modify: `packages/MainUI/utils/form/constants.ts`
+- Modify: `packages/MainUI/utils/index.ts`
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+**Prerequisites** (verify before implementing):
+1. Call the tree datasource endpoint and examine response structure
+2. Confirm fields per node: `id`, `name`/`_identifier`, `parentId`
+3. Confirm: can any level be selected, or only leaf nodes?
+4. Confirm: approximate number of nodes (is client-side tree building viable?)
+
+- [ ] **Step 1: Add constant and mapping**
+
+Add to `constants.ts`:
+
+```typescript
+TREE_REFERENCE: { id: "8C57A4A2E05F4261A1FADF47C30398AD", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+```
+
+Add to `getFieldReference()`:
+
+```typescript
+case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
+  return FieldType.SELECT;
+```
+
+- [ ] **Step 2: Create useTreeData hook**
+
+Create `packages/MainUI/hooks/useTreeData.ts`:
+
+```typescript
+import { useState, useEffect, useCallback } from "react";
+import { Metadata } from "@workspaceui/api-client/src/api/metadata";
+
+export interface TreeNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  children: TreeNode[];
+}
+
+interface UseTreeDataResult {
+  tree: TreeNode[];
+  loading: boolean;
+  error: string | null;
+}
+
+const buildTree = (flatNodes: TreeNode[]): TreeNode[] => {
+  const nodeMap = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const node of flatNodes) {
+    nodeMap.set(node.id, { ...node, children: [] });
+  }
+
+  for (const node of nodeMap.values()) {
+    if (node.parentId && nodeMap.has(node.parentId)) {
+      nodeMap.get(node.parentId)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  return roots;
+};
+
+export const useTreeData = (datasourceId: string | null): UseTreeDataResult => {
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!datasourceId) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      // The exact endpoint and response parsing will depend on manual testing findings.
+      // This is the expected structure — adjust field names after verifying the datasource response.
+      const response = await Metadata.client.request(`api/datasource/${datasourceId}`, {
+        method: "GET",
+      });
+
+      const data = response?.data?.response?.data || [];
+      const flatNodes: TreeNode[] = data.map((item: any) => ({
+        id: String(item.id),
+        name: String(item._identifier || item.name || ""),
+        parentId: item.parentId || item.treeNode || null,
+        children: [],
+      }));
+
+      setTree(buildTree(flatNodes));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error loading tree data");
+    } finally {
+      setLoading(false);
+    }
+  }, [datasourceId]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { tree, loading, error };
+};
+```
+
+- [ ] **Step 3: Create TreeModal**
+
+Create `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeModal.tsx`:
+
+```tsx
+import { useState, useCallback } from "react";
+import Modal from "@workspaceui/componentlibrary/src/components/BasicModal";
+import Button from "@workspaceui/componentlibrary/src/components/Button/Button";
+import Spinner from "@workspaceui/componentlibrary/src/components/Spinner";
+import SearchOutlined from "@workspaceui/componentlibrary/src/assets/icons/search.svg";
+import type { TreeNode } from "@/hooks/useTreeData";
+
+interface TreeModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onSelect: (node: TreeNode) => void;
+  tree: TreeNode[];
+  loading: boolean;
+  error: string | null;
+  currentId?: string | null;
+}
+
+const TreeNodeItem = ({
+  node,
+  level,
+  selectedId,
+  onSelect,
+}: {
+  node: TreeNode;
+  level: number;
+  selectedId: string | null;
+  onSelect: (node: TreeNode) => void;
+}) => {
+  const [expanded, setExpanded] = useState(level === 0);
+  const hasChildren = node.children.length > 0;
+  const isSelected = node.id === selectedId;
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1 px-2 py-1.5 cursor-pointer rounded text-sm transition-colors
+          ${isSelected ? "bg-blue-100 text-blue-800 font-medium" : "hover:bg-gray-100"}`}
+        style={{ paddingLeft: `${level * 20 + 8}px` }}
+        onClick={() => onSelect(node)}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setExpanded(!expanded); }}
+            className="w-4 h-4 flex items-center justify-center flex-shrink-0"
+          >
+            <svg className={`w-3 h-3 transition-transform ${expanded ? "rotate-90" : ""}`}
+              viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" />
+            </svg>
+          </button>
+        ) : (
+          <span className="w-4 flex-shrink-0" />
+        )}
+        <span className="truncate">{node.name}</span>
+      </div>
+      {expanded && hasChildren && node.children.map((child) => (
+        <TreeNodeItem
+          key={child.id}
+          node={child}
+          level={level + 1}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+};
+
+const TreeModal = ({ open, onCancel, onSelect, tree, loading, error, currentId }: TreeModalProps) => {
+  const [selectedNode, setSelectedNode] = useState<TreeNode | null>(null);
+
+  const handleSelect = useCallback((node: TreeNode) => {
+    setSelectedNode(node);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (selectedNode) onSelect(selectedNode);
+  }, [selectedNode, onSelect]);
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onCancel}
+      tittleHeader="Select Value"
+      descriptionText=""
+      HeaderIcon={SearchOutlined}
+      showHeader
+      buttons={
+        <div className="flex gap-2 flex-1">
+          <Button className="flex-[1_0_0]" variant="outlined" onClick={onCancel}>Cancel</Button>
+          <Button className="flex-[1_0_0]" variant="filled" onClick={handleConfirm} disabled={!selectedNode}>
+            OK
+          </Button>
+        </div>
+      }
+    >
+      <div className="p-4 max-h-80 overflow-y-auto">
+        {loading && <div className="flex justify-center p-8"><Spinner /></div>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        {!loading && !error && tree.map((node) => (
+          <TreeNodeItem
+            key={node.id}
+            node={node}
+            level={0}
+            selectedId={selectedNode?.id || currentId || null}
+            onSelect={handleSelect}
+          />
+        ))}
+      </div>
+    </Modal>
+  );
+};
+
+export default TreeModal;
+```
+
+- [ ] **Step 4: Create TreeSelector**
+
+Create `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeSelector.tsx`:
+
+```tsx
+import { useState, useCallback } from "react";
+import { useFormContext } from "react-hook-form";
+import SearchOutlined from "@workspaceui/componentlibrary/src/assets/icons/search.svg";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import TreeModal from "./TreeModal";
+import { useTreeData, type TreeNode } from "@/hooks/useTreeData";
+
+interface TreeSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+
+const TreeSelector = ({ field, isReadOnly }: TreeSelectorProps) => {
+  const { watch, setValue } = useFormContext();
+  const fieldName = field.hqlName || field.columnName || field.name;
+  const value = watch(fieldName);
+  const identifier = watch(`${fieldName}$_identifier`);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // The datasource ID comes from the field's selector configuration.
+  // Adjust this property path after manual testing confirms where it lives.
+  const datasourceId = (field.selector?.datasourceName as string) || null;
+  const { tree, loading, error } = useTreeData(isModalOpen ? datasourceId : null);
+
+  const handleSelect = useCallback(
+    (node: TreeNode) => {
+      setValue(fieldName, node.id, { shouldDirty: true, shouldTouch: true });
+      setValue(`${fieldName}$_identifier`, node.name, { shouldDirty: true });
+      setIsModalOpen(false);
+    },
+    [fieldName, setValue]
+  );
+
+  const displayValue = identifier || value || "";
+
+  return (
+    <>
+      <div
+        className={`flex items-center w-full px-3 rounded-t h-10.5 border-0 border-b-2 transition-colors outline-none ${
+          isReadOnly
+            ? "bg-transparent cursor-not-allowed border-dotted border-(--color-transparent-neutral-40)"
+            : "bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30) hover:border-(--color-transparent-neutral-100) cursor-pointer"
+        }`}
+        onClick={() => !isReadOnly && setIsModalOpen(true)}
+        tabIndex={isReadOnly ? -1 : 0}
+        onKeyDown={(e) => {
+          if ((e.key === "Enter" || e.key === " ") && !isReadOnly) {
+            e.preventDefault();
+            setIsModalOpen(true);
+          }
+        }}
+      >
+        <span className={`text-sm truncate flex-1 font-medium ${displayValue ? "text-(--color-transparent-neutral-80)" : "text-baseline-60"}`}>
+          {displayValue || "Select..."}
+        </span>
+        <SearchOutlined fill="currentColor" className="w-4 h-4 flex-shrink-0 text-(--color-transparent-neutral-60)" />
+      </div>
+      {isModalOpen && (
+        <TreeModal
+          open={isModalOpen}
+          onCancel={() => setIsModalOpen(false)}
+          onSelect={handleSelect}
+          tree={tree}
+          loading={loading}
+          error={error}
+          currentId={value}
+        />
+      )}
+    </>
+  );
+};
+
+export default TreeSelector;
+```
+
+- [ ] **Step 5: Create barrel export**
+
+Create `packages/MainUI/components/Form/FormView/selectors/TreeSelector/index.ts`:
+
+```typescript
+export { default as TreeSelector } from "./TreeSelector";
+```
+
+- [ ] **Step 6: Route in GenericSelector**
+
+Add import and case:
+
+```tsx
+import { TreeSelector } from "./TreeSelector";
+
+// In switch:
+case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
+  return <TreeSelector field={effectiveField} isReadOnly={isReadOnly} />;
+```
+
+- [ ] **Step 7: Test manually**
+
+Open a window with `M_Ch_Value_ID` (Characteristic Value) and verify:
+1. Field shows current value as text
+2. Click opens tree modal
+3. Tree loads and displays nodes hierarchically
+4. Selecting a node and clicking OK updates the field
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/MainUI/hooks/useTreeData.ts \
+       packages/MainUI/components/Form/FormView/selectors/TreeSelector/ \
+       packages/MainUI/utils/form/constants.ts \
+       packages/MainUI/utils/index.ts \
+       packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3931: Add TreeSelector for tree reference fields"
+```

--- a/docs/superpowers/plans/2026-06-01-tree-selector-and-assignment.md
+++ b/docs/superpowers/plans/2026-06-01-tree-selector-and-assignment.md
@@ -1,0 +1,842 @@
+# Tree Selector & Assignment Reference — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two missing field reference types — Assignment (ref 33) mapped to TableDirSelector, and Tree Reference (ref 8C57...) with a new hierarchical TreeSelector component.
+
+**Architecture:** Assignment is a simple constant + switch case addition. Tree Reference requires a pure utility (`treeUtils.ts`) to transform flat datasource records into a depth-annotated list, and a new `TreeSelector` component that renders a dropdown with indented tree nodes. TreeSelector reuses `useTableDirDatasource` for data fetching, `useSelectFieldOptions` for option building, and the existing `DropdownPortal`/`useDropdownPosition`/`SearchInput` infrastructure for the dropdown UI.
+
+**Tech Stack:** React 19, TypeScript, react-hook-form, Tailwind CSS, Jest
+
+**Spec:** `docs/superpowers/specs/2026-06-01-tree-selector-and-assignment-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/MainUI/utils/form/treeUtils.ts` | **New** — Pure `buildFlatTreeList()` function: takes flat EntityData[] with parentId, returns depth-annotated TreeNode[] |
+| `packages/MainUI/utils/form/__tests__/treeUtils.test.ts` | **New** — Unit tests for tree utility |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx` | **New** — Tree-aware dropdown selector component |
+| `packages/MainUI/utils/form/constants.ts` | **Modify** — Add ASSIGNMENT and TREE_REFERENCE to FIELD_REFERENCE_CODES |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | **Modify** — Add switch cases routing to TableDirSelector and TreeSelector |
+
+---
+
+### Task 1: Tree Hierarchy Utility — Tests
+
+**Files:**
+- Create: `packages/MainUI/utils/form/__tests__/treeUtils.test.ts`
+
+**Note:** All new files must include the Etendo license header. See any existing file (e.g. `packages/MainUI/utils/form/constants.ts` lines 1-16) for the exact header text. The code blocks below omit it for brevity but it MUST be included.
+
+- [ ] **Step 1: Write the test file for buildFlatTreeList**
+
+```typescript
+import { buildFlatTreeList } from "../treeUtils";
+import type { EntityData } from "@workspaceui/api-client/src/api/types";
+
+describe("buildFlatTreeList", () => {
+  it("should return empty array for empty input", () => {
+    expect(buildFlatTreeList([])).toEqual([]);
+  });
+
+  it("should handle flat records with no parents", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "Alpha" },
+      { id: "B", _identifier: "Beta" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "A", depth: 0, hasChildren: false }),
+      expect.objectContaining({ id: "B", depth: 0, hasChildren: false }),
+    ]);
+  });
+
+  it("should nest children under parents using parentId", () => {
+    const records: EntityData[] = [
+      { id: "ROOT", _identifier: "Root", isCharacteristic: true },
+      { id: "CHILD1", _identifier: "Child 1", parentId: "ROOT" },
+      { id: "CHILD2", _identifier: "Child 2", parentId: "ROOT" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "ROOT", depth: 0, hasChildren: true }),
+      expect.objectContaining({ id: "CHILD1", depth: 1, hasChildren: false }),
+      expect.objectContaining({ id: "CHILD2", depth: 1, hasChildren: false }),
+    ]);
+  });
+
+  it("should handle multi-level nesting (3+ levels)", () => {
+    const records: EntityData[] = [
+      { id: "L0", _identifier: "Level 0" },
+      { id: "L1", _identifier: "Level 1", parentId: "L0" },
+      { id: "L2", _identifier: "Level 2", parentId: "L1" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "L0", depth: 0, hasChildren: true }),
+      expect.objectContaining({ id: "L1", depth: 1, hasChildren: true }),
+      expect.objectContaining({ id: "L2", depth: 2, hasChildren: false }),
+    ]);
+  });
+
+  it("should treat orphan records as roots", () => {
+    const records: EntityData[] = [
+      { id: "ORPHAN", _identifier: "Orphan", parentId: "NONEXISTENT" },
+      { id: "ROOT", _identifier: "Root" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ depth: 0 });
+    expect(result[1]).toMatchObject({ depth: 0 });
+  });
+
+  it("should not infinite-loop on circular references", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "A", parentId: "B" },
+      { id: "B", _identifier: "B", parentId: "A" },
+    ];
+    // Should not hang — both treated as roots since neither has a valid non-circular ancestor
+    const result = buildFlatTreeList(records);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should handle single node", () => {
+    const records: EntityData[] = [{ id: "ONLY", _identifier: "Only Node" }];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "ONLY", depth: 0, hasChildren: false }),
+    ]);
+  });
+
+  it("should preserve all original record properties", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "A", isCharacteristic: true, showOpenIcon: true, customProp: "val" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result[0]).toMatchObject({
+      id: "A",
+      _identifier: "A",
+      isCharacteristic: true,
+      showOpenIcon: true,
+      customProp: "val",
+      depth: 0,
+      hasChildren: false,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:mainui -- --testPathPattern="treeUtils" --verbose`
+Expected: FAIL — `Cannot find module '../treeUtils'`
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add packages/MainUI/utils/form/__tests__/treeUtils.test.ts
+git commit -m "Feature ETP-3754: Add failing tests for buildFlatTreeList utility"
+```
+
+---
+
+### Task 2: Tree Hierarchy Utility — Implementation
+
+**Files:**
+- Create: `packages/MainUI/utils/form/treeUtils.ts`
+
+- [ ] **Step 1: Implement buildFlatTreeList**
+
+```typescript
+import type { EntityData } from "@workspaceui/api-client/src/api/types";
+
+export interface TreeNode extends EntityData {
+  depth: number;
+  hasChildren: boolean;
+}
+
+/**
+ * Transforms a flat array of records with parentId references into a
+ * depth-annotated flat list suitable for rendering an indented tree dropdown.
+ *
+ * Root detection: a record is a root when its parentId is falsy OR
+ * references an ID not present in the dataset (orphan).
+ *
+ * Walks depth-first so children appear directly after their parent.
+ * Tracks visited nodes to prevent infinite loops from circular references.
+ */
+export function buildFlatTreeList(records: EntityData[]): TreeNode[] {
+  if (records.length === 0) return [];
+
+  const idSet = new Set(records.map((r) => r.id as string));
+  const childrenMap = new Map<string, EntityData[]>();
+  const roots: EntityData[] = [];
+
+  for (const record of records) {
+    const parentId = record.parentId as string | undefined;
+    if (!parentId || !idSet.has(parentId)) {
+      roots.push(record);
+    } else {
+      const siblings = childrenMap.get(parentId) ?? [];
+      siblings.push(record);
+      childrenMap.set(parentId, siblings);
+    }
+  }
+
+  const result: TreeNode[] = [];
+  const visited = new Set<string>();
+
+  const walk = (nodes: EntityData[], depth: number) => {
+    for (const node of nodes) {
+      const nodeId = node.id as string;
+      if (visited.has(nodeId)) continue;
+      visited.add(nodeId);
+
+      const children = childrenMap.get(nodeId) ?? [];
+      result.push({
+        ...node,
+        depth,
+        hasChildren: children.length > 0,
+      });
+      if (children.length > 0) {
+        walk(children, depth + 1);
+      }
+    }
+  };
+
+  walk(roots, 0);
+
+  // Any unvisited records (from circular references) are added as roots
+  for (const record of records) {
+    if (!visited.has(record.id as string)) {
+      result.push({ ...record, depth: 0, hasChildren: false });
+    }
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `pnpm test:mainui -- --testPathPattern="treeUtils" --verbose`
+Expected: All 7 tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/MainUI/utils/form/treeUtils.ts
+git commit -m "Feature ETP-3754: Implement buildFlatTreeList tree hierarchy utility"
+```
+
+---
+
+### Task 3: Add ASSIGNMENT and TREE_REFERENCE Constants
+
+**Files:**
+- Modify: `packages/MainUI/utils/form/constants.ts:114-118` (after LINK entry, before PRODUCT_CHARACTERISTICS)
+
+- [ ] **Step 1: Add the new reference codes to FIELD_REFERENCE_CODES**
+
+In `packages/MainUI/utils/form/constants.ts`, add these entries after the `LINK` entry (line 113) and before `PRODUCT_CHARACTERISTICS` (line 117):
+
+```typescript
+  // Assignment — resource assignment FK (ref 33 in Classic).
+  // Uses TableDirDomainType in Classic; mapped to TableDirSelector.
+  ASSIGNMENT: { id: "33", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+
+  // Tree Reference — hierarchical FK selector (e.g. Characteristic Values)
+  TREE_REFERENCE: { id: "8C57A4A2E05F4261A1FADF47C30398AD", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+```
+
+- [ ] **Step 2: Run lint to verify**
+
+Run: `pnpm lint -- packages/MainUI/utils/form/constants.ts`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/MainUI/utils/form/constants.ts
+git commit -m "Feature ETP-3754: Add Assignment and Tree Reference to FIELD_REFERENCE_CODES"
+```
+
+---
+
+### Task 4: TreeSelector Component
+
+**Files:**
+- Create: `packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx`
+
+**Note:** Include the Etendo license header (same as other files in the selectors/ directory).
+
+- [ ] **Step 1: Create the TreeSelector component**
+
+Write the complete file below to `packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx`.
+This follows the `Select.tsx` pattern (trigger div + `DropdownPortal`) but replaces flat option rendering with indented tree nodes.
+
+```typescript
+// @data-testid-ignore
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+import ChevronDown from "@workspaceui/componentlibrary/src/assets/icons/chevron-down.svg";
+import ChevronRight from "@workspaceui/componentlibrary/src/assets/icons/chevron-right.svg";
+import XIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import CheckIcon from "@workspaceui/componentlibrary/src/assets/icons/check-circle-filled.svg";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import { useTableDirDatasource } from "@/hooks/datasource/useTableDirDatasource";
+import { useSelectFieldOptions } from "@/hooks/useSelectFieldOptions";
+import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+import { updateSelectorValue } from "@/utils/form/selectors/utils";
+import { useDropdownPosition } from "@/components/Form/FormView/selectors/hooks/useDropdownPosition";
+import DropdownPortal from "@/components/Form/FormView/selectors/components/Select/DropdownPortal";
+import {
+  handleKeyboardActivation,
+  useFocusHandler,
+  useHoverHandlers,
+  useOpenDropdownEffect,
+  useSearchHandler,
+  useSearchTermHandler,
+} from "@/utils/selectorUtils";
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface TreeSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+
+const isNodeSelectable = (node: TreeNode): boolean => !node.isCharacteristic;
+
+function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
+  const { t } = useTranslation();
+  const { register, setValue, watch } = useFormContext();
+  const fieldName = field.hqlName || field.columnName || field.name;
+  const selectedValue = watch(fieldName);
+  const currentIdentifier = watch(`${fieldName}$_identifier`);
+
+  // --- Data fetching (same pattern as TableDirSelector) ---
+  const { records, loading, refetch } = useTableDirDatasource({ field });
+  const options = useSelectFieldOptions(field, records);
+
+  // --- Build tree from flat options ---
+  const treeNodes = useMemo(() => {
+    const recordData = options
+      .filter((opt) => opt.data && Object.keys(opt.data).length > 0)
+      .map((opt) => opt.data!);
+    return buildFlatTreeList(recordData);
+  }, [options]);
+
+  // Lookup map for O(1) parent resolution in filters
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, TreeNode>();
+    for (const node of treeNodes) {
+      map.set(node.id as string, node);
+    }
+    return map;
+  }, [treeNodes]);
+
+  // --- UI state ---
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [isHovering, setIsHovering] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const [selectedLabel, setSelectedLabel] = useState("");
+
+  const listRef = useRef<HTMLUListElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const dropdownId = useMemo(() => `tree-dropdown-${fieldName}`, [fieldName]);
+
+  const handleSearchChange = useSearchHandler();
+
+  // --- Visible nodes: search filter + collapse filter ---
+  const visibleNodes = useMemo(() => {
+    let filtered = treeNodes;
+
+    if (searchTerm) {
+      // Search: keep matches + their ancestor chain for context
+      const lowerSearch = searchTerm.toLowerCase();
+      const matchIds = new Set(
+        treeNodes
+          .filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch))
+          .map((n) => n.id as string)
+      );
+      const keepIds = new Set(matchIds);
+      for (const node of treeNodes) {
+        if (matchIds.has(node.id as string)) {
+          let current: TreeNode | undefined = node;
+          while (current?.parentId && typeof current.parentId === "string") {
+            keepIds.add(current.parentId);
+            current = nodeMap.get(current.parentId);
+          }
+        }
+      }
+      filtered = filtered.filter((n) => keepIds.has(n.id as string));
+    } else {
+      // No search: apply collapse filter — hide children of collapsed parents
+      filtered = filtered.filter((node) => {
+        let parentId = node.parentId as string | undefined;
+        while (parentId) {
+          if (collapsedNodes.has(parentId)) return false;
+          const parent = nodeMap.get(parentId);
+          parentId = parent?.parentId as string | undefined;
+        }
+        return true;
+      });
+    }
+
+    return filtered;
+  }, [treeNodes, searchTerm, collapsedNodes, nodeMap]);
+
+  // --- Selectable nodes only (for keyboard nav index) ---
+  const selectableIndices = useMemo(() => {
+    const indices: number[] = [];
+    for (let i = 0; i < visibleNodes.length; i++) {
+      if (isNodeSelectable(visibleNodes[i])) {
+        indices.push(i);
+      }
+    }
+    return indices;
+  }, [visibleNodes]);
+
+  // --- Toggle collapse ---
+  const toggleCollapse = useCallback((nodeId: string) => {
+    setCollapsedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  }, []);
+
+  // --- Selection ---
+  const handleSelect = useCallback(
+    (node: TreeNode) => {
+      if (!isNodeSelectable(node)) return;
+      const nodeId = node.id as string;
+      updateSelectorValue(setValue, fieldName, nodeId, node);
+      setSelectedLabel(node._identifier as string);
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+      setIsFocused(false);
+    },
+    [fieldName, setValue]
+  );
+
+  // --- Keyboard navigation (skips non-selectable nodes) ---
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const currentPos = selectableIndices.indexOf(prev);
+          const nextPos = currentPos < 0 ? 0 : (currentPos + 1) % selectableIndices.length;
+          return selectableIndices[nextPos];
+        });
+        return;
+      }
+
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const currentPos = selectableIndices.indexOf(prev);
+          const nextPos = currentPos <= 0 ? selectableIndices.length - 1 : currentPos - 1;
+          return selectableIndices[nextPos];
+        });
+        return;
+      }
+
+      if (e.key === "Enter" && highlightedIndex >= 0) {
+        e.preventDefault();
+        const node = visibleNodes[highlightedIndex];
+        if (node) {
+          if (isNodeSelectable(node)) {
+            handleSelect(node);
+          } else if (node.hasChildren) {
+            toggleCollapse(node.id as string);
+          }
+        }
+      }
+    },
+    [visibleNodes, highlightedIndex, selectableIndices, handleSelect, toggleCollapse]
+  );
+
+  // --- Dropdown open/close ---
+  const closeDropdown = useCallback(() => {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+    setIsFocused(false);
+    setCollapsedNodes(new Set()); // reset collapse state
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (!isReadOnly) {
+        setIsOpen((prev) => !prev);
+        setIsFocused(true);
+      }
+    },
+    [isReadOnly]
+  );
+
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setValue(`${fieldName}$_identifier`, "", { shouldDirty: false });
+      setValue(`${fieldName}_data`, null);
+      setValue(fieldName, "", { shouldDirty: true, shouldValidate: true });
+      setSelectedLabel("");
+    },
+    [fieldName, setValue]
+  );
+
+  // --- Blur / click-outside ---
+  const handleBlur = useCallback(
+    (e: React.FocusEvent) => {
+      const relatedTarget = e.relatedTarget as Element | null;
+      if (relatedTarget?.closest(`[data-dropdown-portal="${dropdownId}"]`)) return;
+      setTimeout(() => {
+        const activeElement = document.activeElement;
+        const isInPortal = activeElement?.closest(`[data-dropdown-portal="${dropdownId}"]`);
+        const isInWrapper = wrapperRef.current?.contains(activeElement);
+        if (!isInPortal && !isInWrapper) closeDropdown();
+      }, 150);
+    },
+    [closeDropdown, dropdownId]
+  );
+
+  const handleSearchBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const relatedTarget = e.relatedTarget as Element | null;
+      if (wrapperRef.current?.contains(relatedTarget)) return;
+      setTimeout(() => {
+        const activeElement = document.activeElement;
+        const isInPortal = activeElement?.closest(`[data-dropdown-portal="${dropdownId}"]`);
+        const isInWrapper = wrapperRef.current?.contains(activeElement);
+        if (!isInPortal && !isInWrapper) closeDropdown();
+      }, 150);
+    },
+    [closeDropdown, dropdownId]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element;
+      const isInWrapper = wrapperRef.current?.contains(target);
+      const isInPortal = target.closest(`[data-dropdown-portal="${dropdownId}"]`);
+      if (!isInWrapper && !isInPortal) closeDropdown();
+    };
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+    }, 100);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, closeDropdown, dropdownId]);
+
+  // --- Shared hooks ---
+  const { handleMouseEnter, handleMouseLeave } = useHoverHandlers(setIsHovering);
+  const handleFocus = useFocusHandler(refetch);
+  const handleSetSearchTerm = useSearchTermHandler(handleSearchChange, setSearchTerm);
+  const handleScroll = useCallback(() => {}, []); // no infinite scroll for tree data
+  const dropdownViewportData = useDropdownPosition(isOpen, triggerRef as React.RefObject<HTMLDivElement>);
+
+  useOpenDropdownEffect(
+    isOpen,
+    setSearchTerm,
+    setHighlightedIndex,
+    searchInputRef as React.RefObject<HTMLInputElement>
+  );
+
+  // --- Sync selected label from form state ---
+  useEffect(() => {
+    const node = treeNodes.find((n) => (n.id as string) === selectedValue);
+    setSelectedLabel(node ? (node._identifier as string) : currentIdentifier || selectedValue || "");
+  }, [selectedValue, treeNodes, currentIdentifier]);
+
+  // --- Scroll highlighted into view ---
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
+
+  // --- Trigger styles (same as Select.tsx) ---
+  const mainDivClassNames = useMemo(() => {
+    const base =
+      "w-full flex items-center justify-between px-3 pr-3 rounded-t tracking-normal h-10.5 border-0 border-b-2 transition-colors outline-none";
+    if (isReadOnly) {
+      return `${base} bg-transparent rounded-t-lg cursor-not-allowed border-b-2 border-dotted border-(--color-transparent-neutral-40) hover:border-dotted hover:border-(--color-transparent-neutral-70) hover:bg-transparent focus:border-dotted focus:border-(--color-transparent-neutral-70) focus:bg-transparent focus:text-(--color-transparent-neutral-80)`;
+    }
+    const active = "border-[#004ACA] text-[#004ACA] bg-[#E5EFFF]";
+    const hover = "hover:border-(--color-transparent-neutral-100) hover:bg-(--color-transparent-neutral-10)";
+    const focus = "focus:border-[#004ACA] focus:text-[#004ACA] focus:bg-[#E5EFFF] focus:outline-none cursor-pointer";
+    const interactive = isFocused || isOpen ? active : hover;
+    return `${base} bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30) text-(--color-transparent-neutral-80) font-medium text-sm leading-5 ${interactive} ${focus}`;
+  }, [isReadOnly, isFocused, isOpen]);
+
+  const labelClassNames = useMemo(() => {
+    const base = "text-sm truncate max-w-[calc(100%-40px)] font-medium";
+    if (!selectedLabel) return `${base} text-baseline-60`;
+    const isActive = (isFocused || isOpen) && !isReadOnly;
+    return `${base} ${isActive ? "text-[#004ACA]" : "text-(--color-transparent-neutral-80)"}`;
+  }, [selectedLabel, isFocused, isOpen, isReadOnly]);
+
+  const chevronClassNames = useMemo(() => {
+    const base = "w-5 h-5 transition-transform";
+    const isActive = isFocused || isOpen;
+    return `${base} ${isActive ? "text-(--color-baseline-100) rotate-180" : "text-(--color-transparent-neutral-60)"}`;
+  }, [isFocused, isOpen]);
+
+  const shouldShowClearButton = selectedLabel && (isHovering || isOpen) && !isReadOnly;
+
+  // --- Rendered tree options ---
+  const renderedOptions = useMemo(() => {
+    if (loading && visibleNodes.length === 0) {
+      return <li className="px-4 py-3 text-sm text-baseline-60">Loading...</li>;
+    }
+    if (visibleNodes.length === 0) {
+      return <li className="px-4 py-3 text-sm text-baseline-60">No options found</li>;
+    }
+
+    return visibleNodes.map((node, index) => {
+      const nodeId = node.id as string;
+      const identifier = node._identifier as string;
+      const selectable = isNodeSelectable(node);
+      const isSelected = selectedValue === nodeId;
+      const isHighlighted = highlightedIndex === index;
+      const isCollapsed = collapsedNodes.has(nodeId);
+
+      return (
+        <li
+          key={nodeId}
+          aria-selected={isSelected}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (selectable) {
+              handleSelect(node);
+            } else if (node.hasChildren) {
+              toggleCollapse(nodeId);
+            }
+          }}
+          onMouseEnter={() => {
+            if (selectable) setHighlightedIndex(index);
+          }}
+          className={`py-2.5 text-sm flex items-center justify-between focus:outline-none
+            ${selectable ? "cursor-pointer hover:bg-baseline-10" : "cursor-default"}
+            ${isHighlighted && selectable ? "bg-baseline-10" : ""}
+            ${isSelected ? "bg-baseline-10" : ""}`}
+          style={{ paddingLeft: `${16 + node.depth * 20}px`, paddingRight: "16px" }}>
+          <span className="flex items-center gap-1.5 truncate mr-2">
+            {node.hasChildren && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleCollapse(nodeId);
+                }}
+                className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-baseline-60 hover:text-baseline-90">
+                <ChevronRight
+                  className={`w-3 h-3 transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+                  fill="currentColor"
+                />
+              </button>
+            )}
+            {!node.hasChildren && <span className="w-4 flex-shrink-0" />}
+            <span
+              className={`truncate ${
+                selectable
+                  ? isSelected
+                    ? "text-dynamic-dark font-medium"
+                    : "text-baseline-90"
+                  : "font-semibold text-baseline-60"
+              }`}>
+              {identifier}
+            </span>
+          </span>
+          {isSelected && (
+            <CheckIcon className="fade-in-left flex-shrink-0" height={16} width={16} />
+          )}
+        </li>
+      );
+    });
+  }, [visibleNodes, highlightedIndex, selectedValue, collapsedNodes, handleSelect, toggleCollapse, loading]);
+
+  return (
+    <>
+      <div
+        ref={wrapperRef}
+        className={`relative w-full font-['Inter'] ${isReadOnly ? "pointer-events-none" : ""}`}
+        onBlur={handleBlur}
+        aria-label={field.name}
+        aria-readonly={isReadOnly}
+        aria-required={field.isMandatory}
+        aria-disabled={isReadOnly}
+        aria-details={field.helpComment}
+        tabIndex={-1}>
+        <input {...register(fieldName)} type="hidden" readOnly={isReadOnly} />
+        <div
+          ref={triggerRef}
+          onClick={handleClick}
+          onKeyDown={(e) => handleKeyboardActivation(e, () => handleClick(e as unknown as React.MouseEvent))}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onFocus={handleFocus}
+          tabIndex={isReadOnly ? -1 : 0}
+          className={mainDivClassNames}>
+          <span className={labelClassNames}>
+            {selectedLabel || (!isReadOnly ? t("form.select.placeholder") : "")}
+          </span>
+          <div className="flex items-center flex-shrink-0 ml-2">
+            {shouldShowClearButton && (
+              <button
+                type="button"
+                onClick={handleClear}
+                onKeyDown={(e) => handleKeyboardActivation(e, () => handleClear(e as unknown as React.MouseEvent))}
+                className={`mr-1 hover:text-gray-600 transition-opacity opacity-100 focus:outline-none focus:ring-2 focus:ring-dynamic-light rounded ${
+                  isFocused || isOpen ? "text-(--color-baseline-100)" : "text-(--color-transparent-neutral-60)"
+                }`}
+                aria-label="Clear selection">
+                <XIcon />
+              </button>
+            )}
+            {!isReadOnly && (
+              <ChevronDown fill="currentColor" className={chevronClassNames} />
+            )}
+          </div>
+        </div>
+      </div>
+      {!isReadOnly && (
+        <DropdownPortal
+          isOpen={isOpen}
+          viewportData={dropdownViewportData}
+          searchTerm={searchTerm}
+          searchInputRef={searchInputRef as React.RefObject<HTMLInputElement>}
+          handleSetSearchTerm={handleSetSearchTerm}
+          handleKeyDown={handleKeyDown}
+          handleSearchBlur={handleSearchBlur}
+          handleFocus={handleFocus}
+          listRef={listRef as React.RefObject<HTMLUListElement>}
+          handleScroll={handleScroll}
+          renderedOptions={<>{renderedOptions}</>}
+          dropdownId={dropdownId}
+        />
+      )}
+    </>
+  );
+}
+
+export const TreeSelector = memo(TreeSelectorCmp);
+export default TreeSelector;
+```
+
+- [ ] **Step 2: Verify lint passes**
+
+Run: `pnpm lint -- packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
+git commit -m "Feature ETP-3754: Add TreeSelector component with hierarchical dropdown"
+```
+
+---
+
+### Task 5: Wire Up GenericSelector Switch Cases
+
+**Files:**
+- Modify: `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx`
+
+- [ ] **Step 1: Add the import for TreeSelector**
+
+At the top of `GenericSelector.tsx`, add after the existing selector imports (around line 51):
+
+```typescript
+import { TreeSelector } from "./TreeSelector";
+```
+
+- [ ] **Step 2: Add the ASSIGNMENT case (grouped with TableDir cases)**
+
+In the switch statement, add AFTER the existing `TABLE_DIR_18` case (line 112) and BEFORE the closing `return` of the TableDirSelector block (line 114). This groups it logically with the other TableDir references:
+
+```typescript
+      case FIELD_REFERENCE_CODES.TABLE_DIR_18.id:
+      // Assignment (ref 33): uses TableDirDomainType in Classic — resource assignment FK
+      case FIELD_REFERENCE_CODES.ASSIGNMENT.id:
+        return (
+          <TableDirSelector field={effectiveField} isReadOnly={isReadOnly} data-testid="TableDirSelector__6e80fa" />
+        );
+```
+
+- [ ] **Step 3: Add the TREE_REFERENCE case**
+
+In the switch statement, add BEFORE the `default` case (around line 216):
+
+```typescript
+      // Tree Reference: hierarchical FK selector (e.g. Characteristic Values)
+      case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
+        return (
+          <TreeSelector field={effectiveField} isReadOnly={isReadOnly} />
+        );
+```
+
+- [ ] **Step 4: Verify lint and build pass**
+
+Run: `pnpm lint -- packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx && pnpm build`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+git commit -m "Feature ETP-3754: Wire Assignment and Tree Reference in GenericSelector"
+```
+
+---
+
+### Task 6: Manual Verification
+
+- [ ] **Step 1: Start dev server and verify Assignment field renders as TableDir dropdown**
+
+Run: `pnpm dev`
+Navigate to a window with an Assignment field (Resource Booking or Manufacturing Order with S_ResourceAssignment_ID). Confirm it renders as a standard TableDir dropdown instead of a plain text field.
+
+- [ ] **Step 2: Verify Tree Reference field renders with hierarchy**
+
+Navigate to the Product window → Product Characteristics tab (or use filters). Confirm the Characteristic Value field renders a tree dropdown with:
+- Root nodes (characteristics) shown in bold, non-selectable
+- Child nodes (values) indented under their parent, selectable
+- Search filters and preserves ancestor context
+- Expand/collapse chevrons work on parent nodes
+
+- [ ] **Step 3: Verify no regressions in existing selectors**
+
+Open a window with TableDir fields (e.g. Sales Order), Select fields, List fields. Confirm they all still render and function correctly.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pnpm test`
+Expected: All tests pass, including the new treeUtils tests.

--- a/docs/superpowers/specs/2026-05-27-missing-reference-types-design.md
+++ b/docs/superpowers/specs/2026-05-27-missing-reference-types-design.md
@@ -1,0 +1,380 @@
+# Missing Reference Types & Existing Type Fixes — Design Spec
+
+## Overview
+
+Complete the field/column reference type coverage in the new Etendo UI by fixing gaps in existing types and implementing the remaining reference types that are actively used in Etendo Core.
+
+**Backend changes**: None. All metadata (reference IDs, column properties, selector info) is already sent by the metadata module.
+
+**Branch**: `epic/ETP-3931`
+
+**Approach**: Extend existing components where possible (Approach B). No new component for Memo — reuse TextLongSelector. New components only when behavior genuinely differs.
+
+**Commit strategy**: One commit per fix/feature, grouped by phase.
+
+---
+
+## Phase 1: Fixes to Existing Types
+
+### 1.1 Integer/Decimal min/max Validation
+
+**Problem**: `NumericSelector` does not validate `minValue`/`maxValue` from column metadata. Only `QuantitySelector` does (receives `min`/`max` as props from GenericSelector:130-131). Integer and Decimal fields with range constraints are accepted without client-side validation.
+
+**Solution**: Read `field.column.minValue` and `field.column.maxValue` inside `UnifiedNumericSelector`. Use `validateNumber` from `@workspaceui/componentlibrary/src/utils/quantitySelectorUtil` (already used by QuantitySelector) for the validity check, then write new inline clamping logic in `handleBlur`. Show visual feedback when the value is out of range.
+
+**Important**: `validateNumber` accepts a **string** as its first argument and returns `{ isValid, errorMessage }` — it does **not** clamp. The clamping logic (`Math.max(min, Math.min(max, value))`) must be written separately in `handleBlur`. Pass `String(parsedValue)` to `validateNumber` since `handleBlur` already has the parsed number.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/components/Form/FormView/selectors/NumericSelector.tsx` | Import `validateNumber` from `@workspaceui/componentlibrary/src/utils/quantitySelectorUtil`. In `handleBlur`, after parsing the value: (1) read `field.column.minValue`/`maxValue`, (2) call `validateNumber(String(parsedValue), minValue, maxValue, true)` to check validity, (3) if invalid, clamp with `Math.max(min, Math.min(max, parsedValue))` and set the clamped value. Add red border feedback via a local `hasError` state. |
+
+**Behavior**:
+- On blur: if value < minValue, clamp to minValue. If value > maxValue, clamp to maxValue.
+- Show brief visual error indicator (red bottom border) before clamping.
+- `allowNegative` defaults to `true` for Integer/Decimal (unlike Quantity which defaults to `false`).
+
+**Validation**: Test with Sales Order > Lines > `Line No.` field (Integer with typical min=0).
+
+---
+
+### 1.2 Upload File — Form Save Pipeline
+
+**Problem**: The NOTE in GenericSelector (line 187-190) states that the form save pipeline does not support multipart uploads. `UploadFileSelector` stores a fake path string. Actual file persistence is not connected.
+
+**Solution**: Follow the `ImageSelector` + `useImageUpload` pattern. Create a `useFileUpload` hook that uploads the file via a dedicated endpoint before the form save, then stores the resulting attachment ID in the form value.
+
+**Endpoint discovery required**: The exact upload endpoint, request format, and response format must be determined before implementation. The existing `useImageUpload` uses `POST /api/erp/utility/ImageInfoBLOB` with params like `Command: "SAVE_OB3"`, `inpColumnName`, `inpTabId` and parses an HTML callback response. The file upload endpoint is likely different (possibly `/ws/com.etendoerp.attachment` or similar). **Pre-implementation step**: inspect Classic network traffic when uploading a file in a window with Upload File reference type to determine the exact endpoint, required form fields, and response format.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/hooks/useFileUpload.ts` | **New** — Hook accepting a `File` object. Uploads via `FormData` POST to the discovered endpoint. Returns `{ upload, isUploading, error, attachmentId }`. |
+| `packages/MainUI/components/ProcessModal/selectors/UploadFileSelector.tsx` | Integrate `useFileUpload`. On file selection, trigger upload immediately. Show progress indicator during upload. In read-only mode, show download link. Add clear/remove button. |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Remove the NOTE comment (lines 187-190) once the pipeline is connected. |
+
+**Hook API**:
+
+```typescript
+interface UseFileUploadResult {
+  upload: (file: File) => Promise<string>; // returns attachment ID
+  isUploading: boolean;
+  progress: number; // 0-100
+  error: string | null;
+  reset: () => void;
+}
+
+function useFileUpload(): UseFileUploadResult;
+```
+
+**Behavior**:
+1. User selects file → `upload(file)` fires immediately
+2. Progress indicator shown during upload
+3. On success, attachment ID stored in form value via `setValue`
+4. On error, show error message, allow retry
+5. Read-only: show filename as download link (fetched from attachment metadata)
+6. Clear button: remove attachment reference, set form value to null
+
+**Validation**: Find a window with Upload File reference type in Classic DB and test end-to-end.
+
+---
+
+### 1.3 Text/Memo Grid Truncation
+
+**Problem**: Text and Memo fields in grid view show full content without truncation or tooltip. Long content breaks grid layout or is silently clipped by CSS without user indication.
+
+**Solution**: Add a `renderTextCell` helper in `tableColumns.tsx` that wraps long text in a truncated container with a tooltip showing the full content on hover.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/tableColumns.tsx` | Add `renderTextCell(value: string)` — returns a `<span>` with `truncate` class and Tooltip wrapper from ComponentLibrary. Max display: single line in grid. |
+| `packages/MainUI/hooks/table/useColumns.tsx` | Apply `renderTextCell` for columns whose `column.reference` matches Text (`"14"`), Memo (`"34"`), or Rich Text (`"7CB371C13D204EB69BF370217F692999"`). Do **not** match on `FieldType.TEXT` — that is the default fallback for all unrecognized reference types and would over-apply truncation. |
+
+**Behavior**:
+- Grid cell shows single line of text with ellipsis overflow
+- Hover shows full content in a tooltip (using existing Tooltip component)
+- Applies only to reference types: Text (14), Memo (34), and Rich Text (rendered as stripped plain text in grid)
+
+---
+
+### 1.4 PAttribute Improvements
+
+**Problem**: The PAttribute modal works for basic cases but has gaps:
+1. `hasRequiredFields` does not validate mandatory lot/serial fields from config
+2. No way to clear/reset a selected attribute set instance
+3. Instance vs non-instance distinction not handled (deferred — depends on backend behavior)
+
+**Solution**:
+
+**1.4a — Mandatory lot/serial validation**:
+
+The current `AttributeSetConfig` type only has `isLot` and `isSerNo` (booleans for feature enabled), but does **not** have `isMandatoryLot` or `isMandatorySerNo`. The backend response from `AttributeSetInstanceActionHandler` needs to be checked for these fields.
+
+**Pre-implementation step**: Inspect the backend response from the CONFIG action for an attribute set that has mandatory lot enabled. Check if `isMandatoryLot`/`isMandatorySerNo` are present in the response JSON.
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/types.ts` | If backend sends mandatory flags: add `isMandatoryLot: boolean` and `isMandatorySerNo: boolean` to `AttributeSetConfig` |
+| `packages/MainUI/hooks/useAttributeSetConfig.ts` | If backend sends mandatory flags: parse `data.isMandatoryLot` and `data.isMandatorySerNo` in the config mapping (lines 59-66) |
+| `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceModal.tsx` | Extend `hasRequiredFields` memo: if `config.isMandatoryLot && !formData.lot` return false. Same for `isMandatorySerNo`/`serialNo`. If backend does not send these flags, skip this sub-item (no backend changes in this spec). |
+
+**1.4b — Clear button**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx` | Add X icon button next to the search icon (visible only when value is set and not read-only). On click: `setValue(fieldName, null)`, `setValue(\`${fieldName}$_identifier\`, null)`, clear `displayValue` and `lastSavedInstanceId`. |
+
+**1.4c — Instance vs non-instance** (deferred):
+
+The save endpoint (`useAttributeSetInstance.saveInstance`) already receives `attributeSetId` and `instanceId`. The backend should handle whether to create a new instance or reuse. If the backend does not distinguish, this becomes a backend task. No frontend change planned for this spec — verify during manual testing.
+
+---
+
+### 1.5 Password Show/Hide Toggle
+
+**Problem**: `PasswordSelector` renders with fixed `type="password"`. No way to reveal the value for verification.
+
+**Solution**: Add a toggle button with eye/eye-off icon inside the input field.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx` | Add `showPassword` state (default false). Pass `showClearButton={false}` to TextInput (clear button is not useful for password fields — the user should retype, not clear and retype). Use the `endAdornment` prop of TextInput to render the eye toggle button (absolute positioned right, same slot where clear button would be). When toggled, switch between `type="password"` and `type="text"`. Do not show toggle when value is the placeholder `"***"`. |
+
+**Behavior**:
+- Default: password masked
+- Click eye icon: reveals text
+- Click again: masks again
+- When value is `"***"` (placeholder): toggle hidden (nothing useful to reveal)
+- Clear button removed (`showClearButton={false}`) — eye toggle takes its place via `endAdornment`
+- Icon: inline SVG (eye-open / eye-closed), no new dependency
+
+---
+
+### Phase 1 Commit Plan
+
+| # | Commit message | Scope |
+|---|---------------|-------|
+| 1 | `Feature ETP-3931: Add min/max validation to NumericSelector` | 1.1 |
+| 2 | `Feature ETP-3931: Integrate file upload pipeline for UploadFileSelector` | 1.2 |
+| 3 | `Feature ETP-3931: Add grid truncation with tooltip for Text fields` | 1.3 |
+| 4 | `Feature ETP-3931: Improve PAttribute mandatory validation and clear` | 1.4 |
+| 5 | `Feature ETP-3931: Add show/hide toggle to PasswordSelector` | 1.5 |
+
+---
+
+## Phase 2: New Reference Types (Frequently Used)
+
+### 2.1 Memo (ID: 34) — Route to TextLongSelector
+
+**Problem**: 11 columns in core (DefaultValue, SQL_Record_Identifier, Observation, etc.) fall through to `StringSelector` and render as single-line inputs instead of textareas.
+
+**Solution**: Add routing only — no new component. Memo is functionally identical to Text (14) in the new UI.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `MEMO: { id: "34", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR }` |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add `case FIELD_REFERENCE_CODES.MEMO.id:` alongside the existing `TEXT_LONG` case, both routing to `TextLongSelector` |
+| `packages/MainUI/utils/index.ts` | Add `case "34":` in `getFieldReference()` returning `FieldType.TEXT` |
+
+**Validation**: Open a window with a Memo field (e.g., Tables and Columns > Table > Observation field) and confirm it renders as a textarea.
+
+---
+
+### 2.2 Link (ID: 800101) — New LinkSelector
+
+**Problem**: 3 columns (URL in BankAccount, YourCompanyURL, etc.) fall through to `StringSelector`. Should render as clickable hyperlink in read-only and text input in edit mode.
+
+**Solution**: New `LinkSelector` component with dual rendering.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `LINK: { id: "800101", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR }` |
+| `packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx` | **New** — See component spec below |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add `case FIELD_REFERENCE_CODES.LINK.id:` → `LinkSelector` |
+| `packages/MainUI/utils/index.ts` | Add `case "800101":` in `getFieldReference()` returning `FieldType.TEXT` |
+
+**Component spec**:
+
+```typescript
+interface LinkSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+```
+
+**Behavior**:
+- **Edit mode**: Standard `TextInput` (reuse existing component). Same as StringSelector but with URL-specific placeholder ("https://...").
+- **Read-only mode**: Render as `<a href={value} target="_blank" rel="noopener noreferrer">` with link styling (blue, underline). Truncated with `max-w` and ellipsis if URL is long.
+- **Empty value**: Show nothing in read-only (not a broken link). Show empty input in edit.
+- **No strict URL validation on input**: Users can type freely. Only the display mode changes.
+
+**Validation**: Open Business Partner > Customer/Vendor tab > URL field.
+
+---
+
+### 2.3 Product Characteristics (ID: C632F1CFF5A1453EB28BDF44A70478F8) — Read-Only Routing
+
+**Problem**: 3 columns (`Characteristic_Desc`) fall through to StringSelector. This field is always read-only — it displays a concatenated description of product characteristics composed from the Product Characteristics window.
+
+**Solution**: Route to `StringSelector` with forced `isReadOnly={true}`. No new component.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `PRODUCT_CHARACTERISTICS: { id: "C632F1CFF5A1453EB28BDF44A70478F8", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR }` |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add case: `return <StringSelector field={effectiveField} readOnly={true} />`. Add a comment on the case explaining that Product Characteristics are always read-only (composed from Product Characteristics window, not editable inline). This hardcoded override intentionally ignores the `isReadOnly` prop from GenericSelector. |
+| `packages/MainUI/utils/index.ts` | Add case in `getFieldReference()` returning `FieldType.TEXT` |
+
+**Validation**: Find a Product with characteristics and verify the field shows the concatenated description as read-only text.
+
+---
+
+### Phase 2 Commit Plan
+
+| # | Commit message | Scope |
+|---|---------------|-------|
+| 6 | `Feature ETP-3931: Route Memo reference type to TextLongSelector` | 2.1 |
+| 7 | `Feature ETP-3931: Add LinkSelector for URL reference fields` | 2.2 |
+| 8 | `Feature ETP-3931: Route Product Characteristics as read-only string` | 2.3 |
+
+---
+
+## Phase 3: Isolated Types (Manual Testing Required Before Implementation)
+
+**Important**: Both types in this phase are blocked until manual verification of metadata responses. Implementation starts only after confirming the prerequisites listed below.
+
+### 3.1 Assignment (ID: 33) — Route to TableDirSelector or New AssignmentSelector
+
+**Problem**: 3 columns (`S_ResourceAssignment_ID`) fall through to StringSelector. In Classic, this opens a popup to select a resource assignment (resource, date, quantity).
+
+**Hypothesis**: Since Assignment is a FK to `S_ResourceAssignment`, routing to `TableDirSelector` may work if the metadata module exposes the entity correctly.
+
+**Prerequisites to verify manually**:
+1. Open a window with an Assignment field in the new UI
+2. Check browser devtools: does the metadata response include `referencedEntity: "ResourceAssignment"` for this field?
+3. Does the selector search modal load and show results for this entity?
+
+**Option A — TableDirSelector works**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `ASSIGNMENT: { id: "33", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE }` |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add case → `TableDirSelector` |
+| `packages/MainUI/utils/index.ts` | Add case returning `FieldType.TABLEDIR` |
+
+**Option B — Needs custom component** (if metadata doesn't resolve the entity):
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/components/Form/FormView/selectors/AssignmentSelector.tsx` | **New** — Wrapper around TableDirSelector with hardcoded entity configuration for `ResourceAssignment` |
+| Other files | Same as Option A |
+
+**Validation**: Test in a window containing `S_ResourceAssignment_ID` (e.g., resource-related windows).
+
+---
+
+### 3.2 Tree Reference (ID: 8C57A4A2E05F4261A1FADF47C30398AD) — New TreeSelector
+
+**Problem**: 1 column (`M_Ch_Value_ID` — Characteristic Value) uses Tree Reference. In Classic, this renders as a selector with hierarchical tree navigation (parent-child nodes).
+
+**Prerequisites to verify manually**:
+1. Check the tree datasource response: call the tree datasource endpoint (ID `90034CAE96E847D78FBEF6D38CB1930D` defined in metadata constants) and examine the response structure
+2. Confirm: what fields come per node? (expected: `id`, `name`/`_identifier`, `parentId`)
+3. Confirm: can any level be selected, or only leaf nodes?
+4. Confirm: how many nodes typically exist? (determines if client-side tree building is viable)
+
+**Solution**: New `TreeSelector` component with modal containing an expandable tree.
+
+**Changes**:
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `TREE_REFERENCE: { id: "8C57A4A2E05F4261A1FADF47C30398AD", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE }` |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeSelector.tsx` | **New** — Field display + button to open modal |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/TreeModal.tsx` | **New** — Modal with expandable/collapsible tree |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector/index.ts` | **New** — barrel export |
+| `packages/MainUI/hooks/useTreeData.ts` | **New** — Fetches tree datasource, builds hierarchical structure from flat list using `parentId` |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add case → `TreeSelector` |
+| `packages/MainUI/utils/index.ts` | Add case returning `FieldType.SELECT` |
+
+**TreeSelector behavior**:
+- **Read-only**: Plain text label showing selected node's identifier
+- **Edit mode**: Text display + search icon button (same visual pattern as AttributeSetInstanceSelector)
+- Click opens `TreeModal`
+
+**TreeModal behavior**:
+- Loads all nodes on open via `useTreeData`
+- Builds tree structure client-side (flat list → nested, using `parentId`)
+- Each node: indented by level, chevron icon for expand/collapse, click to select
+- Selected node highlighted with blue background
+- OK/Cancel buttons at bottom
+- Optional: search/filter input at top to filter nodes by name
+
+**useTreeData hook**:
+
+```typescript
+interface TreeNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  children: TreeNode[];
+}
+
+interface UseTreeDataResult {
+  tree: TreeNode[];        // root nodes with nested children
+  loading: boolean;
+  error: string | null;
+}
+
+function useTreeData(datasourceId: string | null): UseTreeDataResult;
+```
+
+**Styling**: Pure Tailwind, no tree library dependency. The dataset is small (Characteristic Values are typically < 100 nodes).
+
+**Validation**: Open a window with `M_Ch_Value_ID` field and test tree navigation.
+
+---
+
+### Phase 3 Commit Plan
+
+| # | Commit message | Scope |
+|---|---------------|-------|
+| 9 | `Feature ETP-3931: Add Assignment reference type support` | 3.1 |
+| 10 | `Feature ETP-3931: Add TreeSelector for tree reference fields` | 3.2 |
+
+---
+
+## Summary
+
+| Phase | Items | New Files | New Dependencies |
+|-------|-------|-----------|-----------------|
+| 1 — Fixes | 5 fixes to existing types | 1 (useFileUpload hook) | 0 |
+| 2 — Frequent types | 3 new reference types | 1 (LinkSelector) | 0 |
+| 3 — Isolated types | 2 new reference types | 3-5 (TreeSelector + hook, possibly AssignmentSelector) | 0 |
+
+**Total new dependencies**: 0
+
+**Reference types NOT implemented (confirmed unused in core columns)**:
+- Color (ID: 27) — 0 columns
+- Window Reference (FF808181...) — 0 columns (UI framework config only)
+- DateTime_From / DateTime_To — 0 columns
+- Search Vector — 0 columns
+- Non-Transactional Sequence — 0 columns
+- Masked String — does not exist as reference type
+- OBKMO_Widget in Form — does not exist as reference type
+
+**Previously confirmed as already working**:
+- `isUpdateable='N'` — handled in BaseSelector.tsx:266 and Table/index.tsx:473-499
+- Hardcoded buttons (DocAction, Posted, CreateFrom, etc.) — fully resolved via metadata-driven process definitions
+- Color (ID: 27) — no columns use it; ColorCell is for FK color display only

--- a/docs/superpowers/specs/2026-05-28-sr-tab-autoopen-fix.md
+++ b/docs/superpowers/specs/2026-05-28-sr-tab-autoopen-fix.md
@@ -1,0 +1,128 @@
+# SR Tab Auto-Open Regression — Investigation & Fix Context
+
+## The Bug
+
+SR (Single Record) tabs like **Customer** and **Vendor/Creditor** in the **Business Partner** window should auto-open in form view when a parent record is selected. Instead, they show an empty grid.
+
+## What SR Tabs Are
+
+SR tabs have `uIPattern: "SR"` (mapped to `UIPattern.EDIT_ONLY`) and `defaultEditMode: true`. They represent a 1:1 relationship where the child record shares the same entity and ID as the parent. Examples:
+- Business Partner > **Customer** tab (tab 223) — same entity `BusinessPartner`, same record ID
+- Business Partner > **Vendor/Creditor** tab — same entity, same record ID
+- Client > **Client Information** tab — `AD_ClientInfo`, PK = FK to parent
+
+In Classic, these tabs **never show a grid**. They go directly to form view displaying the parent's record.
+
+## Root Causes Found (Two Separate Issues)
+
+### Issue 1: Wrong datasource criteria for SR tabs
+
+**File:** `packages/MainUI/utils/criteriaUtils.ts` and `packages/MainUI/hooks/table/useTableData.tsx`
+
+The datasource query for Customer/Vendor tabs sends the WRONG filter:
+```
+criteria: { fieldName: "salesRepresentative", value: "<parentId>", operator: "equals" }
+```
+
+Should send (like Classic):
+```
+criteria: { fieldName: "id", value: "<parentId>", operator: "equals" }
+```
+
+**Why:** `getParentFieldName()` in `useTableData.tsx:417-425` only detects SR tabs when `parentColumns` is empty. But Customer/Vendor tabs have non-empty `parentColumns`, so they fall through to `resolveParentFieldName()` which picks the wrong field.
+
+**Fix needed:** Move the SR check (`tab.uIPattern === UIPattern.EDIT_ONLY && parentTab`) BEFORE the `parentColumns.length === 0` check, so SR tabs always use `fieldName: "id"`.
+
+Additionally, `buildBaseCriteria()` in `criteriaUtils.ts:111` converts `fieldName: "id"` to `_dummy` (to avoid filtering child table by its own PK). But for SR tabs, `id = parentId` IS correct because they share the same entity. Add an SR exception before that guard.
+
+### Issue 2: Reset effect clears form state on initial mount
+
+**File:** `packages/MainUI/components/window/Tab.tsx:195-211`
+
+Commit `90433c133` ("Reset child tab when parent record changes") added a `useEffect` that clears child tab state when the parent changes. But the condition `prev === undefined && parentSelectedRecordId === undefined` doesn't skip the initial mount when `parentSelectedRecordId` already has a value. On first mount with a selected parent, `prev=undefined` and `parentSelectedRecordId=<value>`, so the effect fires and clears everything — including the form state that the auto-open just set.
+
+**Fix needed:** Change the initial-mount guard from:
+```typescript
+if (prev === undefined && parentSelectedRecordId === undefined) return;
+```
+To:
+```typescript
+if (prev === undefined) return;
+```
+
+This skips the effect entirely on mount (prev is always undefined on first render), only reacting to actual parent changes afterward.
+
+## Architecture Insight: The Right Approach for SR Tabs
+
+The current approach tries to: load grid → wait for records → auto-open form. This is fragile because of timing issues between the reset effect, datasource loading, and auto-open effects.
+
+**The better approach** (what Classic does): SR tabs should show form view as their DEFAULT, not as an auto-open afterthought. This means:
+
+1. `shouldShowForm` should be `true` by default for SR tabs when parent has selection
+2. `currentRecordId` should fall back to `parentSelectedRecordId` for SR tabs (since they share the same entity/record)
+3. The reset effect should skip SR tabs — their `effectiveRecordId` updates naturally when parent changes
+
+Specifically:
+```typescript
+// After parentSelectedRecordId is defined (~line 192):
+const isSrTab = tab.uIPattern === UIPattern.EDIT_ONLY && tab.defaultEditMode;
+const effectiveRecordId = isSrTab && parentSelectedRecordId
+  ? (currentRecordId || parentSelectedRecordId)
+  : currentRecordId;
+
+const isSrDefaultForm = isSrTab && parentHasSelection;
+const shouldShowForm =
+  isSrDefaultForm || hasFormViewState || isFormView({...});
+
+// In the reset effect: skip for SR tabs
+if (isSrTab) return;
+
+// FormView receives effectiveRecordId instead of currentRecordId
+<FormView recordId={effectiveRecordId} ... />
+```
+
+**IMPORTANT:** The `isSrTab` / `isSrDefaultForm` variables and `effectiveRecordId` must be defined AFTER `parentSelectedRecordId` (line 192) to avoid "used before initialization" errors.
+
+## What We Tried and Why It Failed
+
+1. **Just fixing the initial mount guard** — Fixed mount but auto-open still didn't work because the datasource returned 0 records (Issue 1)
+2. **Fixing datasource criteria** — Records loaded, auto-open worked first time, but `srAutoOpenedForParentRef` in Table/index.tsx wasn't reset on parent change → subsequent parent changes didn't auto-open
+3. **Adding ref reset in Table/index.tsx** — Helped but race conditions between reset effect and auto-open persisted
+4. **Making shouldShowForm default to true for SR tabs** — Worked! But `currentRecordId` was empty (no form state) → FormView had no record to load. Fixed by adding `effectiveRecordId` fallback to parentId
+5. **Adding srFormDismissed state for "user closes form"** — Didn't work because `clearTabFormState` from the reset effect looked the same as user closing form
+6. **Skipping reset effect for SR tabs** — Broke non-SR child tab behavior because the condition was too broad
+
+The fundamental issue: each fix solved one symptom but revealed another interaction. The correct fix needs to address BOTH issues atomically:
+- Fix the datasource criteria (Issue 1) so records load
+- Fix the shouldShowForm default (architecture fix) so the form shows immediately
+- Skip the reset effect for SR tabs so it doesn't interfere
+- Keep the reset effect working for non-SR child tabs
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/hooks/table/useTableData.tsx:417-425` | Move SR check before parentColumns check |
+| `packages/MainUI/utils/criteriaUtils.ts:94-119` | Add SR exception before the `fieldName === "id"` → `_dummy` guard |
+| `packages/MainUI/components/window/Tab.tsx:187-215` | Add `effectiveRecordId`, `isSrDefaultForm`, skip reset for SR, pass `effectiveRecordId` to FormView |
+
+## How to Verify
+
+1. Open Business Partner window
+2. Select a BP → Customer tab should show form view immediately with correct data
+3. Select another BP → Customer tab should update to new BP's data without flash
+4. Repeat for Vendor/Creditor tab
+5. Open Sales Order → Lines tab should still work normally (non-SR child tab)
+6. Open Client > Client Information (SR 1:1 extension tab) — should also work
+
+## Original Implementation Reference
+
+The SR feature was originally implemented in `feature/ETP-3350`:
+- Commit `db1c6f84f` — Initial SR visualization
+- Commit `63ba9b156` — Added `defaultEditMode` check and `srAutoOpenedForParentRef`
+- Commit `2c434e246` (ETP-3740) — Split into 1:1 extension (Tab.tsx) vs logical SR (Table/index.tsx)
+- Commit `90433c133` (ETP-3931) — Added reset effect that introduced the regression
+
+## Current State of Files (after revert)
+
+All four files are at their HEAD state (no uncommitted changes). The fixes need to be applied fresh.

--- a/docs/superpowers/specs/2026-06-01-tree-selector-and-assignment-design.md
+++ b/docs/superpowers/specs/2026-06-01-tree-selector-and-assignment-design.md
@@ -1,0 +1,165 @@
+# Tree Selector & Assignment Reference — Design Spec
+
+**Date:** 2026-06-01
+**Branch:** feature/ETP-3754
+**Status:** Approved
+
+## Summary
+
+Implement two missing field reference types from Etendo Classic:
+
+1. **Assignment (ref 33)** — Map to existing `TableDirSelector` (it uses `TableDirDomainType` in Classic)
+2. **Tree Reference (ref 8C57A4A2E05F4261A1FADF47C30398AD)** — New `TreeSelector` component with hierarchical dropdown display
+
+## Context
+
+These are the last unmapped reference types. Both currently fall through to the `default` case in `GenericSelector.tsx` and render as a plain `StringSelector`.
+
+- **Assignment** is used for `S_ResourceAssignment_ID` columns in Resource Booking / Manufacturing windows. In Classic, the WAD implementation (`WADAssignment`) is essentially empty — it behaves as a standard TableDir combo box.
+- **Tree Reference** is used for hierarchical FK lookups, primarily `M_Ch_Value_ID` (Characteristic Value) in the Product window. In Classic, it renders as `OBTreeItem` — a text input with a tree picker popup showing parent-child hierarchy.
+
+## Design
+
+### 1. Assignment (ref 33) → TableDirSelector
+
+Simple mapping with no new components:
+
+- Add `ASSIGNMENT: { id: "33", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE }` to `FIELD_REFERENCE_CODES`
+- Add a `case` in `GenericSelector.tsx` routing to `TableDirSelector`
+- Include a comment explaining this is a TableDir in Classic (`TableDirDomainType`)
+
+### 2. Tree Reference → TreeSelector
+
+#### Datasource Response Format
+
+The backend returns a **flat array** with `parentId` references for hierarchy:
+
+```json
+{
+  "response": {
+    "data": [
+      {
+        "id": "2081F4D68CAF40BDBEC1FE2E27296E8A",
+        "_identifier": "Cola",
+        "showOpenIcon": true,
+        "isCharacteristic": true
+      },
+      {
+        "id": "42FDB301BBB2486A97392E1EDDE48159",
+        "_identifier": "Uva",
+        "parentId": "2081F4D68CAF40BDBEC1FE2E27296E8A",
+        "characteristic": "2081F4D68CAF40BDBEC1FE2E27296E8A",
+        "characteristic$_identifier": "Cola"
+      },
+      {
+        "id": "82EACD21982F43BFB27953FA4BE2F7C8",
+        "_identifier": "Manzana",
+        "parentId": "2081F4D68CAF40BDBEC1FE2E27296E8A",
+        "characteristic": "2081F4D68CAF40BDBEC1FE2E27296E8A",
+        "characteristic$_identifier": "Cola"
+      }
+    ]
+  }
+}
+```
+
+Root detection is **generic**: a record is a root when `!record.parentId` (undefined/null/empty). The `isCharacteristic` flag is domain-specific and only controls whether a node is selectable — it is NOT used for hierarchy construction.
+
+Child nodes: `parentId` points to parent record.
+
+#### Data Flow
+
+1. `useTableDirDatasource` fetches flat records (same API pattern as TableDir/Select)
+2. `useSelectFieldOptions` transforms records into standard `SelectOption[]` (preserving current-value fallback, injected `$_entries`, custom `valueField`/`displayField`, and color fields)
+3. `buildFlatTreeList()` utility augments the options' underlying record data with `depth` and `hasChildren`
+4. `TreeSelector` renders a custom dropdown with indentation per depth level
+
+#### Tree Hierarchy Utility
+
+**New file:** `packages/MainUI/utils/form/treeUtils.ts`
+
+```typescript
+type TreeNode = {
+  id: string;
+  _identifier: string;
+  parentId?: string;
+  isCharacteristic?: boolean;
+  depth: number;
+  hasChildren: boolean;
+  [key: string]: unknown;
+};
+
+function buildFlatTreeList(records: EntityData[]): TreeNode[]
+```
+
+Builds a `Map<parentId, children[]>`, then walks depth-first to produce a flat array annotated with `depth` and `hasChildren`. No nested React recursion needed — the dropdown renders a flat list with padding.
+
+**Edge cases:**
+- **Orphan records** (parentId references a non-existent node): treated as root nodes (depth 0)
+- **Empty input**: returns empty array
+- **Single node**: returns array with one item at depth 0
+- **Circular references**: the DFS walk tracks visited nodes to prevent infinite loops
+- **N-level nesting**: fully supported — the utility is generic, not capped at 2 levels
+
+#### TreeSelector Component
+
+**New file:** `packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx`
+
+**Architecture decision:** TreeSelector implements its own lightweight dropdown rather than modifying the shared `Select` component. Rationale: `Select` is used across the entire app and has no extension point for custom option rendering (indentation, bold/disabled states, chevrons). Adding render props to `Select` risks regressions in all existing selectors. Tree dropdowns are simple (no infinite scroll — trees are small datasets) so the duplication cost is low.
+
+**Props:** `{ field: Field; isReadOnly: boolean }` (same shape as TableDirSelector)
+
+**Rendering:**
+- Custom dropdown with tree-indented options
+- Each option rendered with `paddingLeft: depth * 20px`
+- Root/parent nodes: bold text, non-selectable when `isCharacteristic: true`
+- Child/leaf nodes: normal text, indented, selectable
+- Expand/collapse chevrons on parent nodes to show/hide children
+- All nodes expanded by default on first open
+
+**Expand/collapse state:**
+- Component maintains a `Set<string>` of collapsed node IDs in React state
+- The flat list is filtered to exclude children of collapsed nodes before rendering
+- Collapse state resets when the dropdown closes
+
+**Search behavior:**
+- Typing filters matching nodes (case-insensitive substring on `_identifier`)
+- Ancestor nodes of matches are preserved to maintain hierarchy context
+- Example: searching "Uva" shows `Cola > Uva` with Cola as non-selectable context
+- No results: shows "No options" placeholder
+
+**Keyboard navigation:**
+- Arrow keys navigate the visible (non-collapsed) list, skipping non-selectable items
+- Enter selects the focused item
+- Escape closes the dropdown
+
+**Value handling:**
+- Selecting a node sets `fieldName` = node id, `fieldName$_identifier` = node `_identifier`
+- Same pattern as TableDirSelector value updates via `useFormContext`
+
+#### Tests
+
+**`packages/MainUI/utils/form/__tests__/treeUtils.test.ts`** — Unit tests for `buildFlatTreeList`:
+- Empty input
+- Flat input (all roots, no parents)
+- Single root with children
+- Multi-level nesting (3+ levels)
+- Orphan nodes (parentId not in data)
+- Circular parent references
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/MainUI/utils/form/constants.ts` | Add `ASSIGNMENT` and `TREE_REFERENCE` to `FIELD_REFERENCE_CODES` |
+| `packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx` | Add switch cases for `ASSIGNMENT` → TableDirSelector, `TREE_REFERENCE` → TreeSelector |
+| `packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx` | **New** — tree-aware selector component |
+| `packages/MainUI/utils/form/treeUtils.ts` | **New** — `buildFlatTreeList()` utility |
+| `packages/MainUI/utils/form/__tests__/treeUtils.test.ts` | **New** — unit tests for tree utility |
+
+## What's NOT in Scope
+
+- Grid cell editor for tree fields (falls back to text)
+- Column filter for tree fields (falls back to text)
+- Process modal tree parameter support
+- Deep nesting display optimization (utility supports N levels; practical usage is 1-2 levels deep)

--- a/packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx
@@ -185,7 +185,7 @@ const AttributeSetInstanceSelector: React.FC<AttributeSetInstanceSelectorProps> 
                 onClick={handleClear}
                 className="p-0.5 hover:text-gray-600 transition-colors"
                 data-testid={`clear-attr__${field.id}`}>
-                <X className="w-3.5 h-3.5 text-gray-400" />
+                <X className="w-3.5 h-3.5 text-gray-400" data-testid={"X__" + field.id} />
               </button>
             )}
             <SearchOutlined

--- a/packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/AttributeSetInstance/AttributeSetInstanceSelector.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import { useState, useCallback, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import SearchOutlined from "@workspaceui/componentlibrary/src/assets/icons/search.svg";
+import X from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
 import type { Field } from "@workspaceui/api-client/src/api/types";
 import AttributeSetInstanceModal from "./AttributeSetInstanceModal";
 import { useProductAttributeSet } from "@/hooks/useProductAttributeSet";
@@ -94,6 +95,18 @@ const AttributeSetInstanceSelector: React.FC<AttributeSetInstanceSelectorProps> 
     }
   }, [value, identifier]);
 
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setValue(fieldName, null, { shouldDirty: true, shouldTouch: true });
+      setValue(`${fieldName}$_identifier`, null, { shouldDirty: true });
+      setValue(`${fieldName}_data`, null, { shouldDirty: true });
+      setDisplayValue("");
+      setLastSavedInstanceId(null);
+    },
+    [fieldName, setValue]
+  );
+
   const handleOpenModal = useCallback(() => {
     if (isReadOnly) return;
     setIsModalOpen(true);
@@ -166,6 +179,15 @@ const AttributeSetInstanceSelector: React.FC<AttributeSetInstanceSelectorProps> 
               className={`text-sm truncate font-medium ${displayValue ? "text-(--color-transparent-neutral-80)" : "text-baseline-60"}`}>
               {displayValue || "Select attribute..."}
             </span>
+            {value && !isReadOnly && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="p-0.5 hover:text-gray-600 transition-colors"
+                data-testid={`clear-attr__${field.id}`}>
+                <X className="w-3.5 h-3.5 text-gray-400" />
+              </button>
+            )}
             <SearchOutlined
               fill="currentColor"
               className="w-4 h-4 flex-shrink-0 text-(--color-transparent-neutral-60)"

--- a/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/BaseSelector.tsx
@@ -526,9 +526,10 @@ const BaseSelectorComp = ({
 
   if (isDisplayed) {
     const isTextLong = field.column.reference === FIELD_REFERENCE_CODES.TEXT_LONG.id;
+    const isMemo = field.column.reference === FIELD_REFERENCE_CODES.MEMO.id;
     const isImage = field.column.reference === FIELD_REFERENCE_CODES.IMAGE.id;
     const isRichText = field.column.reference === FIELD_REFERENCE_CODES.RICH_TEXT.id;
-    const isExpandedField = isTextLong || isImage || isRichText;
+    const isExpandedField = isTextLong || isMemo || isImage || isRichText;
     const containerClasses = isExpandedField ? "row-span-3 flex items-start pt-2" : "h-12 flex items-center";
 
     return (

--- a/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
@@ -176,6 +176,7 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
             data-testid="AttributeSetInstanceSelector__6e80fa"
           />
         );
+      case FIELD_REFERENCE_CODES.MEMO.id:
       case FIELD_REFERENCE_CODES.TEXT_LONG.id:
         return <TextLongSelector field={effectiveField} readOnly={isReadOnly} data-testid="TextLongSelector__6e80fa" />;
       case FIELD_REFERENCE_CODES.IMAGE.id:
@@ -206,6 +207,10 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
         return (
           <ButtonSelector field={effectiveField} isReadOnly={isReadOnly} data-testid={`ButtonSelector__${field.id}`} />
         );
+      // Product Characteristics: always read-only — composed from Product Characteristics window, not editable inline.
+      // This hardcoded readOnly={true} intentionally overrides the isReadOnly prop from GenericSelector.
+      case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
+        return <StringSelector field={effectiveField} readOnly={true} data-testid={`StringSelector__prodchar__${field.id}`} />;
       default:
         return <StringSelector field={effectiveField} readOnly={isReadOnly} data-testid="StringSelector__6e80fa" />;
     }

--- a/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
@@ -49,6 +49,7 @@ import { UploadFileSelector } from "@/components/ProcessModal/selectors/UploadFi
 import { ButtonSelector } from "./ButtonSelector";
 import { LinkSelector } from "./LinkSelector";
 import { RichTextSelector } from "./RichTextSelector";
+import { TreeSelector } from "./TreeSelector";
 import { useProcessDefinitionTrigger } from "@/hooks/useProcessDefinitionTrigger";
 import ProcessDefinitionModal from "@/components/ProcessModal/ProcessDefinitionModal";
 import { PROCESS_TYPES } from "@/utils/processes/definition/constants";
@@ -110,6 +111,8 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
       case FIELD_REFERENCE_CODES.SELECTOR_AS_LINK.id: // Selector rendered as navigable link
       case FIELD_REFERENCE_CODES.TABLE_DIR_19.id:
       case FIELD_REFERENCE_CODES.TABLE_DIR_18.id:
+      // Assignment (ref 33): uses TableDirDomainType in Classic — resource assignment FK
+      case FIELD_REFERENCE_CODES.ASSIGNMENT.id:
         return (
           <TableDirSelector field={effectiveField} isReadOnly={isReadOnly} data-testid="TableDirSelector__6e80fa" />
         );
@@ -219,6 +222,9 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
             data-testid={`StringSelector__prodchar__${field.id}`}
           />
         );
+      // Tree Reference: hierarchical FK selector (e.g. Characteristic Values)
+      case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
+        return <TreeSelector field={effectiveField} isReadOnly={isReadOnly} />;
       default:
         return <StringSelector field={effectiveField} readOnly={isReadOnly} data-testid="StringSelector__6e80fa" />;
     }

--- a/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
@@ -212,7 +212,9 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
           <ButtonSelector field={effectiveField} isReadOnly={isReadOnly} data-testid={`ButtonSelector__${field.id}`} />
         );
       case FIELD_REFERENCE_CODES.LINK.id:
-        return <LinkSelector field={effectiveField} isReadOnly={isReadOnly} />;
+        return (
+          <LinkSelector field={effectiveField} isReadOnly={isReadOnly} data-testid={"LinkSelector__" + field.id} />
+        );
       // Product Characteristics: always read-only — composed from Product Characteristics window, not editable inline.
       case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
         return (
@@ -224,7 +226,9 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
         );
       // Tree Reference: hierarchical FK selector (e.g. Characteristic Values)
       case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
-        return <TreeSelector field={effectiveField} isReadOnly={isReadOnly} />;
+        return (
+          <TreeSelector field={effectiveField} isReadOnly={isReadOnly} data-testid={"TreeSelector__" + field.id} />
+        );
       default:
         return <StringSelector field={effectiveField} readOnly={isReadOnly} data-testid="StringSelector__6e80fa" />;
     }

--- a/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/GenericSelector.tsx
@@ -47,6 +47,7 @@ import AttributeSetInstanceSelector from "./AttributeSetInstance";
 import { ImageSelector } from "./ImageSelector";
 import { UploadFileSelector } from "@/components/ProcessModal/selectors/UploadFileSelector";
 import { ButtonSelector } from "./ButtonSelector";
+import { LinkSelector } from "./LinkSelector";
 import { RichTextSelector } from "./RichTextSelector";
 import { useProcessDefinitionTrigger } from "@/hooks/useProcessDefinitionTrigger";
 import ProcessDefinitionModal from "@/components/ProcessModal/ProcessDefinitionModal";
@@ -207,10 +208,17 @@ const GenericSelectorCmp = ({ field, isReadOnly }: GenericSelectorProps) => {
         return (
           <ButtonSelector field={effectiveField} isReadOnly={isReadOnly} data-testid={`ButtonSelector__${field.id}`} />
         );
+      case FIELD_REFERENCE_CODES.LINK.id:
+        return <LinkSelector field={effectiveField} isReadOnly={isReadOnly} />;
       // Product Characteristics: always read-only — composed from Product Characteristics window, not editable inline.
-      // This hardcoded readOnly={true} intentionally overrides the isReadOnly prop from GenericSelector.
       case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
-        return <StringSelector field={effectiveField} readOnly={true} data-testid={`StringSelector__prodchar__${field.id}`} />;
+        return (
+          <StringSelector
+            field={effectiveField}
+            readOnly={true}
+            data-testid={`StringSelector__prodchar__${field.id}`}
+          />
+        );
       default:
         return <StringSelector field={effectiveField} readOnly={isReadOnly} data-testid="StringSelector__6e80fa" />;
     }

--- a/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
@@ -50,12 +50,36 @@ export const LinkSelector = ({ field, isReadOnly }: LinkSelectorProps) => {
     setValue(fieldName, value, { shouldValidate: true });
   };
 
+  const handleOpenLink = () => {
+    if (currentValue) {
+      window.open(currentValue, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const linkButton = currentValue ? (
+    <button
+      type="button"
+      onClick={handleOpenLink}
+      className="absolute right-8 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-blue-600 transition-colors z-10"
+      title="Open link"
+      data-testid={`LinkSelector__open__${field.id}`}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <title>Open link</title>
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+        <polyline points="15 3 21 3 21 9" />
+        <line x1="10" y1="14" x2="21" y2="3" />
+      </svg>
+    </button>
+  ) : null;
+
   return (
     <TextInput
       {...register(fieldName)}
       field={field}
       setValue={handleSetValue}
       showClearButton={true}
+      endAdornment={linkButton}
       value={currentValue}
       placeholder="https://..."
       data-testid={`LinkSelector__${field.id}`}

--- a/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
@@ -62,9 +62,16 @@ export const LinkSelector = ({ field, isReadOnly }: LinkSelectorProps) => {
       onClick={handleOpenLink}
       className="absolute right-8 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-blue-600 transition-colors z-10"
       title="Open link"
-      data-testid={`LinkSelector__open__${field.id}`}
-    >
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      data-testid={`LinkSelector__open__${field.id}`}>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round">
         <title>Open link</title>
         <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
         <polyline points="15 3 21 3 21 9" />

--- a/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/LinkSelector.tsx
@@ -1,0 +1,64 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright (C) 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import { TextInput } from "./components/TextInput";
+import { useFormContext, type FieldValues } from "react-hook-form";
+
+interface LinkSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+
+export const LinkSelector = ({ field, isReadOnly }: LinkSelectorProps) => {
+  const { register, watch, setValue } = useFormContext<FieldValues>();
+  const fieldName = field.hqlName;
+  const currentValue = watch(fieldName) as string | undefined;
+
+  if (isReadOnly) {
+    if (!currentValue) {
+      return <span className="text-sm text-gray-400 h-10.5 flex items-center px-3">&mdash;</span>;
+    }
+
+    return (
+      <a
+        href={currentValue}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm text-blue-600 underline hover:text-blue-800 truncate block h-10.5 flex items-center px-3 max-w-full"
+        title={currentValue}>
+        {currentValue}
+      </a>
+    );
+  }
+
+  const handleSetValue = (value: string) => {
+    setValue(fieldName, value, { shouldValidate: true });
+  };
+
+  return (
+    <TextInput
+      {...register(fieldName)}
+      field={field}
+      setValue={handleSetValue}
+      showClearButton={true}
+      value={currentValue}
+      placeholder="https://..."
+      data-testid={`LinkSelector__${field.id}`}
+    />
+  );
+};

--- a/packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx
@@ -15,27 +15,72 @@
  *************************************************************************
  */
 
+import { useState } from "react";
 import type { Field } from "@workspaceui/api-client/src/api/types";
 import { TextInput } from "./components/TextInput";
 import { useFormContext, type FieldValues } from "react-hook-form";
+import { PASSWORD_PLACEHOLDER } from "@/utils/form/constants";
 
-export const PasswordSelector = (props: { field: Field } & React.ComponentProps<typeof TextInput>) => {
+const EyeIcon = ({ open }: { open: boolean }): React.ReactElement => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    role="img"
+    aria-label={open ? "Hide password" : "Show password"}>
+    <title>{open ? "Hide password" : "Show password"}</title>
+    {open ? (
+      <>
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+        <circle cx="12" cy="12" r="3" />
+      </>
+    ) : (
+      <>
+        <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+        <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+        <line x1="1" y1="1" x2="23" y2="23" />
+      </>
+    )}
+  </svg>
+);
+
+export const PasswordSelector = (
+  props: { field: Field } & React.ComponentProps<typeof TextInput>
+): React.ReactElement => {
   const { register, watch, setValue } = useFormContext<FieldValues>();
   const fieldName = props.field.hqlName;
-
   const currentValue = watch(fieldName);
-  const handleSetValue = (value: string) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleSetValue = (value: string): void => {
     setValue(fieldName, value, { shouldValidate: true });
   };
+
+  const isPlaceholder = currentValue === PASSWORD_PLACEHOLDER;
+
+  const eyeToggle =
+    !isPlaceholder && currentValue ? (
+      <button
+        type="button"
+        data-testid={`eye-toggle__${props.field.id}`}
+        onClick={() => setShowPassword((prev) => !prev)}
+        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 transition-colors z-10">
+        <EyeIcon open={showPassword} />
+      </button>
+    ) : null;
 
   return (
     <TextInput
       {...register(fieldName)}
       field={props.field}
       setValue={handleSetValue}
-      showClearButton={true}
+      showClearButton={false}
+      endAdornment={eyeToggle}
       value={currentValue}
-      type="password"
+      type={showPassword ? "text" : "password"}
       maxLength={Number(props.field.column.length)}
       autoComplete="new-password"
       data-testid="TextInput__1b1414"

--- a/packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/PasswordSelector.tsx
@@ -68,7 +68,7 @@ export const PasswordSelector = (
         data-testid={`eye-toggle__${props.field.id}`}
         onClick={() => setShowPassword((prev) => !prev)}
         className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 transition-colors z-10">
-        <EyeIcon open={showPassword} />
+        <EyeIcon open={showPassword} data-testid="EyeIcon__1b1414" />
       </button>
     ) : null;
 

--- a/packages/MainUI/components/Form/FormView/selectors/SelectorModal.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/SelectorModal.tsx
@@ -217,8 +217,22 @@ const SelectorModal = ({ field, isOpen, onClose, onSelect }: SelectorModalProps)
       showColumnFilters: true,
     },
     muiTablePaperProps: { sx: sx.tablePaper },
-    muiTableHeadCellProps: { sx: sx.tableHeadCell },
-    muiTableBodyCellProps: { sx: sx.tableBodyCell },
+    muiTableHeadCellProps: {
+      sx: {
+        ...sx.tableHeadCell,
+        fontSize: "0.75rem",
+        padding: "4px 8px",
+        lineHeight: 1.2,
+      },
+    },
+    muiTableBodyCellProps: {
+      sx: {
+        ...sx.tableBodyCell,
+        fontSize: "0.75rem",
+        padding: "2px 8px",
+        lineHeight: 1.2,
+      },
+    },
     muiTableBodyProps: { sx: sx.tableBody },
     muiTableContainerProps: {
       onScroll: (event: UIEvent<HTMLDivElement>) => fetchMoreOnBottomReached(event.currentTarget),
@@ -229,13 +243,29 @@ const SelectorModal = ({ field, isOpen, onClose, onSelect }: SelectorModalProps)
         onSelect(row.original);
         onClose();
       },
-      sx: { cursor: "pointer", ...sx.tableBodyRow },
+      sx: {
+        cursor: "pointer",
+        ...sx.tableBodyRow,
+        height: "28px",
+      },
     }),
+    muiFilterTextFieldProps: {
+      sx: {
+        "& .MuiInputBase-input": {
+          fontSize: "0.75rem",
+          padding: "4px 8px",
+        },
+      },
+    },
+    defaultColumn: {
+      minSize: 60,
+      size: 120,
+    },
     initialState: { density: "compact" },
   });
 
   return (
-    <Dialog open={isOpen} onClose={onClose} maxWidth="lg" fullWidth data-testid={`Dialog__${field.id}`}>
+    <Dialog open={isOpen} onClose={onClose} maxWidth="xl" fullWidth data-testid={`Dialog__${field.id}`}>
       <Box className="relative flex justify-center items-center p-4 border-b" data-testid={`Box__${field.id}`}>
         <Typography
           sx={{ fontSize: "1.125rem", fontWeight: 700, textTransform: "none", color: "text.primary" }}

--- a/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
@@ -1,0 +1,491 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+// @data-testid-ignore
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+import ChevronDown from "@workspaceui/componentlibrary/src/assets/icons/chevron-down.svg";
+import ChevronRight from "@workspaceui/componentlibrary/src/assets/icons/chevron-right.svg";
+import XIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import CheckIcon from "@workspaceui/componentlibrary/src/assets/icons/check-circle-filled.svg";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+import { useTableDirDatasource } from "@/hooks/datasource/useTableDirDatasource";
+import { useSelectFieldOptions } from "@/hooks/useSelectFieldOptions";
+import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+import { updateSelectorValue } from "@/utils/form/selectors/utils";
+import { useDropdownPosition } from "@/components/Form/FormView/selectors/hooks/useDropdownPosition";
+import DropdownPortal from "@/components/Form/FormView/selectors/components/Select/DropdownPortal";
+import {
+  handleKeyboardActivation,
+  useFocusHandler,
+  useHoverHandlers,
+  useOpenDropdownEffect,
+  useSearchHandler,
+  useSearchTermHandler,
+} from "@/utils/selectorUtils";
+import { useTranslation } from "@/hooks/useTranslation";
+
+interface TreeSelectorProps {
+  field: Field;
+  isReadOnly: boolean;
+}
+
+const isNodeSelectable = (node: TreeNode): boolean => !node.isCharacteristic;
+
+function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
+  const { t } = useTranslation();
+  const { register, setValue, watch } = useFormContext();
+  const fieldName = field.hqlName || field.columnName || field.name;
+  const selectedValue = watch(fieldName);
+  const currentIdentifier = watch(`${fieldName}$_identifier`);
+
+  // --- Data fetching (same pattern as TableDirSelector) ---
+  const { records, loading, refetch } = useTableDirDatasource({ field });
+  const options = useSelectFieldOptions(field, records);
+
+  // --- Build tree from flat options ---
+  const treeNodes = useMemo(() => {
+    const recordData = options
+      .filter((opt) => opt.data && Object.keys(opt.data).length > 0)
+      .map((opt) => opt.data ?? {});
+    return buildFlatTreeList(recordData);
+  }, [options]);
+
+  // Lookup map for O(1) parent resolution in filters
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, TreeNode>();
+    for (const node of treeNodes) {
+      map.set(node.id as string, node);
+    }
+    return map;
+  }, [treeNodes]);
+
+  // --- UI state ---
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [isHovering, setIsHovering] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const [selectedLabel, setSelectedLabel] = useState("");
+
+  const listRef = useRef<HTMLUListElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
+  const dropdownId = useMemo(() => `tree-dropdown-${fieldName}`, [fieldName]);
+
+  const handleSearchChange = useSearchHandler();
+
+  // --- Visible nodes: search filter + collapse filter ---
+  const visibleNodes = useMemo(() => {
+    let filtered = treeNodes;
+
+    if (searchTerm) {
+      // Search: keep matches + their ancestor chain for context
+      const lowerSearch = searchTerm.toLowerCase();
+      const matchIds = new Set(
+        treeNodes
+          .filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch))
+          .map((n) => n.id as string)
+      );
+      const keepIds = new Set(matchIds);
+      for (const node of treeNodes) {
+        if (matchIds.has(node.id as string)) {
+          let current: TreeNode | undefined = node;
+          while (current?.parentId && typeof current.parentId === "string") {
+            keepIds.add(current.parentId);
+            current = nodeMap.get(current.parentId);
+          }
+        }
+      }
+      filtered = filtered.filter((n) => keepIds.has(n.id as string));
+    } else {
+      // No search: apply collapse filter — hide children of collapsed parents
+      filtered = filtered.filter((node) => {
+        let parentId = node.parentId as string | undefined;
+        while (parentId) {
+          if (collapsedNodes.has(parentId)) return false;
+          const parent = nodeMap.get(parentId);
+          parentId = parent?.parentId as string | undefined;
+        }
+        return true;
+      });
+    }
+
+    return filtered;
+  }, [treeNodes, searchTerm, collapsedNodes, nodeMap]);
+
+  // --- Selectable nodes only (for keyboard nav index) ---
+  const selectableIndices = useMemo(() => {
+    const indices: number[] = [];
+    for (let i = 0; i < visibleNodes.length; i++) {
+      if (isNodeSelectable(visibleNodes[i])) {
+        indices.push(i);
+      }
+    }
+    return indices;
+  }, [visibleNodes]);
+
+  // --- Toggle collapse ---
+  const toggleCollapse = useCallback((nodeId: string) => {
+    setCollapsedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) {
+        next.delete(nodeId);
+      } else {
+        next.add(nodeId);
+      }
+      return next;
+    });
+  }, []);
+
+  // --- Selection ---
+  const handleSelect = useCallback(
+    (node: TreeNode) => {
+      if (!isNodeSelectable(node)) return;
+      const nodeId = node.id as string;
+      updateSelectorValue(setValue, fieldName, nodeId, node);
+      setSelectedLabel(node._identifier as string);
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+      setIsFocused(false);
+    },
+    [fieldName, setValue]
+  );
+
+  // --- Keyboard navigation (skips non-selectable nodes) ---
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const currentPos = selectableIndices.indexOf(prev);
+          const nextPos = currentPos < 0 ? 0 : (currentPos + 1) % selectableIndices.length;
+          return selectableIndices[nextPos];
+        });
+        return;
+      }
+
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const currentPos = selectableIndices.indexOf(prev);
+          const nextPos = currentPos <= 0 ? selectableIndices.length - 1 : currentPos - 1;
+          return selectableIndices[nextPos];
+        });
+        return;
+      }
+
+      if (e.key === "Enter" && highlightedIndex >= 0) {
+        e.preventDefault();
+        const node = visibleNodes[highlightedIndex];
+        if (node) {
+          if (isNodeSelectable(node)) {
+            handleSelect(node);
+          } else if (node.hasChildren) {
+            toggleCollapse(node.id as string);
+          }
+        }
+      }
+    },
+    [visibleNodes, highlightedIndex, selectableIndices, handleSelect, toggleCollapse]
+  );
+
+  // --- Dropdown open/close ---
+  const closeDropdown = useCallback(() => {
+    setIsOpen(false);
+    setHighlightedIndex(-1);
+    setIsFocused(false);
+    setCollapsedNodes(new Set()); // reset collapse state
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (!isReadOnly) {
+        setIsOpen((prev) => !prev);
+        setIsFocused(true);
+      }
+    },
+    [isReadOnly]
+  );
+
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setValue(`${fieldName}$_identifier`, "", { shouldDirty: false });
+      setValue(`${fieldName}_data`, null);
+      setValue(fieldName, "", { shouldDirty: true, shouldValidate: true });
+      setSelectedLabel("");
+    },
+    [fieldName, setValue]
+  );
+
+  // --- Blur / click-outside ---
+  const handleBlur = useCallback(
+    (e: React.FocusEvent) => {
+      const relatedTarget = e.relatedTarget as Element | null;
+      if (relatedTarget?.closest(`[data-dropdown-portal="${dropdownId}"]`)) return;
+      setTimeout(() => {
+        const activeElement = document.activeElement;
+        const isInPortal = activeElement?.closest(`[data-dropdown-portal="${dropdownId}"]`);
+        const isInWrapper = wrapperRef.current?.contains(activeElement);
+        if (!isInPortal && !isInWrapper) closeDropdown();
+      }, 150);
+    },
+    [closeDropdown, dropdownId]
+  );
+
+  const handleSearchBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const relatedTarget = e.relatedTarget as Element | null;
+      if (wrapperRef.current?.contains(relatedTarget)) return;
+      setTimeout(() => {
+        const activeElement = document.activeElement;
+        const isInPortal = activeElement?.closest(`[data-dropdown-portal="${dropdownId}"]`);
+        const isInWrapper = wrapperRef.current?.contains(activeElement);
+        if (!isInPortal && !isInWrapper) closeDropdown();
+      }, 150);
+    },
+    [closeDropdown, dropdownId]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element;
+      const isInWrapper = wrapperRef.current?.contains(target);
+      const isInPortal = target.closest(`[data-dropdown-portal="${dropdownId}"]`);
+      if (!isInWrapper && !isInPortal) closeDropdown();
+    };
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+    }, 100);
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, closeDropdown, dropdownId]);
+
+  // --- Shared hooks ---
+  const { handleMouseEnter, handleMouseLeave } = useHoverHandlers(setIsHovering);
+  const handleFocus = useFocusHandler(refetch);
+  const handleSetSearchTerm = useSearchTermHandler(handleSearchChange, setSearchTerm);
+  const handleScroll = useCallback(() => {}, []); // no infinite scroll for tree data
+  const dropdownViewportData = useDropdownPosition(isOpen, triggerRef as React.RefObject<HTMLDivElement>);
+
+  useOpenDropdownEffect(
+    isOpen,
+    setSearchTerm,
+    setHighlightedIndex,
+    searchInputRef as React.RefObject<HTMLInputElement>
+  );
+
+  // --- Sync selected label from form state ---
+  useEffect(() => {
+    const node = treeNodes.find((n) => (n.id as string) === selectedValue);
+    setSelectedLabel(node ? (node._identifier as string) : currentIdentifier || selectedValue || "");
+  }, [selectedValue, treeNodes, currentIdentifier]);
+
+  // --- Scroll highlighted into view ---
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
+
+  // --- Trigger styles (same as Select.tsx) ---
+  const mainDivClassNames = useMemo(() => {
+    const base =
+      "w-full flex items-center justify-between px-3 pr-3 rounded-t tracking-normal h-10.5 border-0 border-b-2 transition-colors outline-none";
+    if (isReadOnly) {
+      return `${base} bg-transparent rounded-t-lg cursor-not-allowed border-b-2 border-dotted border-(--color-transparent-neutral-40) hover:border-dotted hover:border-(--color-transparent-neutral-70) hover:bg-transparent focus:border-dotted focus:border-(--color-transparent-neutral-70) focus:bg-transparent focus:text-(--color-transparent-neutral-80)`;
+    }
+    const active = "border-[#004ACA] text-[#004ACA] bg-[#E5EFFF]";
+    const hover = "hover:border-(--color-transparent-neutral-100) hover:bg-(--color-transparent-neutral-10)";
+    const focus = "focus:border-[#004ACA] focus:text-[#004ACA] focus:bg-[#E5EFFF] focus:outline-none cursor-pointer";
+    const interactive = isFocused || isOpen ? active : hover;
+    return `${base} bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30) text-(--color-transparent-neutral-80) font-medium text-sm leading-5 ${interactive} ${focus}`;
+  }, [isReadOnly, isFocused, isOpen]);
+
+  const labelClassNames = useMemo(() => {
+    const base = "text-sm truncate max-w-[calc(100%-40px)] font-medium";
+    if (!selectedLabel) return `${base} text-baseline-60`;
+    const isActive = (isFocused || isOpen) && !isReadOnly;
+    return `${base} ${isActive ? "text-[#004ACA]" : "text-(--color-transparent-neutral-80)"}`;
+  }, [selectedLabel, isFocused, isOpen, isReadOnly]);
+
+  const chevronClassNames = useMemo(() => {
+    const base = "w-5 h-5 transition-transform";
+    const isActive = isFocused || isOpen;
+    return `${base} ${isActive ? "text-(--color-baseline-100) rotate-180" : "text-(--color-transparent-neutral-60)"}`;
+  }, [isFocused, isOpen]);
+
+  const shouldShowClearButton = selectedLabel && (isHovering || isOpen) && !isReadOnly;
+
+  // --- Rendered tree options ---
+  const renderedOptions = useMemo(() => {
+    if (loading && visibleNodes.length === 0) {
+      return <li className="px-4 py-3 text-sm text-baseline-60">Loading...</li>;
+    }
+    if (visibleNodes.length === 0) {
+      return <li className="px-4 py-3 text-sm text-baseline-60">No options found</li>;
+    }
+
+    return visibleNodes.map((node, index) => {
+      const nodeId = node.id as string;
+      const identifier = node._identifier as string;
+      const selectable = isNodeSelectable(node);
+      const isSelected = selectedValue === nodeId;
+      const isHighlighted = highlightedIndex === index;
+      const isCollapsed = collapsedNodes.has(nodeId);
+
+      return (
+        <li
+          key={nodeId}
+          aria-selected={isSelected}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (selectable) {
+              handleSelect(node);
+            } else if (node.hasChildren) {
+              toggleCollapse(nodeId);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.stopPropagation();
+              if (selectable) {
+                handleSelect(node);
+              } else if (node.hasChildren) {
+                toggleCollapse(nodeId);
+              }
+            }
+          }}
+          onMouseEnter={() => {
+            if (selectable) setHighlightedIndex(index);
+          }}
+          className={`py-2.5 text-sm flex items-center justify-between focus:outline-none
+            ${selectable ? "cursor-pointer hover:bg-baseline-10" : "cursor-default"}
+            ${isHighlighted && selectable ? "bg-baseline-10" : ""}
+            ${isSelected ? "bg-baseline-10" : ""}`}
+          style={{ paddingLeft: `${16 + node.depth * 20}px`, paddingRight: "16px" }}>
+          <span className="flex items-center gap-1.5 truncate mr-2">
+            {node.hasChildren && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleCollapse(nodeId);
+                }}
+                className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-baseline-60 hover:text-baseline-90">
+                <ChevronRight
+                  className={`w-3 h-3 transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+                  fill="currentColor"
+                />
+              </button>
+            )}
+            {!node.hasChildren && <span className="w-4 flex-shrink-0" />}
+            <span
+              className={`truncate ${
+                selectable
+                  ? isSelected
+                    ? "text-dynamic-dark font-medium"
+                    : "text-baseline-90"
+                  : "font-semibold text-baseline-60"
+              }`}>
+              {identifier}
+            </span>
+          </span>
+          {isSelected && <CheckIcon className="fade-in-left flex-shrink-0" height={16} width={16} />}
+        </li>
+      );
+    });
+  }, [visibleNodes, highlightedIndex, selectedValue, collapsedNodes, handleSelect, toggleCollapse, loading]);
+
+  return (
+    <>
+      <div
+        ref={wrapperRef}
+        className={`relative w-full font-['Inter'] ${isReadOnly ? "pointer-events-none" : ""}`}
+        onBlur={handleBlur}
+        aria-label={field.name}
+        aria-readonly={isReadOnly}
+        aria-required={field.isMandatory}
+        aria-disabled={isReadOnly}
+        aria-details={field.helpComment}
+        tabIndex={-1}>
+        <input {...register(fieldName)} type="hidden" readOnly={isReadOnly} />
+        <div
+          ref={triggerRef}
+          onClick={handleClick}
+          onKeyDown={(e) => handleKeyboardActivation(e, () => handleClick(e as unknown as React.MouseEvent))}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          onFocus={handleFocus}
+          tabIndex={isReadOnly ? -1 : 0}
+          className={mainDivClassNames}>
+          <span className={labelClassNames}>{selectedLabel || (!isReadOnly ? t("form.select.placeholder") : "")}</span>
+          <div className="flex items-center flex-shrink-0 ml-2">
+            {shouldShowClearButton && (
+              <button
+                type="button"
+                onClick={handleClear}
+                onKeyDown={(e) => handleKeyboardActivation(e, () => handleClear(e as unknown as React.MouseEvent))}
+                className={`mr-1 hover:text-gray-600 transition-opacity opacity-100 focus:outline-none focus:ring-2 focus:ring-dynamic-light rounded ${
+                  isFocused || isOpen ? "text-(--color-baseline-100)" : "text-(--color-transparent-neutral-60)"
+                }`}
+                aria-label="Clear selection">
+                <XIcon />
+              </button>
+            )}
+            {!isReadOnly && <ChevronDown fill="currentColor" className={chevronClassNames} />}
+          </div>
+        </div>
+      </div>
+      {!isReadOnly && (
+        <DropdownPortal
+          isOpen={isOpen}
+          viewportData={dropdownViewportData}
+          searchTerm={searchTerm}
+          searchInputRef={searchInputRef as React.RefObject<HTMLInputElement>}
+          handleSetSearchTerm={handleSetSearchTerm}
+          handleKeyDown={handleKeyDown}
+          handleSearchBlur={handleSearchBlur}
+          handleFocus={handleFocus}
+          listRef={listRef as React.RefObject<HTMLUListElement>}
+          handleScroll={handleScroll}
+          renderedOptions={renderedOptions}
+          dropdownId={dropdownId}
+        />
+      )}
+    </>
+  );
+}
+
+export const TreeSelector = memo(TreeSelectorCmp);
+export default TreeSelector;

--- a/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
@@ -25,7 +25,13 @@ import CheckIcon from "@workspaceui/componentlibrary/src/assets/icons/check-circ
 import type { Field } from "@workspaceui/api-client/src/api/types";
 import { useTableDirDatasource } from "@/hooks/datasource/useTableDirDatasource";
 import { useSelectFieldOptions } from "@/hooks/useSelectFieldOptions";
-import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+import {
+  buildFlatTreeList,
+  buildNodeMap,
+  filterVisibleNodes,
+  getNodeTextClass,
+  type TreeNode,
+} from "@/utils/form/treeUtils";
 import { updateSelectorValue } from "@/utils/form/selectors/utils";
 import { useDropdownPosition } from "@/components/Form/FormView/selectors/hooks/useDropdownPosition";
 import DropdownPortal from "@/components/Form/FormView/selectors/components/Select/DropdownPortal";
@@ -46,11 +52,6 @@ interface TreeSelectorProps {
 
 const isNodeSelectable = (node: TreeNode): boolean => !node.isCharacteristic;
 
-const getNodeTextClass = (selectable: boolean, isSelected: boolean): string => {
-  if (!selectable) return "font-semibold text-baseline-60";
-  return isSelected ? "text-dynamic-dark font-medium" : "text-baseline-90";
-};
-
 function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
   const { t } = useTranslation();
   const { register, setValue, watch } = useFormContext();
@@ -70,14 +71,7 @@ function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
     return buildFlatTreeList(recordData);
   }, [options]);
 
-  // Lookup map for O(1) parent resolution in filters
-  const nodeMap = useMemo(() => {
-    const map = new Map<string, TreeNode>();
-    for (const node of treeNodes) {
-      map.set(node.id as string, node);
-    }
-    return map;
-  }, [treeNodes]);
+  const nodeMap = useMemo(() => buildNodeMap(treeNodes), [treeNodes]);
 
   // --- UI state ---
   const [isOpen, setIsOpen] = useState(false);
@@ -96,44 +90,10 @@ function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
 
   const handleSearchChange = useSearchHandler();
 
-  // --- Visible nodes: search filter + collapse filter ---
-  const visibleNodes = useMemo(() => {
-    let filtered = treeNodes;
-
-    if (searchTerm) {
-      // Search: keep matches + their ancestor chain for context
-      const lowerSearch = searchTerm.toLowerCase();
-      const matchIds = new Set(
-        treeNodes
-          .filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch))
-          .map((n) => n.id as string)
-      );
-      const keepIds = new Set(matchIds);
-      for (const node of treeNodes) {
-        if (matchIds.has(node.id as string)) {
-          let current: TreeNode | undefined = node;
-          while (current?.parentId && typeof current.parentId === "string") {
-            keepIds.add(current.parentId);
-            current = nodeMap.get(current.parentId);
-          }
-        }
-      }
-      filtered = filtered.filter((n) => keepIds.has(n.id as string));
-    } else {
-      // No search: apply collapse filter — hide children of collapsed parents
-      filtered = filtered.filter((node) => {
-        let parentId = node.parentId as string | undefined;
-        while (parentId) {
-          if (collapsedNodes.has(parentId)) return false;
-          const parent = nodeMap.get(parentId);
-          parentId = parent?.parentId as string | undefined;
-        }
-        return true;
-      });
-    }
-
-    return filtered;
-  }, [treeNodes, searchTerm, collapsedNodes, nodeMap]);
+  const visibleNodes = useMemo(
+    () => filterVisibleNodes(treeNodes, nodeMap, searchTerm, collapsedNodes),
+    [treeNodes, nodeMap, searchTerm, collapsedNodes]
+  );
 
   // --- Selectable nodes only (for keyboard nav index) ---
   const selectableIndices = useMemo(() => {

--- a/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/TreeSelector.tsx
@@ -46,6 +46,11 @@ interface TreeSelectorProps {
 
 const isNodeSelectable = (node: TreeNode): boolean => !node.isCharacteristic;
 
+const getNodeTextClass = (selectable: boolean, isSelected: boolean): string => {
+  if (!selectable) return "font-semibold text-baseline-60";
+  return isSelected ? "text-dynamic-dark font-medium" : "text-baseline-90";
+};
+
 function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
   const { t } = useTranslation();
   const { register, setValue, watch } = useFormContext();
@@ -410,16 +415,7 @@ function TreeSelectorCmp({ field, isReadOnly }: TreeSelectorProps) {
               </button>
             )}
             {!node.hasChildren && <span className="w-4 flex-shrink-0" />}
-            <span
-              className={`truncate ${
-                selectable
-                  ? isSelected
-                    ? "text-dynamic-dark font-medium"
-                    : "text-baseline-90"
-                  : "font-semibold text-baseline-60"
-              }`}>
-              {identifier}
-            </span>
+            <span className={`truncate ${getNodeTextClass(selectable, isSelected)}`}>{identifier}</span>
           </span>
           {isSelected && <CheckIcon className="fade-in-left flex-shrink-0" height={16} width={16} />}
         </li>

--- a/packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/__tests__/LinkSelector.test.tsx
@@ -1,0 +1,63 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright (C) 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { LinkSelector } from "../LinkSelector";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+
+jest.mock("@/contexts/language", () => ({
+  useLanguage: () => ({ language: "en_US" }),
+}));
+
+const mockField: Field = {
+  id: "link-1",
+  name: "URL",
+  hqlName: "url",
+  columnName: "url",
+  isMandatory: false,
+  column: { reference: "800101" },
+} as unknown as Field;
+
+const Wrapper = ({ defaultValue = "", readOnly = false }: { defaultValue?: string; readOnly?: boolean }) => {
+  const methods = useForm({ defaultValues: { url: defaultValue } });
+  return (
+    <FormProvider {...methods}>
+      <LinkSelector field={mockField} isReadOnly={readOnly} />
+    </FormProvider>
+  );
+};
+
+describe("LinkSelector", () => {
+  it("should render as text input in edit mode", () => {
+    render(<Wrapper defaultValue="https://example.com" />);
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("https://example.com");
+  });
+
+  it("should render as clickable link in read-only mode", () => {
+    render(<Wrapper defaultValue="https://example.com" readOnly />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("should render empty in read-only mode when no value", () => {
+    render(<Wrapper defaultValue="" readOnly />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/__tests__/PasswordSelector.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { PasswordSelector } from "../PasswordSelector";
+import type { Field } from "@workspaceui/api-client/src/api/types";
+
+jest.mock("@/contexts/language", () => ({
+  useLanguage: () => ({ language: "en_US" }),
+}));
+
+const makeField = (overrides: Partial<Field> = {}): Field =>
+  ({
+    id: "pwd-1",
+    name: "Password",
+    hqlName: "password",
+    columnName: "password",
+    isMandatory: false,
+    column: { reference: "C5C21C28B39E4683A91779F16C112E40", length: "60" },
+    ...overrides,
+  }) as unknown as Field;
+
+const Wrapper = ({ defaultValue = "" }: { defaultValue?: string }) => {
+  const methods = useForm({ defaultValues: { password: defaultValue } });
+  return (
+    <FormProvider {...methods}>
+      <PasswordSelector field={makeField()} />
+    </FormProvider>
+  );
+};
+
+describe("PasswordSelector", () => {
+  it("should render as password type by default", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("should toggle to text type when eye icon is clicked", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const toggle = screen.getByTestId(/eye-toggle/);
+    fireEvent.click(toggle);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("should toggle back to password on second click", () => {
+    render(<Wrapper defaultValue="secret123" />);
+    const toggle = screen.getByTestId(/eye-toggle/);
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    const input = screen.getByDisplayValue("secret123");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("should not show toggle when value is placeholder ***", () => {
+    render(<Wrapper defaultValue="***" />);
+    expect(screen.queryByTestId(/eye-toggle/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/MainUI/components/Form/FormView/selectors/components/TextAreaInput.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/components/TextAreaInput.tsx
@@ -18,7 +18,7 @@ export const TextAreaInput = ({
   showClearButton = true,
   onClear,
   setValue,
-  rows,
+  rows = 3,
   ...props
 }: TextAreaInputProps) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -48,9 +48,9 @@ export const TextAreaInput = ({
     const paddingLeft = leftIcon ? "pl-10" : "pl-3";
     const paddingRight = showClearButton || rightIcon ? "pr-10" : "pr-3";
 
-    const baseClasses = `w-full ${paddingLeft} ${paddingRight} py-2 rounded-t tracking-normal resize-y
+    const baseClasses = `w-full ${paddingLeft} ${paddingRight} py-2 rounded-t tracking-normal resize-none
       border-0 border-b-2 bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30)
-      text-(--color-transparent-neutral-80) font-medium text-sm leading-5 max-h-40 overflow-y-auto
+      text-(--color-transparent-neutral-80) font-medium text-sm leading-5 overflow-y-auto
       focus:border-[#004ACA] focus:text-[#004ACA] focus:bg-[#E5EFFF] focus:outline-none
       hover:border-(--color-transparent-neutral-100) hover:bg-(--color-transparent-neutral-10)`;
 

--- a/packages/MainUI/components/Form/FormView/selectors/components/TextAreaInput.tsx
+++ b/packages/MainUI/components/Form/FormView/selectors/components/TextAreaInput.tsx
@@ -48,10 +48,10 @@ export const TextAreaInput = ({
     const paddingLeft = leftIcon ? "pl-10" : "pl-3";
     const paddingRight = showClearButton || rightIcon ? "pr-10" : "pr-3";
 
-    const baseClasses = `w-full ${paddingLeft} ${paddingRight} py-2 rounded-t tracking-normal resize-none
-      border-0 border-b-2 bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30) 
-      text-(--color-transparent-neutral-80) font-medium text-sm leading-5 
-      focus:border-[#004ACA] focus:text-[#004ACA] focus:bg-[#E5EFFF] focus:outline-none 
+    const baseClasses = `w-full ${paddingLeft} ${paddingRight} py-2 rounded-t tracking-normal resize-y
+      border-0 border-b-2 bg-(--color-transparent-neutral-5) border-(--color-transparent-neutral-30)
+      text-(--color-transparent-neutral-80) font-medium text-sm leading-5 max-h-40 overflow-y-auto
+      focus:border-[#004ACA] focus:text-[#004ACA] focus:bg-[#E5EFFF] focus:outline-none
       hover:border-(--color-transparent-neutral-100) hover:bg-(--color-transparent-neutral-10)`;
 
     const disabledStyles =

--- a/packages/MainUI/components/Table/ColumnFilter.tsx
+++ b/packages/MainUI/components/Table/ColumnFilter.tsx
@@ -11,7 +11,7 @@ import { TreeColumnFilter } from "./TreeColumnFilter";
 import { useTranslation } from "@/hooks/useTranslation";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 
-const TREE_REFERENCE_IDS = new Set([
+const TREE_REFERENCE_IDS: Set<string> = new Set([
   FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
   FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
 ]);
@@ -114,6 +114,7 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = ({
         hasMore={filterState?.hasMore || false}
         placeholder={`Filter ${column.name || column.columnName}...`}
         filterState={filterState}
+        data-testid="TreeColumnFilter__a8fea9"
       />
     );
   }

--- a/packages/MainUI/components/Table/ColumnFilter.tsx
+++ b/packages/MainUI/components/Table/ColumnFilter.tsx
@@ -7,7 +7,17 @@ import {
   type FilterOption,
 } from "@workspaceui/api-client/src/utils/column-filter-utils";
 import { MultiSelect } from "../Form/FormView/selectors/components/MultiSelect";
+import { TreeColumnFilter } from "./TreeColumnFilter";
 import { useTranslation } from "@/hooks/useTranslation";
+import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
+
+const TREE_REFERENCE_IDS = new Set([
+  FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
+  FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
+]);
+
+const isTreeColumn = (column: Column): boolean =>
+  !!column.column?.reference && TREE_REFERENCE_IDS.has(column.column.reference);
 
 export interface ColumnFilterProps {
   column: Column;
@@ -41,7 +51,8 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = ({
   const isBooleanColumn =
     column.type === "boolean" || column.column?._identifier === "YesNo" || column.column?.reference === "20";
 
-  const supportsDropdown = isBooleanColumn || ColumnFilterUtils.supportsDropdownFilter(column);
+  const isTree = isTreeColumn(column);
+  const supportsDropdown = isBooleanColumn || isTree || ColumnFilterUtils.supportsDropdownFilter(column);
 
   const booleanOptions = useMemo<FilterOption[]>(
     () => [
@@ -60,6 +71,8 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = ({
         id: option.id,
         label: option.label,
         value: option.value ?? option.id,
+        parentId: option.parentId,
+        isCharacteristic: option.isCharacteristic,
       }));
 
     // Ensure selected options are always present for label display, even before the dropdown loads
@@ -83,10 +96,27 @@ export const ColumnFilter: React.FC<ColumnFilterProps> = ({
   };
 
   const handleLoadMore = () => {
-    if (onLoadMoreOptions && ColumnFilterUtils.isTableDirColumn(column) && !isBooleanColumn) {
+    if (onLoadMoreOptions && (ColumnFilterUtils.isTableDirColumn(column) || isTree) && !isBooleanColumn) {
       onLoadMoreOptions(filterState?.searchQuery);
     }
   };
+
+  if (isTree) {
+    return (
+      <TreeColumnFilter
+        options={availableOptions}
+        selectedValues={selectedValues}
+        onSelectionChange={handleSelectionChange}
+        onSearch={handleSearchChange}
+        onFocus={onLoadOptions}
+        onLoadMore={handleLoadMore}
+        loading={filterState?.loading || false}
+        hasMore={filterState?.hasMore || false}
+        placeholder={`Filter ${column.name || column.columnName}...`}
+        filterState={filterState}
+      />
+    );
+  }
 
   return (
     <MultiSelect

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -29,7 +29,13 @@ import { useDebouncedCallback } from "./utils/performanceOptimizations";
 import type { Column } from "@workspaceui/api-client/src/api/types";
 import type { FilterOption, ColumnFilterState } from "@workspaceui/api-client/src/utils/column-filter-utils";
 import { useColumnFilterData } from "@workspaceui/api-client/src/hooks/useColumnFilterData";
-import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+import {
+  buildFlatTreeList,
+  buildNodeMap,
+  filterVisibleNodes,
+  getNodeTextClass,
+  type TreeNode,
+} from "@/utils/form/treeUtils";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 
 /**
@@ -43,11 +49,6 @@ const TREE_REFERENCE_CONFIG: Record<string, { datasourceId: string; existsQuery:
     existsQuery:
       "exists (from ProductCharacteristicValue v where e = v.product and v.characteristicValue.id in ($value))",
   },
-};
-
-const getNodeTextClass = (selectable: boolean, isSelected: boolean): string => {
-  if (!selectable) return "font-semibold text-baseline-60";
-  return isSelected ? "text-dynamic-dark font-medium" : "text-baseline-90";
 };
 
 const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
@@ -175,49 +176,12 @@ function TreeColumnFilterCmp({
   // Build tree hierarchy from options
   const treeNodes = useMemo(() => buildTreeFromOptions(options), [options]);
 
-  // Node map for O(1) parent lookups
-  const nodeMap = useMemo(() => {
-    const map = new Map<string, TreeFilterNode>();
-    for (const node of treeNodes) map.set(node.id as string, node);
-    return map;
-  }, [treeNodes]);
+  const nodeMap = useMemo(() => buildNodeMap(treeNodes), [treeNodes]);
 
-  // Filter: search + collapse
-  const visibleNodes = useMemo(() => {
-    let filtered = treeNodes;
-
-    if (searchTerm) {
-      const lowerSearch = searchTerm.toLowerCase();
-      const matchIds = new Set(
-        treeNodes
-          .filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch))
-          .map((n) => n.id as string)
-      );
-      const keepIds = new Set(matchIds);
-      for (const node of treeNodes) {
-        if (matchIds.has(node.id as string)) {
-          let current: TreeFilterNode | undefined = node;
-          while (current?.parentId && typeof current.parentId === "string") {
-            keepIds.add(current.parentId as string);
-            current = nodeMap.get(current.parentId as string);
-          }
-        }
-      }
-      filtered = filtered.filter((n) => keepIds.has(n.id as string));
-    } else {
-      filtered = filtered.filter((node) => {
-        let parentId = node.parentId as string | undefined;
-        while (parentId) {
-          if (collapsedNodes.has(parentId)) return false;
-          const parent = nodeMap.get(parentId);
-          parentId = parent?.parentId as string | undefined;
-        }
-        return true;
-      });
-    }
-
-    return filtered;
-  }, [treeNodes, searchTerm, collapsedNodes, nodeMap]);
+  const visibleNodes = useMemo(
+    () => filterVisibleNodes(treeNodes, nodeMap, searchTerm, collapsedNodes),
+    [treeNodes, nodeMap, searchTerm, collapsedNodes]
+  );
 
   const toggleCollapse = useCallback((nodeId: string) => {
     setCollapsedNodes((prev) => {

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -1,0 +1,465 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+// @data-testid-ignore
+import { memo, useCallback, useMemo, useRef, useState, useEffect } from "react";
+import { handleKeyboardActivation, useClickOutside, useOpenDropdownEffect } from "@/utils/selectorUtils";
+import { Checkbox, styled } from "@mui/material";
+import ChevronDown from "@workspaceui/componentlibrary/src/assets/icons/chevron-down.svg";
+import ChevronRight from "@workspaceui/componentlibrary/src/assets/icons/chevron-right.svg";
+import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import { useTranslation } from "@/hooks/useTranslation";
+import { DropdownPortal } from "../Form/FormView/selectors/components/DropdownPortal";
+import SearchInput from "../Form/FormView/selectors/components/Select/SearchInput";
+import { useDebouncedCallback } from "./utils/performanceOptimizations";
+import type { FilterOption, ColumnFilterState } from "@workspaceui/api-client/src/utils/column-filter-utils";
+import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+
+const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
+  padding: 0,
+  marginRight: "0.5rem",
+  "&.Mui-checked": {
+    color: theme.palette.dynamicColor?.main,
+  },
+}));
+
+interface TreeFilterNode extends TreeNode {
+  filterValue: string;
+}
+
+interface TreeColumnFilterProps {
+  options: FilterOption[];
+  selectedValues: string[];
+  onSelectionChange: (selectedIds: string[]) => void;
+  onSearch?: (term: string) => void;
+  onFocus?: () => void;
+  onLoadMore?: () => void;
+  loading?: boolean;
+  hasMore?: boolean;
+  placeholder?: string;
+  filterState?: ColumnFilterState;
+}
+
+/**
+ * Builds tree hierarchy from FilterOptions that have parentId.
+ * Returns a flat, depth-annotated list for rendering.
+ */
+function buildTreeFromOptions(options: FilterOption[]): TreeFilterNode[] {
+  const records = options.map((opt) => ({
+    id: opt.id,
+    _identifier: opt.label,
+    parentId: opt.parentId,
+    isCharacteristic: opt.isCharacteristic,
+    filterValue: opt.value,
+  }));
+  const nodes = buildFlatTreeList(records);
+  return nodes as TreeFilterNode[];
+}
+
+function TreeColumnFilterCmp({
+  options,
+  selectedValues,
+  onSelectionChange,
+  onSearch,
+  onFocus,
+  loading = false,
+  placeholder = "Select options...",
+}: TreeColumnFilterProps) {
+  const { t } = useTranslation();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [isDebouncing, setIsDebouncing] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
+  const [isFetchingInitial, setIsFetchingInitial] = useState(false);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const portalRef = useRef<HTMLDivElement>(null);
+
+  // Build tree hierarchy from options
+  const treeNodes = useMemo(() => buildTreeFromOptions(options), [options]);
+
+  // Node map for O(1) parent lookups
+  const nodeMap = useMemo(() => {
+    const map = new Map<string, TreeFilterNode>();
+    for (const node of treeNodes) map.set(node.id as string, node);
+    return map;
+  }, [treeNodes]);
+
+  // Filter: search + collapse
+  const visibleNodes = useMemo(() => {
+    let filtered = treeNodes;
+
+    if (searchTerm) {
+      const lowerSearch = searchTerm.toLowerCase();
+      const matchIds = new Set(
+        treeNodes
+          .filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch))
+          .map((n) => n.id as string)
+      );
+      const keepIds = new Set(matchIds);
+      for (const node of treeNodes) {
+        if (matchIds.has(node.id as string)) {
+          let current: TreeFilterNode | undefined = node;
+          while (current?.parentId && typeof current.parentId === "string") {
+            keepIds.add(current.parentId as string);
+            current = nodeMap.get(current.parentId as string);
+          }
+        }
+      }
+      filtered = filtered.filter((n) => keepIds.has(n.id as string));
+    } else {
+      filtered = filtered.filter((node) => {
+        let parentId = node.parentId as string | undefined;
+        while (parentId) {
+          if (collapsedNodes.has(parentId)) return false;
+          const parent = nodeMap.get(parentId);
+          parentId = parent?.parentId as string | undefined;
+        }
+        return true;
+      });
+    }
+
+    return filtered;
+  }, [treeNodes, searchTerm, collapsedNodes, nodeMap]);
+
+  const toggleCollapse = useCallback((nodeId: string) => {
+    setCollapsedNodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  }, []);
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      const newSelection = selectedValues.includes(id)
+        ? selectedValues.filter((v) => v !== id)
+        : [...selectedValues, id];
+      onSelectionChange(newSelection);
+    },
+    [selectedValues, onSelectionChange]
+  );
+
+  const handleSingleSelect = useCallback(
+    (id: string) => {
+      onSelectionChange([id]);
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+      setSearchTerm("");
+    },
+    [onSelectionChange]
+  );
+
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onSelectionChange([]);
+      setIsOpen(false);
+      setSearchTerm("");
+    },
+    [onSelectionChange]
+  );
+
+  const handleClick = useCallback(() => {
+    setIsOpen((prev) => {
+      if (!prev) {
+        setIsFetchingInitial(true);
+        onFocus?.();
+      }
+      return !prev;
+    });
+  }, [onFocus]);
+
+  // Keyboard: arrow keys skip non-selectable nodes
+  const selectableIndices = useMemo(() => {
+    const indices: number[] = [];
+    for (let i = 0; i < visibleNodes.length; i++) {
+      if (!visibleNodes[i].isCharacteristic) indices.push(i);
+    }
+    return indices;
+  }, [visibleNodes]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const pos = selectableIndices.indexOf(prev);
+          return selectableIndices[pos < 0 ? 0 : (pos + 1) % selectableIndices.length];
+        });
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        if (selectableIndices.length === 0) return;
+        setHighlightedIndex((prev) => {
+          const pos = selectableIndices.indexOf(prev);
+          return selectableIndices[pos <= 0 ? selectableIndices.length - 1 : pos - 1];
+        });
+        return;
+      }
+      if (e.key === "Enter" && highlightedIndex >= 0) {
+        e.preventDefault();
+        const node = visibleNodes[highlightedIndex];
+        if (node && !node.isCharacteristic) handleSingleSelect(node.id as string);
+        else if (node?.hasChildren) toggleCollapse(node.id as string);
+      }
+    },
+    [visibleNodes, highlightedIndex, selectableIndices, handleSingleSelect, toggleCollapse]
+  );
+
+  const clickOutsideRefs = useMemo(() => [portalRef], []);
+  useClickOutside(
+    wrapperRef as React.RefObject<HTMLDivElement>,
+    () => setIsOpen(false),
+    clickOutsideRefs as React.RefObject<HTMLElement>[]
+  );
+
+  const handleOnSearch = useCallback(
+    (term: string) => {
+      onSearch?.(term);
+      setIsDebouncing(false);
+    },
+    [onSearch]
+  );
+  const debouncedSearch = useDebouncedCallback(handleOnSearch, 500);
+
+  const handleSetSearchTerm = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const term = e.target.value;
+      setSearchTerm(term);
+      if (onSearch) setIsDebouncing(true);
+      debouncedSearch(term);
+    },
+    [debouncedSearch, onSearch]
+  );
+
+  const handleSearchBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    const relatedTarget = e.relatedTarget as Element | null;
+    if (wrapperRef.current?.contains(relatedTarget)) return;
+    setTimeout(() => {
+      const activeElement = document.activeElement;
+      const isInPortal = portalRef.current?.contains(activeElement);
+      const isInWrapper = wrapperRef.current?.contains(activeElement);
+      if (!isInPortal && !isInWrapper) setIsOpen(false);
+    }, 150);
+  }, []);
+
+  useOpenDropdownEffect(
+    isOpen,
+    setSearchTerm,
+    setHighlightedIndex,
+    searchInputRef as React.RefObject<HTMLInputElement>
+  );
+
+  useEffect(() => {
+    if (options.length > 0 && !loading && isFetchingInitial) setIsFetchingInitial(false);
+  }, [options, loading, isFetchingInitial]);
+
+  // Scroll highlighted into view
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const item = listRef.current.children[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
+
+  const selectedLabels = useMemo(
+    () => options.filter((o) => selectedValues.includes(o.id)).map((o) => o.label),
+    [options, selectedValues]
+  );
+
+  const displayText = useMemo(() => {
+    if (!selectedLabels.length) return placeholder;
+    if (selectedLabels.length === 1) return selectedLabels[0];
+    return `${selectedLabels.length} selected`;
+  }, [selectedLabels, placeholder]);
+
+  const showSkeleton = isFetchingInitial && loading;
+  const showLoading = loading || isDebouncing;
+
+  const renderedOptions = useMemo(() => {
+    if (showSkeleton) {
+      return [1, 2, 3].map((i) => (
+        <li key={`skeleton-${i}`} className="px-4 py-2 text-sm pointer-events-none">
+          <div className="flex items-center gap-3 py-1">
+            <div className="h-4 w-4 bg-gray-200 rounded animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded animate-pulse" style={{ width: `${50 + i * 10}%` }} />
+          </div>
+        </li>
+      ));
+    }
+
+    if (visibleNodes.length > 0) {
+      return visibleNodes.map((node, index) => {
+        const nodeId = node.id as string;
+        const identifier = node._identifier as string;
+        const selectable = !node.isCharacteristic;
+        const isSelected = selectedValues.includes(nodeId);
+        const isHighlighted = highlightedIndex === index;
+        const isCollapsed = collapsedNodes.has(nodeId);
+
+        return (
+          <li
+            key={nodeId}
+            aria-selected={isSelected}
+            onClick={() => {
+              if (selectable) handleSingleSelect(nodeId);
+              else if (node.hasChildren) toggleCollapse(nodeId);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                if (selectable) handleSingleSelect(nodeId);
+                else if (node.hasChildren) toggleCollapse(nodeId);
+              }
+            }}
+            onMouseEnter={() => {
+              if (selectable) setHighlightedIndex(index);
+            }}
+            className={`py-2 text-sm flex items-center focus:outline-none
+              ${selectable ? "cursor-pointer hover:bg-baseline-10" : "cursor-default"}
+              ${isHighlighted && selectable ? "bg-baseline-10" : ""}
+              ${isSelected ? "bg-baseline-10" : ""}`}
+            style={{ paddingLeft: `${12 + node.depth * 18}px`, paddingRight: "12px" }}>
+            {node.hasChildren && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleCollapse(nodeId);
+                }}
+                className="flex-shrink-0 w-4 h-4 flex items-center justify-center text-baseline-60 hover:text-baseline-90 mr-1">
+                <ChevronRight
+                  className={`w-3 h-3 transition-transform ${isCollapsed ? "" : "rotate-90"}`}
+                  fill="currentColor"
+                />
+              </button>
+            )}
+            {!node.hasChildren && <span className="w-4 flex-shrink-0 mr-1" />}
+            {selectable && (
+              <CustomCheckbox
+                size="small"
+                checked={isSelected}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggle(nodeId);
+                }}
+                disableRipple
+              />
+            )}
+            <span
+              className={`truncate ${
+                selectable
+                  ? isSelected
+                    ? "text-dynamic-dark font-medium"
+                    : "text-baseline-90"
+                  : "font-semibold text-baseline-60"
+              }`}>
+              {identifier}
+            </span>
+          </li>
+        );
+      });
+    }
+
+    if (!showLoading) {
+      return [
+        <li key="no-options" className="px-4 py-2 text-sm text-baseline-60">
+          {t("multiselect.noOptionsFound")}
+        </li>,
+      ];
+    }
+
+    return null;
+  }, [
+    visibleNodes,
+    highlightedIndex,
+    selectedValues,
+    collapsedNodes,
+    handleSingleSelect,
+    handleToggle,
+    toggleCollapse,
+    showSkeleton,
+    showLoading,
+    t,
+  ]);
+
+  return (
+    <div ref={wrapperRef} className="relative w-full font-['Inter']" tabIndex={-1}>
+      <div
+        onClick={handleClick}
+        onKeyDown={(e) => handleKeyboardActivation(e, handleClick)}
+        className={`w-full flex items-center justify-between py-2 h-10 border-b border-baseline-10 hover:border-baseline-100 focus:outline-none focus:ring-2 focus:ring-dynamic-light
+          ${isOpen ? "rounded border-b-0 border-dynamic-main ring-2 ring-dynamic-light" : ""}
+          text-baseline-20 cursor-pointer hover:border-baseline-60 transition-colors outline-none`}>
+        <div
+          className={`w-full text-sm truncate max-w-[calc(100%-40px)] ${
+            selectedLabels.length ? "text-baseline-90 font-medium" : "text-baseline-50 font-medium"
+          }`}>
+          {displayText}
+        </div>
+        <div className="flex items-center flex-shrink-0 ml-2">
+          {selectedLabels.length > 0 && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="mr-1 text-baseline-60 hover:text-baseline-80 rounded">
+              <CloseIcon className="w-4 h-4" />
+            </button>
+          )}
+          <ChevronDown
+            fill="currentColor"
+            className={`w-5 h-5 text-baseline-60 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          />
+        </div>
+      </div>
+      <DropdownPortal
+        isOpen={isOpen}
+        triggerRef={wrapperRef as React.RefObject<HTMLElement>}
+        portalRef={portalRef as React.RefObject<HTMLDivElement>}
+        minWidth={256}>
+        <SearchInput
+          searchTerm={searchTerm}
+          searchInputRef={searchInputRef as React.RefObject<HTMLInputElement>}
+          handleSetSearchTerm={handleSetSearchTerm}
+          handleKeyDown={handleKeyDown}
+          handleSearchBlur={handleSearchBlur}
+          handleFocus={() => {}}
+        />
+        <ul ref={listRef} className="overflow-y-auto focus:outline-none mt-1" style={{ maxHeight: "200px" }}>
+          {renderedOptions}
+          {showLoading && !showSkeleton && (
+            <li className="px-4 py-2 text-sm text-baseline-60 text-center">{t("multiselect.loadingOptions")}</li>
+          )}
+        </ul>
+      </DropdownPortal>
+    </div>
+  );
+}
+
+export const TreeColumnFilter = memo(TreeColumnFilterCmp);

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -45,6 +45,11 @@ const TREE_REFERENCE_CONFIG: Record<string, { datasourceId: string; existsQuery:
   },
 };
 
+const getNodeTextClass = (selectable: boolean, isSelected: boolean): string => {
+  if (!selectable) return "font-semibold text-baseline-60";
+  return isSelected ? "text-dynamic-dark font-medium" : "text-baseline-90";
+};
+
 const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
   padding: 0,
   marginRight: "0.5rem",
@@ -460,16 +465,7 @@ function TreeColumnFilterCmp({
                 disableRipple
               />
             )}
-            <span
-              className={`truncate ${
-                selectable
-                  ? isSelected
-                    ? "text-dynamic-dark font-medium"
-                    : "text-baseline-90"
-                  : "font-semibold text-baseline-60"
-              }`}>
-              {identifier}
-            </span>
+            <span className={`truncate ${getNodeTextClass(selectable, isSelected)}`}>{identifier}</span>
           </li>
         );
       });

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -29,13 +29,7 @@ import { useDebouncedCallback } from "./utils/performanceOptimizations";
 import type { Column } from "@workspaceui/api-client/src/api/types";
 import type { FilterOption, ColumnFilterState } from "@workspaceui/api-client/src/utils/column-filter-utils";
 import { useColumnFilterData } from "@workspaceui/api-client/src/hooks/useColumnFilterData";
-import {
-  buildFlatTreeList,
-  buildNodeMap,
-  filterVisibleNodes,
-  getNodeTextClass,
-  type TreeNode,
-} from "@/utils/form/treeUtils";
+import { buildNodeMap, buildTreeFromFilterOptions, filterVisibleNodes, getNodeTextClass } from "@/utils/form/treeUtils";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 
 /**
@@ -59,10 +53,6 @@ const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
   },
 }));
 
-interface TreeFilterNode extends TreeNode {
-  filterValue: string;
-}
-
 interface TreeColumnFilterProps {
   options?: FilterOption[];
   selectedValues?: string[];
@@ -78,22 +68,6 @@ interface TreeColumnFilterProps {
   column?: Column;
   entityName?: string;
   tabId?: string;
-}
-
-/**
- * Builds tree hierarchy from FilterOptions that have parentId.
- * Returns a flat, depth-annotated list for rendering.
- */
-function buildTreeFromOptions(options: FilterOption[]): TreeFilterNode[] {
-  const records = options.map((opt) => ({
-    id: opt.id,
-    _identifier: opt.label,
-    parentId: opt.parentId ?? null,
-    isCharacteristic: opt.isCharacteristic ?? false,
-    filterValue: opt.value,
-  }));
-  const nodes = buildFlatTreeList(records);
-  return nodes as TreeFilterNode[];
 }
 
 function TreeColumnFilterCmp({
@@ -174,7 +148,7 @@ function TreeColumnFilterCmp({
   const portalRef = useRef<HTMLDivElement>(null);
 
   // Build tree hierarchy from options
-  const treeNodes = useMemo(() => buildTreeFromOptions(options), [options]);
+  const treeNodes = useMemo(() => buildTreeFromFilterOptions(options), [options]);
 
   const nodeMap = useMemo(() => buildNodeMap(treeNodes), [treeNodes]);
 

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -33,12 +33,16 @@ import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 
 /**
- * Maps reference IDs to their tree datasource IDs.
+ * Maps reference IDs to their tree datasource IDs and HQL exists queries.
  * In Classic, these are hardcoded in ob-formitem-characteristics.js.
  * The backend metadata API does not expose this relationship.
  */
-const TREE_DATASOURCE_BY_REFERENCE: Record<string, string> = {
-  [FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id]: "BE2735798ECC4EF88D131F16F1C4EC72",
+const TREE_REFERENCE_CONFIG: Record<string, { datasourceId: string; existsQuery: string }> = {
+  [FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id]: {
+    datasourceId: "BE2735798ECC4EF88D131F16F1C4EC72",
+    existsQuery:
+      "exists (from ProductCharacteristicValue v where e = v.product and v.characteristicValue.id in ($value))",
+  },
 };
 
 const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
@@ -56,7 +60,7 @@ interface TreeFilterNode extends TreeNode {
 interface TreeColumnFilterProps {
   options?: FilterOption[];
   selectedValues?: string[];
-  onSelectionChange: (selectedIds: string[]) => void;
+  onSelectionChange: (selectedIds: string[], selectedOptions?: FilterOption[]) => void;
   onSearch?: (term: string) => void;
   onFocus?: () => void;
   onLoadMore?: () => void;
@@ -124,9 +128,8 @@ function TreeColumnFilterCmp({
       setSelfLoading(true);
       try {
         // Resolve datasource: check reference-specific mapping, then column metadata, then entity _distinct
-        const refDatasourceId = column.column?.reference
-          ? TREE_DATASOURCE_BY_REFERENCE[column.column.reference]
-          : undefined;
+        const refConfig = column.column?.reference ? TREE_REFERENCE_CONFIG[column.column.reference] : undefined;
+        const refDatasourceId = refConfig?.datasourceId;
         const columnDatasourceId = refDatasourceId || column.datasourceId || column.selectorDefinitionId;
 
         const result = columnDatasourceId
@@ -144,7 +147,11 @@ function TreeColumnFilterCmp({
               tabId,
             });
 
-        setSelfLoadedOptions(result);
+        // Attach existsQuery to options so criteria builder can use it for special filter format
+        const enrichedResult = refConfig?.existsQuery
+          ? result.map((opt) => ({ ...opt, existsQuery: refConfig.existsQuery }))
+          : result;
+        setSelfLoadedOptions(enrichedResult);
         setSelfLoaded(true);
       } catch {
         setSelfLoadedOptions([]);
@@ -216,33 +223,35 @@ function TreeColumnFilterCmp({
     });
   }, []);
 
+  const getSelectedOptions = useCallback((ids: string[]) => options.filter((opt) => ids.includes(opt.id)), [options]);
+
   const handleToggle = useCallback(
     (id: string) => {
       const newSelection = selectedValues.includes(id)
         ? selectedValues.filter((v) => v !== id)
         : [...selectedValues, id];
       if (isSelfLoading) setSelfSelectedValues(newSelection);
-      onSelectionChange(newSelection);
+      onSelectionChange(newSelection, getSelectedOptions(newSelection));
     },
-    [selectedValues, onSelectionChange, isSelfLoading]
+    [selectedValues, onSelectionChange, isSelfLoading, getSelectedOptions]
   );
 
   const handleSingleSelect = useCallback(
     (id: string) => {
       if (isSelfLoading) setSelfSelectedValues([id]);
-      onSelectionChange([id]);
+      onSelectionChange([id], getSelectedOptions([id]));
       setIsOpen(false);
       setHighlightedIndex(-1);
       setSearchTerm("");
     },
-    [onSelectionChange, isSelfLoading]
+    [onSelectionChange, isSelfLoading, getSelectedOptions]
   );
 
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       if (isSelfLoading) setSelfSelectedValues([]);
-      onSelectionChange([]);
+      onSelectionChange([], []);
       setIsOpen(false);
       setSearchTerm("");
     },

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -30,6 +30,16 @@ import type { Column } from "@workspaceui/api-client/src/api/types";
 import type { FilterOption, ColumnFilterState } from "@workspaceui/api-client/src/utils/column-filter-utils";
 import { useColumnFilterData } from "@workspaceui/api-client/src/hooks/useColumnFilterData";
 import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
+import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
+
+/**
+ * Maps reference IDs to their tree datasource IDs.
+ * In Classic, these are hardcoded in ob-formitem-characteristics.js.
+ * The backend metadata API does not expose this relationship.
+ */
+const TREE_DATASOURCE_BY_REFERENCE: Record<string, string> = {
+  [FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id]: "BE2735798ECC4EF88D131F16F1C4EC72",
+};
 
 const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
   padding: 0,
@@ -113,10 +123,11 @@ function TreeColumnFilterCmp({
       if (!column) return;
       setSelfLoading(true);
       try {
-        // Prefer column's own datasource/selector ID (e.g. tree datasource for Product Characteristics)
-        // Fall back to entity name with _distinct for columns without a specific datasource
-        const columnDatasourceId = column.datasourceId || column.selectorDefinitionId;
-        const distinctField = ((column as Record<string, unknown>).filterFieldName as string) || column.columnName;
+        // Resolve datasource: check reference-specific mapping, then column metadata, then entity _distinct
+        const refDatasourceId = column.column?.reference
+          ? TREE_DATASOURCE_BY_REFERENCE[column.column.reference]
+          : undefined;
+        const columnDatasourceId = refDatasourceId || column.datasourceId || column.selectorDefinitionId;
 
         const result = columnDatasourceId
           ? await fetchFilterOptions({
@@ -129,7 +140,7 @@ function TreeColumnFilterCmp({
               datasourceId: entityName || "",
               searchQuery,
               limit: 100,
-              distinctField,
+              distinctField: ((column as Record<string, unknown>).filterFieldName as string) || column.columnName,
               tabId,
             });
 

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -26,7 +26,9 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { DropdownPortal } from "../Form/FormView/selectors/components/DropdownPortal";
 import SearchInput from "../Form/FormView/selectors/components/Select/SearchInput";
 import { useDebouncedCallback } from "./utils/performanceOptimizations";
+import type { Column } from "@workspaceui/api-client/src/api/types";
 import type { FilterOption, ColumnFilterState } from "@workspaceui/api-client/src/utils/column-filter-utils";
+import { useColumnFilterData } from "@workspaceui/api-client/src/hooks/useColumnFilterData";
 import { buildFlatTreeList, type TreeNode } from "@/utils/form/treeUtils";
 
 const CustomCheckbox = styled(Checkbox)(({ theme }) => ({
@@ -42,8 +44,8 @@ interface TreeFilterNode extends TreeNode {
 }
 
 interface TreeColumnFilterProps {
-  options: FilterOption[];
-  selectedValues: string[];
+  options?: FilterOption[];
+  selectedValues?: string[];
   onSelectionChange: (selectedIds: string[]) => void;
   onSearch?: (term: string) => void;
   onFocus?: () => void;
@@ -52,6 +54,10 @@ interface TreeColumnFilterProps {
   hasMore?: boolean;
   placeholder?: string;
   filterState?: ColumnFilterState;
+  /** When provided, the component loads its own data using useColumnFilterData */
+  column?: Column;
+  entityName?: string;
+  tabId?: string;
 }
 
 /**
@@ -71,13 +77,16 @@ function buildTreeFromOptions(options: FilterOption[]): TreeFilterNode[] {
 }
 
 function TreeColumnFilterCmp({
-  options,
-  selectedValues,
+  options: externalOptions,
+  selectedValues: externalSelectedValues,
   onSelectionChange,
   onSearch,
   onFocus,
-  loading = false,
+  loading: externalLoading = false,
   placeholder = "Select options...",
+  column,
+  entityName,
+  tabId,
 }: TreeColumnFilterProps) {
   const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState("");
@@ -86,6 +95,42 @@ function TreeColumnFilterCmp({
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
   const [isFetchingInitial, setIsFetchingInitial] = useState(false);
+
+  // Self-loading mode: fetch data using useColumnFilterData when column/entityName are provided
+  const isSelfLoading = !!column && !!entityName;
+  const { fetchFilterOptions } = useColumnFilterData();
+  const [selfLoadedOptions, setSelfLoadedOptions] = useState<FilterOption[]>([]);
+  const [selfLoading, setSelfLoading] = useState(false);
+  const [selfLoaded, setSelfLoaded] = useState(false);
+  const [selfSelectedValues, setSelfSelectedValues] = useState<string[]>([]);
+
+  const options = isSelfLoading ? selfLoadedOptions : (externalOptions ?? []);
+  const selectedValues = isSelfLoading ? selfSelectedValues : (externalSelectedValues ?? []);
+  const loading = isSelfLoading ? selfLoading : externalLoading;
+
+  const loadSelfOptions = useCallback(
+    async (searchQuery?: string) => {
+      if (!entityName || !column) return;
+      setSelfLoading(true);
+      try {
+        const distinctField = ((column as Record<string, unknown>).filterFieldName as string) || column.columnName;
+        const result = await fetchFilterOptions({
+          datasourceId: entityName,
+          searchQuery,
+          limit: 100,
+          distinctField,
+          tabId,
+        });
+        setSelfLoadedOptions(result);
+        setSelfLoaded(true);
+      } catch {
+        setSelfLoadedOptions([]);
+      } finally {
+        setSelfLoading(false);
+      }
+    },
+    [entityName, column, tabId, fetchFilterOptions]
+  );
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -153,40 +198,47 @@ function TreeColumnFilterCmp({
       const newSelection = selectedValues.includes(id)
         ? selectedValues.filter((v) => v !== id)
         : [...selectedValues, id];
+      if (isSelfLoading) setSelfSelectedValues(newSelection);
       onSelectionChange(newSelection);
     },
-    [selectedValues, onSelectionChange]
+    [selectedValues, onSelectionChange, isSelfLoading]
   );
 
   const handleSingleSelect = useCallback(
     (id: string) => {
+      if (isSelfLoading) setSelfSelectedValues([id]);
       onSelectionChange([id]);
       setIsOpen(false);
       setHighlightedIndex(-1);
       setSearchTerm("");
     },
-    [onSelectionChange]
+    [onSelectionChange, isSelfLoading]
   );
 
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (isSelfLoading) setSelfSelectedValues([]);
       onSelectionChange([]);
       setIsOpen(false);
       setSearchTerm("");
     },
-    [onSelectionChange]
+    [onSelectionChange, isSelfLoading]
   );
 
   const handleClick = useCallback(() => {
     setIsOpen((prev) => {
       if (!prev) {
         setIsFetchingInitial(true);
-        onFocus?.();
+        if (isSelfLoading && !selfLoaded) {
+          loadSelfOptions();
+        } else {
+          onFocus?.();
+        }
       }
       return !prev;
     });
-  }, [onFocus]);
+  }, [onFocus, isSelfLoading, selfLoaded, loadSelfOptions]);
 
   // Keyboard: arrow keys skip non-selectable nodes
   const selectableIndices = useMemo(() => {
@@ -242,10 +294,14 @@ function TreeColumnFilterCmp({
 
   const handleOnSearch = useCallback(
     (term: string) => {
-      onSearch?.(term);
+      if (isSelfLoading) {
+        loadSelfOptions(term);
+      } else {
+        onSearch?.(term);
+      }
       setIsDebouncing(false);
     },
-    [onSearch]
+    [onSearch, isSelfLoading, loadSelfOptions]
   );
   const debouncedSearch = useDebouncedCallback(handleOnSearch, 500);
 

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -110,17 +110,29 @@ function TreeColumnFilterCmp({
 
   const loadSelfOptions = useCallback(
     async (searchQuery?: string) => {
-      if (!entityName || !column) return;
+      if (!column) return;
       setSelfLoading(true);
       try {
+        // Prefer column's own datasource/selector ID (e.g. tree datasource for Product Characteristics)
+        // Fall back to entity name with _distinct for columns without a specific datasource
+        const columnDatasourceId = column.datasourceId || column.selectorDefinitionId;
         const distinctField = ((column as Record<string, unknown>).filterFieldName as string) || column.columnName;
-        const result = await fetchFilterOptions({
-          datasourceId: entityName,
-          searchQuery,
-          limit: 100,
-          distinctField,
-          tabId,
-        });
+
+        const result = columnDatasourceId
+          ? await fetchFilterOptions({
+              datasourceId: String(columnDatasourceId),
+              selectorDefinitionId: column.selectorDefinitionId as string | undefined,
+              searchQuery,
+              limit: 100,
+            })
+          : await fetchFilterOptions({
+              datasourceId: entityName || "",
+              searchQuery,
+              limit: 100,
+              distinctField,
+              tabId,
+            });
+
         setSelfLoadedOptions(result);
         setSelfLoaded(true);
       } catch {

--- a/packages/MainUI/components/Table/TreeColumnFilter.tsx
+++ b/packages/MainUI/components/Table/TreeColumnFilter.tsx
@@ -88,8 +88,8 @@ function buildTreeFromOptions(options: FilterOption[]): TreeFilterNode[] {
   const records = options.map((opt) => ({
     id: opt.id,
     _identifier: opt.label,
-    parentId: opt.parentId,
-    isCharacteristic: opt.isCharacteristic,
+    parentId: opt.parentId ?? null,
+    isCharacteristic: opt.isCharacteristic ?? false,
     filterValue: opt.value,
   }));
   const nodes = buildFlatTreeList(records);

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -79,6 +79,8 @@ import {
 import { processCalloutColumnValues } from "./utils/calloutUtils";
 import { ACTION_FORM_INITIALIZATION, MODE_CHANGE } from "@/utils/hooks/useFormInitialization/constants";
 import { COLUMN_NAMES } from "./constants";
+import { TreeColumnFilter } from "./TreeColumnFilter";
+import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 import { useTableStatePersistenceTab } from "@/hooks/useTableStatePersistenceTab";
 import { CellContextMenu } from "./CellContextMenu";
 import { HeaderContextMenu, type SummaryType } from "./HeaderContextMenu";
@@ -2441,6 +2443,34 @@ const DynamicTable = ({
       // Use stable callback reference instead of inline function
       column.Cell = renderDataColumnCell;
 
+      // Tree reference columns get a tree-aware dropdown filter instead of text
+      const ref = col.column?.reference;
+      if (
+        ref === FIELD_REFERENCE_CODES.TREE_REFERENCE.id ||
+        ref === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id
+      ) {
+        column.enableColumnFilter = true;
+        const colRef = col;
+        column.Filter = () => (
+          <TreeColumnFilter
+            column={colRef}
+            entityName={tab.entityName}
+            tabId={tab.id}
+            onSelectionChange={(selectedIds) => {
+              const colId = colRef.id || colRef.columnName;
+              const selectedOptions = selectedIds.map((id) => ({ id, label: id, value: id }));
+              handleMRTColumnFiltersChange((prev: ColumnFiltersState) => {
+                const filtered = prev.filter((f) => f.id !== colId);
+                if (selectedOptions.length > 0) {
+                  return [...filtered, { id: colId, value: selectedOptions }];
+                }
+                return filtered;
+              });
+            }}
+          />
+        );
+      }
+
       return column;
     });
 
@@ -2506,7 +2536,7 @@ const DynamicTable = ({
     }
 
     return modifiedColumns;
-  }, [baseColumns, shouldUseTreeMode, renderActionsColumnCell, renderDataColumnCell, tableColumnVisibility]);
+  }, [baseColumns, shouldUseTreeMode, renderActionsColumnCell, renderDataColumnCell, tableColumnVisibility, tab.entityName, tab.id, handleMRTColumnFiltersChange]);
 
   // Helper function to check if a row is being edited
 

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -705,6 +705,7 @@ const TreeColumnFilterWrapper = ({ column: mrtColumn }: { column: MRT_Column<Ent
           return filtered;
         });
       }}
+      data-testid="TreeColumnFilter__8ca888"
     />
   );
 };
@@ -2469,10 +2470,7 @@ const DynamicTable = ({
 
       // Tree reference columns get a tree-aware dropdown filter instead of text
       const ref = col.column?.reference;
-      if (
-        ref === FIELD_REFERENCE_CODES.TREE_REFERENCE.id ||
-        ref === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id
-      ) {
+      if (ref === FIELD_REFERENCE_CODES.TREE_REFERENCE.id || ref === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id) {
         column.enableColumnFilter = true;
         // Store props on column for the stable TreeColumnFilterWrapper to read
         (column as any)._treeFilterProps = {
@@ -2549,7 +2547,16 @@ const DynamicTable = ({
     }
 
     return modifiedColumns;
-  }, [baseColumns, shouldUseTreeMode, renderActionsColumnCell, renderDataColumnCell, tableColumnVisibility, tab.entityName, tab.id, handleMRTColumnFiltersChange]);
+  }, [
+    baseColumns,
+    shouldUseTreeMode,
+    renderActionsColumnCell,
+    renderDataColumnCell,
+    tableColumnVisibility,
+    tab.entityName,
+    tab.id,
+    handleMRTColumnFiltersChange,
+  ]);
 
   // Helper function to check if a row is being edited
 

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -2473,7 +2473,7 @@ const DynamicTable = ({
       if (ref === FIELD_REFERENCE_CODES.TREE_REFERENCE.id || ref === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id) {
         column.enableColumnFilter = true;
         // Store props on column for the stable TreeColumnFilterWrapper to read
-        (column as any)._treeFilterProps = {
+        (column as Record<string, unknown>)._treeFilterProps = {
           column: col,
           entityName: tab.entityName,
           tabId: tab.id,

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -2456,12 +2456,11 @@ const DynamicTable = ({
             column={colRef}
             entityName={tab.entityName}
             tabId={tab.id}
-            onSelectionChange={(selectedIds) => {
+            onSelectionChange={(_selectedIds, selectedOptions) => {
               const colId = colRef.id || colRef.columnName;
-              const selectedOptions = selectedIds.map((id) => ({ id, label: id, value: id }));
               handleMRTColumnFiltersChange((prev: ColumnFiltersState) => {
                 const filtered = prev.filter((f) => f.id !== colId);
-                if (selectedOptions.length > 0) {
+                if (selectedOptions && selectedOptions.length > 0) {
                   return [...filtered, { id: colId, value: selectedOptions }];
                 }
                 return filtered;

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -80,6 +80,7 @@ import { processCalloutColumnValues } from "./utils/calloutUtils";
 import { ACTION_FORM_INITIALIZATION, MODE_CHANGE } from "@/utils/hooks/useFormInitialization/constants";
 import { COLUMN_NAMES } from "./constants";
 import { TreeColumnFilter } from "./TreeColumnFilter";
+import type { FilterOption } from "@workspaceui/api-client/src/utils/column-filter-utils";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 import { useTableStatePersistenceTab } from "@/hooks/useTableStatePersistenceTab";
 import { CellContextMenu } from "./CellContextMenu";
@@ -683,6 +684,29 @@ const getHierarchyIcon = (
   }
 
   return <CircleFilledIcon className="min-w-5 min-h-5" fill={"#004ACA"} data-testid="HierarchyIcon__8ca888" />;
+};
+
+/** Stable wrapper for TreeColumnFilter — avoids inline component definitions inside useMemo */
+const TreeColumnFilterWrapper = ({ column: mrtColumn }: { column: MRT_Column<EntityData> }) => {
+  const props = (mrtColumn.columnDef as any)._treeFilterProps;
+  if (!props) return null;
+  return (
+    <TreeColumnFilter
+      column={props.column}
+      entityName={props.entityName}
+      tabId={props.tabId}
+      onSelectionChange={(_selectedIds: string[], selectedOptions?: FilterOption[]) => {
+        const colId = props.column.id || props.column.columnName;
+        props.onFilterChange((prev: ColumnFiltersState) => {
+          const filtered = prev.filter((f: { id: string }) => f.id !== colId);
+          if (selectedOptions && selectedOptions.length > 0) {
+            return [...filtered, { id: colId, value: selectedOptions }];
+          }
+          return filtered;
+        });
+      }}
+    />
+  );
 };
 
 const DynamicTable = ({
@@ -2450,24 +2474,14 @@ const DynamicTable = ({
         ref === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id
       ) {
         column.enableColumnFilter = true;
-        const colRef = col;
-        column.Filter = () => (
-          <TreeColumnFilter
-            column={colRef}
-            entityName={tab.entityName}
-            tabId={tab.id}
-            onSelectionChange={(_selectedIds, selectedOptions) => {
-              const colId = colRef.id || colRef.columnName;
-              handleMRTColumnFiltersChange((prev: ColumnFiltersState) => {
-                const filtered = prev.filter((f) => f.id !== colId);
-                if (selectedOptions && selectedOptions.length > 0) {
-                  return [...filtered, { id: colId, value: selectedOptions }];
-                }
-                return filtered;
-              });
-            }}
-          />
-        );
+        // Store props on column for the stable TreeColumnFilterWrapper to read
+        (column as any)._treeFilterProps = {
+          column: col,
+          entityName: tab.entityName,
+          tabId: tab.id,
+          onFilterChange: handleMRTColumnFiltersChange,
+        };
+        column.Filter = TreeColumnFilterWrapper;
       }
 
       return column;

--- a/packages/MainUI/components/window/Tab.tsx
+++ b/packages/MainUI/components/window/Tab.tsx
@@ -198,9 +198,7 @@ export function Tab({ tab, collapsed }: TabLevelProps) {
   // there's no need to fall back to currentRecordId (which may be stale during the
   // render cycle before the reset effect clears it).
   const isSrTab = tab.uIPattern === UIPattern.EDIT_ONLY && tab.defaultEditMode;
-  const effectiveRecordId = isSrTab && parentSelectedRecordId
-    ? parentSelectedRecordId
-    : currentRecordId;
+  const effectiveRecordId = isSrTab && parentSelectedRecordId ? parentSelectedRecordId : currentRecordId;
 
   // When the parent record changes, reset child tab state (exit form view, clear selection).
   // This replaces the implicit re-render that useWindowContext provided in the pre-Zustand architecture.
@@ -225,7 +223,9 @@ export function Tab({ tab, collapsed }: TabLevelProps) {
   const hasFormViewState = !!tabFormState && tabFormState.mode === TAB_MODES.FORM;
   const isSrDefaultForm = isSrTab && parentHasSelection;
   const shouldShowForm =
-    isSrDefaultForm || hasFormViewState || isFormView({ currentMode, recordId: currentRecordId, hasParentSelection: parentHasSelection });
+    isSrDefaultForm ||
+    hasFormViewState ||
+    isFormView({ currentMode, recordId: currentRecordId, hasParentSelection: parentHasSelection });
   const formMode = currentFormMode === FORM_MODES.NEW ? FormMode.NEW : FormMode.EDIT;
 
   const handleSetRecordId = useCallback<React.Dispatch<React.SetStateAction<string>>>(

--- a/packages/MainUI/components/window/Tab.tsx
+++ b/packages/MainUI/components/window/Tab.tsx
@@ -192,15 +192,27 @@ export function Tab({ tab, collapsed }: TabLevelProps) {
   const parentSelectedRecordId = reactiveParentSelectedRecordId;
   const parentHasSelection = !parentTab || !!parentSelectedRecordId;
 
+  // SR (Single Record) tabs share the same entity/record as the parent.
+  // They should show form view by default (like Classic) instead of loading a grid first.
+  // Always use parentSelectedRecordId directly — since SR child.id === parent.id,
+  // there's no need to fall back to currentRecordId (which may be stale during the
+  // render cycle before the reset effect clears it).
+  const isSrTab = tab.uIPattern === UIPattern.EDIT_ONLY && tab.defaultEditMode;
+  const effectiveRecordId = isSrTab && parentSelectedRecordId
+    ? parentSelectedRecordId
+    : currentRecordId;
+
   // When the parent record changes, reset child tab state (exit form view, clear selection).
   // This replaces the implicit re-render that useWindowContext provided in the pre-Zustand architecture.
+  // For SR tabs this clears stale form state so effectiveRecordId picks up the new parentId.
   const prevParentRecordRef = useRef<string | undefined>(parentSelectedRecordId);
   useEffect(() => {
     const prev = prevParentRecordRef.current;
     prevParentRecordRef.current = parentSelectedRecordId;
 
-    // Only react to actual changes (not initial mount)
-    if (prev === undefined && parentSelectedRecordId === undefined) return;
+    // Skip initial mount — prev is always undefined on first render.
+    // This prevents clearing the form state that auto-open or SR default just set.
+    if (prev === undefined) return;
     if (prev === parentSelectedRecordId) return;
     if (!parentTab || !windowIdentifier) return;
 
@@ -211,8 +223,9 @@ export function Tab({ tab, collapsed }: TabLevelProps) {
   }, [parentSelectedRecordId, parentTab, windowIdentifier, tab, clearTabFormState, clearSelectedRecord, graph]);
 
   const hasFormViewState = !!tabFormState && tabFormState.mode === TAB_MODES.FORM;
+  const isSrDefaultForm = isSrTab && parentHasSelection;
   const shouldShowForm =
-    hasFormViewState || isFormView({ currentMode, recordId: currentRecordId, hasParentSelection: parentHasSelection });
+    isSrDefaultForm || hasFormViewState || isFormView({ currentMode, recordId: currentRecordId, hasParentSelection: parentHasSelection });
   const formMode = currentFormMode === FORM_MODES.NEW ? FormMode.NEW : FormMode.EDIT;
 
   const handleSetRecordId = useCallback<React.Dispatch<React.SetStateAction<string>>>(
@@ -1214,10 +1227,11 @@ export function Tab({ tab, collapsed }: TabLevelProps) {
         <div
           className={`flex-1 h-full min-h-0 relative z-10 transition-[border-left-color] duration-200 border-l-4 ${isFocused ? "border-l-[var(--color-secondary-500)]" : "border-l-transparent"}`}>
           <FormView
+            key={isSrTab ? `sr-${effectiveRecordId}` : undefined}
             mode={formMode}
             tab={tab}
             window={window}
-            recordId={currentRecordId}
+            recordId={effectiveRecordId}
             setRecordId={handleSetRecordId}
             uIPattern={tab.uIPattern}
             isFocused={isFocused}

--- a/packages/MainUI/hooks/__tests__/useFormInitialState.test.ts
+++ b/packages/MainUI/hooks/__tests__/useFormInitialState.test.ts
@@ -223,7 +223,9 @@ describe("useFormInitialState", () => {
         columnValues: { IsActive: { value: "N" } },
       } as any;
       const { result } = renderHook(() => useFormInitialState(formInit));
-      expect(result.current?.active).toBe("N");
+      // "N" is the Classic representation of false for YES_NO fields and must be
+      // converted to a proper boolean so BooleanSelector doesn't treat it as truthy.
+      expect(result.current?.active).toBe(false);
     });
 
     it("does not apply @SQL= or @ColumnName@ patterns as static defaults", () => {

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -38,7 +38,7 @@ import { formatClassicDate } from "@workspaceui/componentlibrary/src/utils/dateF
 import { dateTimeSortingFn, dateSortingFn } from "@/utils/table/sortingFunctions";
 import { getTextFilterValue, getAvailableOptions, reconstructFilterState } from "@/utils/table/filters/utils";
 
-const TREE_REFERENCE_IDS = new Set([
+const TREE_REFERENCE_IDS: Set<string> = new Set([
   FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
   FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
 ]);

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -16,7 +16,7 @@
  */
 
 import React, { useMemo } from "react";
-import { parseColumns } from "@/utils/tableColumns";
+import { parseColumns, renderTextCell } from "@/utils/tableColumns";
 import type { Tab } from "@workspaceui/api-client/src/api/types";
 import type { MRT_Cell } from "material-react-table";
 import type { EntityData } from "@workspaceui/api-client/src/api/types";
@@ -242,6 +242,18 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
           // Use custom sorting function for datetime fields to sort by actual date value
           // rather than the formatted string representation
           sortingFn: isAuditField ? dateTimeSortingFn : dateSortingFn,
+        };
+      }
+
+      // Text / Memo / Rich Text columns — truncate with tooltip
+      const TEXT_REFERENCE_IDS = new Set(["14", "34", "7CB371C13D204EB69BF370217F692999"]);
+      if (column.column?.reference && TEXT_REFERENCE_IDS.has(column.column.reference)) {
+        columnConfig = {
+          ...columnConfig,
+          Cell: ({ cell }: { cell: MRT_Cell<EntityData, unknown> }) => {
+            const cellValue = cell?.getValue();
+            return renderTextCell(cellValue);
+          },
         };
       }
 

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -46,11 +46,17 @@ const TREE_REFERENCE_IDS: Set<string> = new Set([
 const isTreeReferenceColumn = (column: Column): boolean =>
   !!column.column?.reference && TREE_REFERENCE_IDS.has(column.column.reference);
 
-const isBooleanType = (column: Column): boolean =>
-  column.type === "boolean" || column.column?._identifier === "YesNo";
+const isBooleanType = (column: Column): boolean => column.type === "boolean" || column.column?._identifier === "YesNo";
 
 const supportsDropdown = (column: Column): boolean =>
   isBooleanType(column) || isTreeReferenceColumn(column) || ColumnFilterUtils.supportsDropdownFilter(column);
+
+const isCustomJsEnabled = (column: Column): boolean => Boolean(column.customJs && column.customJs.trim().length > 0);
+
+const TEXT_REFERENCE_IDS: Set<string> = new Set(["14", "34", "7CB371C13D204EB69BF370217F692999"]);
+
+const isTextReferenceColumn = (column: Column): boolean =>
+  !!column.column?.reference && TEXT_REFERENCE_IDS.has(column.column.reference);
 
 interface UseColumnsOptions {
   onColumnFilter?: (columnId: string, selectedOptions: FilterOption[]) => void;
@@ -202,7 +208,7 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
       const isBooleanColumn = isBooleanType(column);
       const isDateColumn = shouldFormatDateColumn(column);
       const supportsDropdownFilter = supportsDropdown(column);
-      const isCustomJsColumn = Boolean(column.customJs && column.customJs.trim().length > 0);
+      const isCustomJsColumn = isCustomJsEnabled(column);
 
       // --- Initialize filterState for booleans if it doesn't exist ---
       let filterState = columnFilterStates?.find((f) => f.id === column.id);
@@ -260,8 +266,7 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
       }
 
       // Text / Memo / Rich Text columns — truncate with tooltip
-      const TEXT_REFERENCE_IDS = new Set(["14", "34", "7CB371C13D204EB69BF370217F692999"]);
-      if (column.column?.reference && TEXT_REFERENCE_IDS.has(column.column.reference)) {
+      if (isTextReferenceColumn(column)) {
         columnConfig = {
           ...columnConfig,
           Cell: ({ cell }: { cell: MRT_Cell<EntityData, unknown> }) => {

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -38,6 +38,14 @@ import { formatClassicDate } from "@workspaceui/componentlibrary/src/utils/dateF
 import { dateTimeSortingFn, dateSortingFn } from "@/utils/table/sortingFunctions";
 import { getTextFilterValue, getAvailableOptions, reconstructFilterState } from "@/utils/table/filters/utils";
 
+const TREE_REFERENCE_IDS = new Set([
+  FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
+  FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
+]);
+
+const isTreeReferenceColumn = (column: Column): boolean =>
+  !!column.column?.reference && TREE_REFERENCE_IDS.has(column.column.reference);
+
 interface UseColumnsOptions {
   onColumnFilter?: (columnId: string, selectedOptions: FilterOption[]) => void;
   onDateTextFilterChange?: (columnId: string, filterValue: string) => void;
@@ -187,11 +195,8 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
       const isReference = isEntityReference(fieldReference);
       const isBooleanColumn = column.type === "boolean" || column.column?._identifier === "YesNo";
       const isDateColumn = shouldFormatDateColumn(column);
-      const isTreeColumn =
-        column.column?.reference === FIELD_REFERENCE_CODES.TREE_REFERENCE.id ||
-        column.column?.reference === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id;
       const supportsDropdownFilter =
-        isBooleanColumn || isTreeColumn || ColumnFilterUtils.supportsDropdownFilter(column);
+        isBooleanColumn || isTreeReferenceColumn(column) || ColumnFilterUtils.supportsDropdownFilter(column);
       const isCustomJsColumn = Boolean(column.customJs && column.customJs.trim().length > 0);
 
       // --- Initialize filterState for booleans if it doesn't exist ---

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -46,6 +46,12 @@ const TREE_REFERENCE_IDS: Set<string> = new Set([
 const isTreeReferenceColumn = (column: Column): boolean =>
   !!column.column?.reference && TREE_REFERENCE_IDS.has(column.column.reference);
 
+const isBooleanType = (column: Column): boolean =>
+  column.type === "boolean" || column.column?._identifier === "YesNo";
+
+const supportsDropdown = (column: Column): boolean =>
+  isBooleanType(column) || isTreeReferenceColumn(column) || ColumnFilterUtils.supportsDropdownFilter(column);
+
 interface UseColumnsOptions {
   onColumnFilter?: (columnId: string, selectedOptions: FilterOption[]) => void;
   onDateTextFilterChange?: (columnId: string, filterValue: string) => void;
@@ -193,10 +199,9 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
     return originalColumns.map((column: Column) => {
       const fieldReference = getFieldReference(column.column?.reference);
       const isReference = isEntityReference(fieldReference);
-      const isBooleanColumn = column.type === "boolean" || column.column?._identifier === "YesNo";
+      const isBooleanColumn = isBooleanType(column);
       const isDateColumn = shouldFormatDateColumn(column);
-      const supportsDropdownFilter =
-        isBooleanColumn || isTreeReferenceColumn(column) || ColumnFilterUtils.supportsDropdownFilter(column);
+      const supportsDropdownFilter = supportsDropdown(column);
       const isCustomJsColumn = Boolean(column.customJs && column.customJs.trim().length > 0);
 
       // --- Initialize filterState for booleans if it doesn't exist ---

--- a/packages/MainUI/hooks/table/useColumns.tsx
+++ b/packages/MainUI/hooks/table/useColumns.tsx
@@ -187,7 +187,11 @@ export const useColumns = (tab: Tab, options?: UseColumnsOptions) => {
       const isReference = isEntityReference(fieldReference);
       const isBooleanColumn = column.type === "boolean" || column.column?._identifier === "YesNo";
       const isDateColumn = shouldFormatDateColumn(column);
-      const supportsDropdownFilter = isBooleanColumn || ColumnFilterUtils.supportsDropdownFilter(column);
+      const isTreeColumn =
+        column.column?.reference === FIELD_REFERENCE_CODES.TREE_REFERENCE.id ||
+        column.column?.reference === FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id;
+      const supportsDropdownFilter =
+        isBooleanColumn || isTreeColumn || ColumnFilterUtils.supportsDropdownFilter(column);
       const isCustomJsColumn = Boolean(column.customJs && column.customJs.trim().length > 0);
 
       // --- Initialize filterState for booleans if it doesn't exist ---

--- a/packages/MainUI/hooks/table/useGridColumnFilters.ts
+++ b/packages/MainUI/hooks/table/useGridColumnFilters.ts
@@ -18,6 +18,15 @@
 import { useCallback, useRef } from "react";
 import type { Column } from "@workspaceui/api-client/src/api/types";
 import { FieldType } from "@workspaceui/api-client/src/api/types";
+import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
+
+const TREE_REFERENCE_IDS = new Set([
+  FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
+  FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
+]);
+
+const isTreeReferenceColumn = (column: Column): boolean =>
+  !!column.column?.reference && TREE_REFERENCE_IDS.has(column.column.reference);
 import type { MRT_ColumnFiltersState } from "material-react-table";
 import {
   ColumnFilterUtils,
@@ -122,6 +131,21 @@ export const useGridColumnFilters = ({
         });
       }
 
+      // Tree reference columns (e.g. Product Characteristics) — load from datasource like TableDir
+      if (isTreeReferenceColumn(column) && entityName) {
+        return loadTableDirFilterOptions({
+          column,
+          columnId,
+          searchQuery,
+          tabId,
+          entityName,
+          fetchFilterOptions,
+          setFilterOptions,
+          isImplicitFilterApplied,
+          extraParams,
+        });
+      }
+
       return [];
     },
     [columns, fetchFilterOptions, setFilterOptions, tabId, entityName, extraParams]
@@ -142,7 +166,11 @@ export const useGridColumnFilters = ({
         return [];
       }
 
-      if (!ColumnFilterUtils.isTableDirColumn(column) && !(column.type === FieldType.TABLEDIR && entityName)) {
+      if (
+        !ColumnFilterUtils.isTableDirColumn(column) &&
+        !(column.type === FieldType.TABLEDIR && entityName) &&
+        !isTreeReferenceColumn(column)
+      ) {
         return [];
       }
 

--- a/packages/MainUI/hooks/table/useGridColumnFilters.ts
+++ b/packages/MainUI/hooks/table/useGridColumnFilters.ts
@@ -20,7 +20,7 @@ import type { Column } from "@workspaceui/api-client/src/api/types";
 import { FieldType } from "@workspaceui/api-client/src/api/types";
 import { FIELD_REFERENCE_CODES } from "@/utils/form/constants";
 
-const TREE_REFERENCE_IDS = new Set([
+const TREE_REFERENCE_IDS: Set<string> = new Set([
   FIELD_REFERENCE_CODES.TREE_REFERENCE.id,
   FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id,
 ]);

--- a/packages/MainUI/hooks/table/useTableData.tsx
+++ b/packages/MainUI/hooks/table/useTableData.tsx
@@ -415,12 +415,13 @@ export const useTableData = ({
 
   // Helper to find parent field name
   const getParentFieldName = useCallback((): { fieldName: string; directReference: boolean } => {
+    // SR (Single Record) tabs share the same entity/record as the parent.
+    // Always filter by "id" regardless of parentColumns content.
+    if (tab.uIPattern === UIPattern.EDIT_ONLY && parentTab) {
+      return { fieldName: "id", directReference: true };
+    }
+
     if (!Array.isArray(tab?.parentColumns) || tab.parentColumns.length === 0) {
-      // SR (Single Record) tabs share the same entity/table as the parent and have
-      // empty parentColumns. Filter by "id" so only the parent's own record is shown.
-      if (tab.uIPattern === UIPattern.EDIT_ONLY && parentTab) {
-        return { fieldName: "id", directReference: true };
-      }
       return { fieldName: "_dummy", directReference: false };
     }
 

--- a/packages/MainUI/hooks/table/useTableData.tsx
+++ b/packages/MainUI/hooks/table/useTableData.tsx
@@ -47,6 +47,7 @@ import { buildEtendoContext } from "@/utils/contextUtils";
 import { useSelected } from "../../hooks/useSelected";
 import { DEFAULT_PAGE_SIZE } from "@/utils/table/constants";
 import { buildBaseCriteria, resolveParentFieldName } from "@/utils/criteriaUtils";
+import { isSrOneToOneExtension } from "@/utils/window/utils";
 import { parseColumns } from "@/utils/tableColumns";
 
 interface UseTableDataParams {
@@ -415,9 +416,9 @@ export const useTableData = ({
 
   // Helper to find parent field name
   const getParentFieldName = useCallback((): { fieldName: string; directReference: boolean } => {
-    // SR (Single Record) tabs share the same entity/record as the parent.
-    // Always filter by "id" regardless of parentColumns content.
-    if (tab.uIPattern === UIPattern.EDIT_ONLY && parentTab) {
+    // True 1:1 SR tabs share the same PK as the parent — filter by "id".
+    // Non-1:1 SR tabs (e.g. Payment Plan) have distinct IDs and must use FK resolution.
+    if (tab.uIPattern === UIPattern.EDIT_ONLY && parentTab && isSrOneToOneExtension(tab)) {
       return { fieldName: "id", directReference: true };
     }
 

--- a/packages/MainUI/hooks/useFormInitialState.ts
+++ b/packages/MainUI/hooks/useFormInitialState.ts
@@ -34,12 +34,13 @@ type FieldMap = Record<string, Field>;
 
 /**
  * Converts a FIC boolean string value to a JS boolean.
- * Etendo encodes YES_NO (reference "20") columns as "" for false and "Y" for true.
+ * Etendo encodes YES_NO (reference "20") columns as "" for false and "Y" for true
+ * in FIC responses, and "Y"/"N" in column default values.
  * Returns the original string unchanged for non-boolean fields.
  */
 function toBooleanEntityValue(value: string, field: Field | undefined): EntityValue {
   if (field?.column?.reference !== FIELD_REFERENCE_CODES.BOOLEAN.id) return value;
-  if (value === "" || value === "false") return false;
+  if (value === "" || value === "N" || value === "false") return false;
   if (value === "Y" || value === "true") return true;
   return value;
 }
@@ -91,12 +92,23 @@ function applyColumnValues(
   columnValues: FormInitializationResponse["columnValues"],
   fieldsByColumnName: FieldMap,
   fieldsByPropertyFieldKey: FieldMap
-): void {
+): Set<string> {
+  const ficKeys = new Set<string>();
   for (const [key, entry] of Object.entries(columnValues || {})) {
     const field = fieldsByColumnName[key] ?? fieldsByPropertyFieldKey[key];
     const newKey = field?.hqlName ?? key;
     applyColumnValueEntry(acc, newKey, entry, field);
+    // Track fields where FIC provided a meaningful value.
+    // For boolean fields, "" means "no value computed" and should still allow
+    // static defaults to apply. Any other value (including "N", "Y", false, true)
+    // is an explicit answer from the server.
+    const isBooleanEmpty =
+      field?.column?.reference === FIELD_REFERENCE_CODES.BOOLEAN.id && entry.value === "";
+    if (!isBooleanEmpty) {
+      ficKeys.add(newKey);
+    }
   }
+  return ficKeys;
 }
 
 /**
@@ -105,15 +117,22 @@ function applyColumnValues(
  * fields whose server-side default was not evaluated).
  * Skips @...@ expressions (column refs, SQL, session vars) — those are handled
  * elsewhere or delegated to the server.
+ *
+ * `ficKeys` contains fields that the FIC explicitly processed. Even if their
+ * converted value is `false` (e.g. boolean `""` → `false`), the FIC "spoke" for
+ * that field and static defaults must not overwrite it.
  */
-function applyStaticDefaults(acc: EntityData, fields: Tab["fields"]): void {
+function applyStaticDefaults(acc: EntityData, fields: Tab["fields"], ficKeys: Set<string>): void {
   for (const field of Object.values(fields)) {
     const dv = field?.column?.defaultValue;
     if (!dv || !field.hqlName) continue;
     if (dv.startsWith("@")) continue;
+    // If FIC explicitly returned a value for this field, respect it — even if the
+    // converted value is `false` for a boolean field.
+    if (ficKeys.has(field.hqlName)) continue;
     const current = acc[field.hqlName];
-    // For YES_NO (boolean) fields, "" from FIC becomes false after toBooleanEntityValue.
-    // Treat false the same as "" — both mean "no value was computed by the server".
+    // For fields NOT in ficKeys, boolean `false` from an empty FIC value ("" → false)
+    // still counts as empty — the server didn't compute a value.
     const isBooleanField = field?.column?.reference === FIELD_REFERENCE_CODES.BOOLEAN.id;
     const isEmpty = current === undefined || current === "" || (isBooleanField && current === false);
     if (!isEmpty) continue;
@@ -177,8 +196,8 @@ export const useFormInitialState = (formInitialization?: FormInitializationRespo
     const acc = { ...formInitialization.sessionAttributes } as EntityData;
 
     applyAuxiliaryInputs(acc, formInitialization.auxiliaryInputValues, fieldsByColumnName);
-    applyColumnValues(acc, formInitialization.columnValues, fieldsByColumnName, fieldsByPropertyFieldKey);
-    applyStaticDefaults(acc, tab.fields);
+    const ficKeys = applyColumnValues(acc, formInitialization.columnValues, fieldsByColumnName, fieldsByPropertyFieldKey);
+    applyStaticDefaults(acc, tab.fields, ficKeys);
     resolveDefaultReferences(acc, tab.fields, fieldsByColumnName);
 
     return { ...parentData, ...acc };

--- a/packages/MainUI/hooks/useFormInitialState.ts
+++ b/packages/MainUI/hooks/useFormInitialState.ts
@@ -102,8 +102,7 @@ function applyColumnValues(
     // For boolean fields, "" means "no value computed" and should still allow
     // static defaults to apply. Any other value (including "N", "Y", false, true)
     // is an explicit answer from the server.
-    const isBooleanEmpty =
-      field?.column?.reference === FIELD_REFERENCE_CODES.BOOLEAN.id && entry.value === "";
+    const isBooleanEmpty = field?.column?.reference === FIELD_REFERENCE_CODES.BOOLEAN.id && entry.value === "";
     if (!isBooleanEmpty) {
       ficKeys.add(newKey);
     }
@@ -196,7 +195,12 @@ export const useFormInitialState = (formInitialization?: FormInitializationRespo
     const acc = { ...formInitialization.sessionAttributes } as EntityData;
 
     applyAuxiliaryInputs(acc, formInitialization.auxiliaryInputValues, fieldsByColumnName);
-    const ficKeys = applyColumnValues(acc, formInitialization.columnValues, fieldsByColumnName, fieldsByPropertyFieldKey);
+    const ficKeys = applyColumnValues(
+      acc,
+      formInitialization.columnValues,
+      fieldsByColumnName,
+      fieldsByPropertyFieldKey
+    );
     applyStaticDefaults(acc, tab.fields, ficKeys);
     resolveDefaultReferences(acc, tab.fields, fieldsByColumnName);
 

--- a/packages/MainUI/next-env.d.ts
+++ b/packages/MainUI/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/MainUI/utils/__tests__/criteriaUtils.test.ts
+++ b/packages/MainUI/utils/__tests__/criteriaUtils.test.ts
@@ -1,4 +1,5 @@
 import { buildBaseCriteria } from "../criteriaUtils";
+import { UIPattern } from "@workspaceui/api-client/src/api/types";
 
 describe("criteriaUtils", () => {
   describe("buildBaseCriteria", () => {
@@ -63,6 +64,45 @@ describe("criteriaUtils", () => {
       // falls back to @EntityName.id@ session variables for filtering.
       expect(result[0].fieldName).toBe("_dummy");
       expect(result[0].operator).toBe("equals");
+    });
+
+    it("should return id criteria for true 1:1 SR tabs (parentColumns includes PK)", () => {
+      const srOneToOneTab: any = {
+        ...childTab,
+        uIPattern: UIPattern.EDIT_ONLY,
+        parentColumns: ["id"],
+        fields: { id: { column: { keyColumn: true } } },
+      };
+      const result = buildBaseCriteria({
+        tab: srOneToOneTab,
+        parentTab,
+        parentId: "123",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fieldName).toBe("id");
+      expect(result[0].value).toBe("123");
+    });
+
+    it("should use FK resolution for non-1:1 SR tabs (e.g. Payment Plan)", () => {
+      const srNonOneToOneTab: any = {
+        ...childTab,
+        uIPattern: UIPattern.EDIT_ONLY,
+        parentColumns: ["invoice"],
+        fields: {
+          id: { column: { keyColumn: true } },
+          invoice: { referencedEntity: "ParentEntity" },
+        },
+      };
+      const result = buildBaseCriteria({
+        tab: srNonOneToOneTab,
+        parentTab,
+        parentId: "123",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fieldName).toBe("invoice");
+      expect(result[0].value).toBe("123");
     });
   });
 });

--- a/packages/MainUI/utils/__tests__/tableColumns.test.tsx
+++ b/packages/MainUI/utils/__tests__/tableColumns.test.tsx
@@ -15,7 +15,8 @@
  *************************************************************************
  */
 
-import { parseColumns } from "../tableColumns";
+import { render, screen } from "@testing-library/react";
+import { parseColumns, renderTextCell } from "../tableColumns";
 import type { Field } from "@workspaceui/api-client/src/api/types";
 
 // Mock dependencies
@@ -347,6 +348,25 @@ describe("tableColumns", () => {
         // Should not throw
         expect(() => parseColumns([{} as Field])).not.toThrow();
       });
+    });
+  });
+
+  describe("renderTextCell", () => {
+    it("should render the value in a span with truncate class", () => {
+      const result = renderTextCell("A very long text that should be truncated");
+      render(<div>{result}</div>);
+      const span = screen.getByText("A very long text that should be truncated");
+      expect(span).toBeInTheDocument();
+      expect(span.className).toContain("truncate");
+    });
+
+    it("should return empty string for null/undefined", () => {
+      expect(renderTextCell(null)).toBe("");
+      expect(renderTextCell(undefined)).toBe("");
+    });
+
+    it("should handle empty string", () => {
+      expect(renderTextCell("")).toBe("");
     });
   });
 });

--- a/packages/MainUI/utils/criteriaUtils.ts
+++ b/packages/MainUI/utils/criteriaUtils.ts
@@ -15,7 +15,7 @@
  *************************************************************************
  */
 
-import type { Tab, EntityValue } from "@workspaceui/api-client/src/api/types";
+import { type Tab, type EntityValue, UIPattern } from "@workspaceui/api-client/src/api/types";
 
 export interface BaseCriteriaOptions {
   tab: Tab;
@@ -97,6 +97,12 @@ export const buildBaseCriteria = ({ tab, parentTab, parentId }: BaseCriteriaOpti
   }
 
   if (parentId && parentId !== "") {
+    // SR tabs share the same entity/record as the parent — filter by id directly.
+    // Unlike normal child tabs, fieldName="id" IS correct here because child.id === parent.id.
+    if (tab.uIPattern === UIPattern.EDIT_ONLY) {
+      return [{ fieldName: "id", value: parentId as EntityValue, operator: "equals" }];
+    }
+
     // Classic sends _dummy for parent-child tab navigation when disableParentKeyProperty is true.
     // The server uses @EntityName.id@ session variables (set in useTableData) for the actual filtering.
     if (tab.disableParentKeyProperty) {

--- a/packages/MainUI/utils/criteriaUtils.ts
+++ b/packages/MainUI/utils/criteriaUtils.ts
@@ -16,6 +16,7 @@
  */
 
 import { type Tab, type EntityValue, UIPattern } from "@workspaceui/api-client/src/api/types";
+import { isSrOneToOneExtension } from "@/utils/window/utils";
 
 export interface BaseCriteriaOptions {
   tab: Tab;
@@ -97,9 +98,9 @@ export const buildBaseCriteria = ({ tab, parentTab, parentId }: BaseCriteriaOpti
   }
 
   if (parentId && parentId !== "") {
-    // SR tabs share the same entity/record as the parent — filter by id directly.
-    // Unlike normal child tabs, fieldName="id" IS correct here because child.id === parent.id.
-    if (tab.uIPattern === UIPattern.EDIT_ONLY) {
+    // True 1:1 SR tabs share the same PK as the parent — filter by id directly.
+    // Non-1:1 SR tabs (e.g. Payment Plan) have distinct IDs and must use FK resolution.
+    if (tab.uIPattern === UIPattern.EDIT_ONLY && isSrOneToOneExtension(tab)) {
       return [{ fieldName: "id", value: parentId as EntityValue, operator: "equals" }];
     }
 

--- a/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
+++ b/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
@@ -86,9 +86,7 @@ describe("buildFlatTreeList", () => {
   it("should handle single node", () => {
     const records: EntityData[] = [{ id: "ONLY", _identifier: "Only Node" }];
     const result = buildFlatTreeList(records);
-    expect(result).toEqual([
-      expect.objectContaining({ id: "ONLY", depth: 0, hasChildren: false }),
-    ]);
+    expect(result).toEqual([expect.objectContaining({ id: "ONLY", depth: 0, hasChildren: false })]);
   });
 
   it("should preserve all original record properties", () => {

--- a/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
+++ b/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
@@ -15,7 +15,7 @@
  *************************************************************************
  */
 
-import { buildFlatTreeList } from "../treeUtils";
+import { buildFlatTreeList, getNodeTextClass, buildNodeMap, filterVisibleNodes, type TreeNode } from "../treeUtils";
 import type { EntityData } from "@workspaceui/api-client/src/api/types";
 
 describe("buildFlatTreeList", () => {
@@ -102,6 +102,81 @@ describe("buildFlatTreeList", () => {
       customProp: "val",
       depth: 0,
       hasChildren: false,
+    });
+  });
+});
+
+describe("getNodeTextClass", () => {
+  it("should return non-selectable style when not selectable", () => {
+    expect(getNodeTextClass(false, false)).toBe("font-semibold text-baseline-60");
+    expect(getNodeTextClass(false, true)).toBe("font-semibold text-baseline-60");
+  });
+
+  it("should return selected style when selectable and selected", () => {
+    expect(getNodeTextClass(true, true)).toBe("text-dynamic-dark font-medium");
+  });
+
+  it("should return default style when selectable and not selected", () => {
+    expect(getNodeTextClass(true, false)).toBe("text-baseline-90");
+  });
+});
+
+describe("buildNodeMap", () => {
+  it("should build a map from tree nodes", () => {
+    const nodes: TreeNode[] = [
+      { id: "A", _identifier: "Alpha", depth: 0, hasChildren: false },
+      { id: "B", _identifier: "Beta", depth: 0, hasChildren: false },
+    ];
+    const map = buildNodeMap(nodes);
+    expect(map.size).toBe(2);
+    expect(map.get("A")?._identifier).toBe("Alpha");
+    expect(map.get("B")?._identifier).toBe("Beta");
+  });
+
+  it("should return empty map for empty array", () => {
+    expect(buildNodeMap([]).size).toBe(0);
+  });
+});
+
+describe("filterVisibleNodes", () => {
+  const treeNodes: TreeNode[] = [
+    { id: "ROOT", _identifier: "Cola", depth: 0, hasChildren: true, isCharacteristic: true },
+    { id: "C1", _identifier: "Uva", depth: 1, hasChildren: false, parentId: "ROOT" },
+    { id: "C2", _identifier: "Manzana", depth: 1, hasChildren: false, parentId: "ROOT" },
+  ];
+  const nodeMap = buildNodeMap(treeNodes);
+
+  describe("search filtering", () => {
+    it("should filter by search term and keep ancestors", () => {
+      const result = filterVisibleNodes(treeNodes, nodeMap, "uva", new Set());
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe("ROOT");
+      expect(result[1].id).toBe("C1");
+    });
+
+    it("should return only matching node when search matches root", () => {
+      const result = filterVisibleNodes(treeNodes, nodeMap, "cola", new Set());
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("ROOT");
+    });
+
+    it("should return empty when no match", () => {
+      const result = filterVisibleNodes(treeNodes, nodeMap, "nonexistent", new Set());
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("collapse filtering", () => {
+    it("should hide children of collapsed nodes", () => {
+      const collapsed = new Set(["ROOT"]);
+      const result = filterVisibleNodes(treeNodes, nodeMap, "", collapsed);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("ROOT");
+    });
+
+    it("should show all nodes when nothing is collapsed", () => {
+      const result = filterVisibleNodes(treeNodes, nodeMap, "", new Set());
+      expect(result).toHaveLength(3);
     });
   });
 });

--- a/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
+++ b/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
@@ -15,7 +15,14 @@
  *************************************************************************
  */
 
-import { buildFlatTreeList, getNodeTextClass, buildNodeMap, filterVisibleNodes, type TreeNode } from "../treeUtils";
+import {
+  buildFlatTreeList,
+  getNodeTextClass,
+  buildNodeMap,
+  filterVisibleNodes,
+  buildTreeFromFilterOptions,
+  type TreeNode,
+} from "../treeUtils";
 import type { EntityData } from "@workspaceui/api-client/src/api/types";
 
 describe("buildFlatTreeList", () => {
@@ -178,5 +185,42 @@ describe("filterVisibleNodes", () => {
       const result = filterVisibleNodes(treeNodes, nodeMap, "", new Set());
       expect(result).toHaveLength(3);
     });
+  });
+});
+
+describe("buildTreeFromFilterOptions", () => {
+  it("should build tree hierarchy from filter options", () => {
+    const options = [
+      { id: "ROOT", label: "Cola", value: "Cola", isCharacteristic: true },
+      { id: "C1", label: "Uva", value: "Uva", parentId: "ROOT" },
+      { id: "C2", label: "Manzana", value: "Manzana", parentId: "ROOT" },
+    ];
+    const result = buildTreeFromFilterOptions(options);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject({ id: "ROOT", depth: 0, hasChildren: true, filterValue: "Cola" });
+    expect(result[1]).toMatchObject({ id: "C1", depth: 1, hasChildren: false, filterValue: "Uva" });
+    expect(result[2]).toMatchObject({ id: "C2", depth: 1, hasChildren: false, filterValue: "Manzana" });
+  });
+
+  it("should handle flat options without parentId", () => {
+    const options = [
+      { id: "A", label: "Alpha", value: "alpha" },
+      { id: "B", label: "Beta", value: "beta" },
+    ];
+    const result = buildTreeFromFilterOptions(options);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ depth: 0, hasChildren: false });
+    expect(result[1]).toMatchObject({ depth: 0, hasChildren: false });
+  });
+
+  it("should return empty array for empty options", () => {
+    expect(buildTreeFromFilterOptions([])).toEqual([]);
+  });
+
+  it("should preserve filterValue from original option", () => {
+    const options = [{ id: "X", label: "Display", value: "actual-value" }];
+    const result = buildTreeFromFilterOptions(options);
+    expect(result[0].filterValue).toBe("actual-value");
+    expect(result[0]._identifier).toBe("Display");
   });
 });

--- a/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
+++ b/packages/MainUI/utils/form/__tests__/treeUtils.test.ts
@@ -1,0 +1,109 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { buildFlatTreeList } from "../treeUtils";
+import type { EntityData } from "@workspaceui/api-client/src/api/types";
+
+describe("buildFlatTreeList", () => {
+  it("should return empty array for empty input", () => {
+    expect(buildFlatTreeList([])).toEqual([]);
+  });
+
+  it("should handle flat records with no parents", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "Alpha" },
+      { id: "B", _identifier: "Beta" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "A", depth: 0, hasChildren: false }),
+      expect.objectContaining({ id: "B", depth: 0, hasChildren: false }),
+    ]);
+  });
+
+  it("should nest children under parents using parentId", () => {
+    const records: EntityData[] = [
+      { id: "ROOT", _identifier: "Root", isCharacteristic: true },
+      { id: "CHILD1", _identifier: "Child 1", parentId: "ROOT" },
+      { id: "CHILD2", _identifier: "Child 2", parentId: "ROOT" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "ROOT", depth: 0, hasChildren: true }),
+      expect.objectContaining({ id: "CHILD1", depth: 1, hasChildren: false }),
+      expect.objectContaining({ id: "CHILD2", depth: 1, hasChildren: false }),
+    ]);
+  });
+
+  it("should handle multi-level nesting (3+ levels)", () => {
+    const records: EntityData[] = [
+      { id: "L0", _identifier: "Level 0" },
+      { id: "L1", _identifier: "Level 1", parentId: "L0" },
+      { id: "L2", _identifier: "Level 2", parentId: "L1" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "L0", depth: 0, hasChildren: true }),
+      expect.objectContaining({ id: "L1", depth: 1, hasChildren: true }),
+      expect.objectContaining({ id: "L2", depth: 2, hasChildren: false }),
+    ]);
+  });
+
+  it("should treat orphan records as roots", () => {
+    const records: EntityData[] = [
+      { id: "ORPHAN", _identifier: "Orphan", parentId: "NONEXISTENT" },
+      { id: "ROOT", _identifier: "Root" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ depth: 0 });
+    expect(result[1]).toMatchObject({ depth: 0 });
+  });
+
+  it("should not infinite-loop on circular references", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "A", parentId: "B" },
+      { id: "B", _identifier: "B", parentId: "A" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should handle single node", () => {
+    const records: EntityData[] = [{ id: "ONLY", _identifier: "Only Node" }];
+    const result = buildFlatTreeList(records);
+    expect(result).toEqual([
+      expect.objectContaining({ id: "ONLY", depth: 0, hasChildren: false }),
+    ]);
+  });
+
+  it("should preserve all original record properties", () => {
+    const records: EntityData[] = [
+      { id: "A", _identifier: "A", isCharacteristic: true, showOpenIcon: true, customProp: "val" },
+    ];
+    const result = buildFlatTreeList(records);
+    expect(result[0]).toMatchObject({
+      id: "A",
+      _identifier: "A",
+      isCharacteristic: true,
+      showOpenIcon: true,
+      customProp: "val",
+      depth: 0,
+      hasChildren: false,
+    });
+  });
+});

--- a/packages/MainUI/utils/form/constants.ts
+++ b/packages/MainUI/utils/form/constants.ts
@@ -112,6 +112,13 @@ export const FIELD_REFERENCE_CODES = {
   // Link — URL field, renders as clickable hyperlink in read-only
   LINK: { id: "800101", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
 
+  // Assignment — resource assignment FK (ref 33 in Classic).
+  // Uses TableDirDomainType in Classic; mapped to TableDirSelector.
+  ASSIGNMENT: { id: "33", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+
+  // Tree Reference — hierarchical FK selector (e.g. Characteristic Values)
+  TREE_REFERENCE: { id: "8C57A4A2E05F4261A1FADF47C30398AD", calloutTrigger: CALLOUT_TRIGGERS.ON_CHANGE },
+
   // Product Characteristics — always read-only concatenated description
   PRODUCT_CHARACTERISTICS: { id: "C632F1CFF5A1453EB28BDF44A70478F8", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
 } as const;

--- a/packages/MainUI/utils/form/constants.ts
+++ b/packages/MainUI/utils/form/constants.ts
@@ -105,6 +105,15 @@ export const FIELD_REFERENCE_CODES = {
 
   // Rich Text Area — HTML WYSIWYG editor
   RICH_TEXT: { id: "7CB371C13D204EB69BF370217F692999", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+
+  // Memo — large text area (same rendering as Text)
+  MEMO: { id: "34", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+
+  // Link — URL field, renders as clickable hyperlink in read-only
+  LINK: { id: "800101", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
+
+  // Product Characteristics — always read-only concatenated description
+  PRODUCT_CHARACTERISTICS: { id: "C632F1CFF5A1453EB28BDF44A70478F8", calloutTrigger: CALLOUT_TRIGGERS.ON_BLUR },
 } as const;
 
 /**

--- a/packages/MainUI/utils/form/treeUtils.ts
+++ b/packages/MainUI/utils/form/treeUtils.ts
@@ -82,3 +82,56 @@ export function buildFlatTreeList(records: EntityData[]): TreeNode[] {
 
   return result;
 }
+
+/** Returns the CSS class for a tree node label based on selectability and selection state. */
+export function getNodeTextClass(selectable: boolean, isSelected: boolean): string {
+  if (!selectable) return "font-semibold text-baseline-60";
+  return isSelected ? "text-dynamic-dark font-medium" : "text-baseline-90";
+}
+
+/** Builds a Map<id, TreeNode> for O(1) parent lookups. */
+export function buildNodeMap<T extends TreeNode>(nodes: T[]): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const node of nodes) map.set(node.id as string, node);
+  return map;
+}
+
+/**
+ * Filters tree nodes for search (keeping ancestor chain) or collapse state.
+ * When searchTerm is provided, keeps matching nodes + their ancestors.
+ * When no searchTerm, hides children of collapsed nodes.
+ */
+export function filterVisibleNodes<T extends TreeNode>(
+  treeNodes: T[],
+  nodeMap: Map<string, T>,
+  searchTerm: string,
+  collapsedNodes: Set<string>
+): T[] {
+  if (searchTerm) {
+    const lowerSearch = searchTerm.toLowerCase();
+    const matchIds = new Set(
+      treeNodes.filter((n) => (n._identifier as string).toLowerCase().includes(lowerSearch)).map((n) => n.id as string)
+    );
+    const keepIds = new Set(matchIds);
+    for (const node of treeNodes) {
+      if (matchIds.has(node.id as string)) {
+        let current: T | undefined = node;
+        while (current?.parentId && typeof current.parentId === "string") {
+          keepIds.add(current.parentId as string);
+          current = nodeMap.get(current.parentId as string);
+        }
+      }
+    }
+    return treeNodes.filter((n) => keepIds.has(n.id as string));
+  }
+
+  return treeNodes.filter((node) => {
+    let parentId = node.parentId as string | undefined;
+    while (parentId) {
+      if (collapsedNodes.has(parentId)) return false;
+      const parent = nodeMap.get(parentId);
+      parentId = parent?.parentId as string | undefined;
+    }
+    return true;
+  });
+}

--- a/packages/MainUI/utils/form/treeUtils.ts
+++ b/packages/MainUI/utils/form/treeUtils.ts
@@ -83,6 +83,25 @@ export function buildFlatTreeList(records: EntityData[]): TreeNode[] {
   return result;
 }
 
+export interface TreeFilterNode extends TreeNode {
+  filterValue: string;
+}
+
+/** Builds tree hierarchy from filter options that have parentId. */
+export function buildTreeFromFilterOptions(
+  options: { id: string; label: string; value: string; parentId?: string | null; isCharacteristic?: boolean }[]
+): TreeFilterNode[] {
+  const records = options.map((opt) => ({
+    id: opt.id,
+    _identifier: opt.label,
+    parentId: opt.parentId ?? null,
+    isCharacteristic: opt.isCharacteristic ?? false,
+    filterValue: opt.value,
+  }));
+  const nodes = buildFlatTreeList(records);
+  return nodes as TreeFilterNode[];
+}
+
 /** Returns the CSS class for a tree node label based on selectability and selection state. */
 export function getNodeTextClass(selectable: boolean, isSelected: boolean): string {
   if (!selectable) return "font-semibold text-baseline-60";

--- a/packages/MainUI/utils/form/treeUtils.ts
+++ b/packages/MainUI/utils/form/treeUtils.ts
@@ -1,0 +1,84 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import type { EntityData } from "@workspaceui/api-client/src/api/types";
+
+export interface TreeNode extends EntityData {
+  depth: number;
+  hasChildren: boolean;
+}
+
+/**
+ * Transforms a flat array of records with parentId references into a
+ * depth-annotated flat list suitable for rendering an indented tree dropdown.
+ *
+ * Root detection: a record is a root when its parentId is falsy OR
+ * references an ID not present in the dataset (orphan).
+ *
+ * Walks depth-first so children appear directly after their parent.
+ * Tracks visited nodes to prevent infinite loops from circular references.
+ */
+export function buildFlatTreeList(records: EntityData[]): TreeNode[] {
+  if (records.length === 0) return [];
+
+  const idSet = new Set(records.map((r) => r.id as string));
+  const childrenMap = new Map<string, EntityData[]>();
+  const roots: EntityData[] = [];
+
+  for (const record of records) {
+    const parentId = record.parentId as string | undefined;
+    if (!parentId || !idSet.has(parentId)) {
+      roots.push(record);
+    } else {
+      const siblings = childrenMap.get(parentId) ?? [];
+      siblings.push(record);
+      childrenMap.set(parentId, siblings);
+    }
+  }
+
+  const result: TreeNode[] = [];
+  const visited = new Set<string>();
+
+  const walk = (nodes: EntityData[], depth: number) => {
+    for (const node of nodes) {
+      const nodeId = node.id as string;
+      if (visited.has(nodeId)) continue;
+      visited.add(nodeId);
+
+      const children = childrenMap.get(nodeId) ?? [];
+      result.push({
+        ...node,
+        depth,
+        hasChildren: children.length > 0,
+      });
+      if (children.length > 0) {
+        walk(children, depth + 1);
+      }
+    }
+  };
+
+  walk(roots, 0);
+
+  // Any unvisited records (from circular references) are added as roots
+  for (const record of records) {
+    if (!visited.has(record.id as string)) {
+      result.push({ ...record, depth: 0, hasChildren: false });
+    }
+  }
+
+  return result;
+}

--- a/packages/MainUI/utils/index.ts
+++ b/packages/MainUI/utils/index.ts
@@ -45,6 +45,8 @@ export const getFieldReference = (reference?: string): FieldType => {
     case FIELD_REFERENCE_CODES.SELECTOR.id:
     case FIELD_REFERENCE_CODES.SELECTOR_AS_LINK.id:
     case FIELD_REFERENCE_CODES.TABLE_DIR_18.id:
+    case FIELD_REFERENCE_CODES.ASSIGNMENT.id:
+    case FIELD_REFERENCE_CODES.TREE_REFERENCE.id:
       return FieldType.TABLEDIR;
     case FIELD_REFERENCE_CODES.DATE.id:
       return FieldType.DATE;

--- a/packages/MainUI/utils/index.ts
+++ b/packages/MainUI/utils/index.ts
@@ -35,6 +35,10 @@ export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve
 export const getFieldReference = (reference?: string): FieldType => {
   switch (reference) {
     case FIELD_REFERENCE_CODES.STRING.id:
+    case FIELD_REFERENCE_CODES.MEMO.id:
+    case FIELD_REFERENCE_CODES.TEXT_LONG.id:
+    case FIELD_REFERENCE_CODES.LINK.id:
+    case FIELD_REFERENCE_CODES.PRODUCT_CHARACTERISTICS.id:
       return FieldType.TEXT;
     case FIELD_REFERENCE_CODES.TABLE_DIR_19.id:
     case FIELD_REFERENCE_CODES.PRODUCT.id:

--- a/packages/MainUI/utils/tableColumns.tsx
+++ b/packages/MainUI/utils/tableColumns.tsx
@@ -18,9 +18,21 @@
 import type { TranslateFunction } from "@/hooks/types";
 import { getFieldReference } from "@/utils";
 import Tag from "@workspaceui/componentlibrary/src/components/Tag";
+import Tooltip from "@workspaceui/componentlibrary/src/components/Tooltip";
 import { type Column, type Field, FieldType } from "@workspaceui/api-client/src/api/types";
 import { DEFAULT_STATUS_CONFIG, IDENTIFIER_KEY, statusConfig, yesNoConfig } from "./columnsConstants";
 import { isColorString, getContrastTextColor } from "@/utils/color/utils";
+
+// Helper function to render text/memo/richtext cells with truncation and tooltip
+export const renderTextCell = (value: unknown): React.ReactNode => {
+  if (value === null || value === undefined || value === "") return "";
+  const text = String(value);
+  return (
+    <Tooltip title={text} position="top" data-testid="Tooltip__2b5175">
+      <span className="block truncate max-w-full">{text}</span>
+    </Tooltip>
+  );
+};
 
 // Helper function to handle boolean field rendering
 const renderBooleanField = (value: Record<string, unknown>, column: Field, t?: TranslateFunction) => {

--- a/packages/api-client/src/hooks/useColumnFilterData.ts
+++ b/packages/api-client/src/hooks/useColumnFilterData.ts
@@ -118,11 +118,17 @@ const formatOptionItem = (item: Record<string, unknown>, distinctField?: string)
       item.id
   );
 
-  return {
+  const option: FilterOption = {
     id: String(item.id),
     label: identifier,
     value: identifier,
   };
+
+  // Preserve tree hierarchy fields when present (used by tree column filters)
+  if (item.parentId) option.parentId = String(item.parentId);
+  if (item.isCharacteristic) option.isCharacteristic = true;
+
+  return option;
 };
 
 export interface FetchFilterOptionsParams {

--- a/packages/api-client/src/utils/column-filter-utils.ts
+++ b/packages/api-client/src/utils/column-filter-utils.ts
@@ -23,6 +23,8 @@ export interface FilterOption {
   label: string;
   value: string;
   isTextSearch?: boolean;
+  parentId?: string;
+  isCharacteristic?: boolean;
 }
 
 export interface ColumnFilterState {

--- a/packages/api-client/src/utils/column-filter-utils.ts
+++ b/packages/api-client/src/utils/column-filter-utils.ts
@@ -25,6 +25,8 @@ export interface FilterOption {
   isTextSearch?: boolean;
   parentId?: string;
   isCharacteristic?: boolean;
+  /** HQL exists subquery for special filter criteria (e.g. Product Characteristics) */
+  existsQuery?: string;
 }
 
 export interface ColumnFilterState {

--- a/packages/api-client/src/utils/search-utils.ts
+++ b/packages/api-client/src/utils/search-utils.ts
@@ -507,6 +507,24 @@ export class LegacyColumnFilterUtils {
     ];
   }
 
+  private static extractFilterValues(values: unknown[]): { actualValues: unknown[]; isTextSearch: boolean } {
+    let isTextSearch = false;
+    const actualValues = values.map((val) => {
+      if (typeof val === "object" && val !== null && "value" in val) {
+        if ((val as Record<string, unknown>).isTextSearch) isTextSearch = true;
+        return (val as { value: unknown }).value;
+      }
+      return val;
+    });
+    return { actualValues, isTextSearch };
+  }
+
+  private static resolveFilterOperator(isTextSearch: boolean, column: Column): "iContains" | "iEquals" | "equals" {
+    if (isTextSearch) return "iContains";
+    if (ColumnFilterUtils.isTableDirColumn(column)) return "iEquals";
+    return "equals";
+  }
+
   private static handleArrayFilter(fieldName: string, values: unknown[], column: Column): BaseCriteria[] {
     if (values.length === 0) return [];
 
@@ -517,18 +535,7 @@ export class LegacyColumnFilterUtils {
       return LegacyColumnFilterUtils.buildExistsQueryCriteria(fieldName, values, String(firstObj.existsQuery));
     }
 
-    // Extract actual values from FilterOption objects if present
-    // This supports both new format (FilterOption[]) and legacy format (string[])
-    let isTextSearch = false;
-    const actualValues = values.map((val) => {
-      // If it's a FilterOption object with a value property, extract it
-      if (typeof val === "object" && val !== null && "value" in val) {
-        if ((val as any).isTextSearch) isTextSearch = true;
-        return (val as { value: unknown }).value;
-      }
-      // Otherwise use the value as-is (backward compatibility with string[])
-      return val;
-    });
+    const { actualValues, isTextSearch } = LegacyColumnFilterUtils.extractFilterValues(values);
 
     // For TABLEDIR columns, use the $_identifier field and iEquals operator (like Etendo Classic)
     const actualFieldName = ColumnFilterUtils.isTableDirColumn(column) ? `${fieldName}$_identifier` : fieldName;
@@ -540,14 +547,7 @@ export class LegacyColumnFilterUtils {
       }
     }
 
-    let operator: "iContains" | "iEquals" | "equals";
-    if (isTextSearch) {
-      operator = "iContains";
-    } else if (ColumnFilterUtils.isTableDirColumn(column)) {
-      operator = "iEquals";
-    } else {
-      operator = "equals";
-    }
+    const operator = LegacyColumnFilterUtils.resolveFilterOperator(isTextSearch, column);
 
     // SmartClient sends list/select equals criteria with value as an array (e.g. ["FATAL"]),
     // even for single selections. Classic datasources like OBPickAndExecuteDataSource require this.

--- a/packages/api-client/src/utils/search-utils.ts
+++ b/packages/api-client/src/utils/search-utils.ts
@@ -489,26 +489,33 @@ export class LegacyColumnFilterUtils {
     return result;
   }
 
+  private static buildExistsQueryCriteria(
+    fieldName: string,
+    values: unknown[],
+    existsQuery: string
+  ): BaseCriteria[] {
+    const ids = values
+      .filter((v) => typeof v === "object" && v !== null && "id" in v && !(v as Record<string, unknown>).isCharacteristic)
+      .map((v) => String((v as { id: unknown }).id));
+    if (ids.length === 0) return [];
+    return [
+      {
+        fieldName,
+        operator: "exists",
+        value: ids,
+        existsQuery,
+        isProductCharacteristicsCriteria: true,
+      } as unknown as BaseCriteria,
+    ];
+  }
+
   private static handleArrayFilter(fieldName: string, values: unknown[], column: Column): BaseCriteria[] {
     if (values.length === 0) return [];
 
     // Check for special existsQuery criteria (e.g. Product Characteristics tree filter)
     const firstObj = typeof values[0] === "object" && values[0] !== null ? (values[0] as Record<string, unknown>) : null;
     if (firstObj?.existsQuery) {
-      const existsQuery = String(firstObj.existsQuery);
-      const ids = values
-        .filter((v) => typeof v === "object" && v !== null && "id" in v && !(v as Record<string, unknown>).isCharacteristic)
-        .map((v) => String((v as { id: unknown }).id));
-      if (ids.length === 0) return [];
-      return [
-        {
-          fieldName,
-          operator: "exists",
-          value: ids,
-          existsQuery,
-          isProductCharacteristicsCriteria: true,
-        } as unknown as BaseCriteria,
-      ];
+      return LegacyColumnFilterUtils.buildExistsQueryCriteria(fieldName, values, String(firstObj.existsQuery));
     }
 
     // Extract actual values from FilterOption objects if present

--- a/packages/api-client/src/utils/search-utils.ts
+++ b/packages/api-client/src/utils/search-utils.ts
@@ -492,6 +492,25 @@ export class LegacyColumnFilterUtils {
   private static handleArrayFilter(fieldName: string, values: unknown[], column: Column): BaseCriteria[] {
     if (values.length === 0) return [];
 
+    // Check for special existsQuery criteria (e.g. Product Characteristics tree filter)
+    const firstObj = typeof values[0] === "object" && values[0] !== null ? (values[0] as Record<string, unknown>) : null;
+    if (firstObj?.existsQuery) {
+      const existsQuery = String(firstObj.existsQuery);
+      const ids = values
+        .filter((v) => typeof v === "object" && v !== null && "id" in v && !(v as Record<string, unknown>).isCharacteristic)
+        .map((v) => String((v as { id: unknown }).id));
+      if (ids.length === 0) return [];
+      return [
+        {
+          fieldName,
+          operator: "exists",
+          value: ids,
+          existsQuery,
+          isProductCharacteristicsCriteria: true,
+        } as unknown as BaseCriteria,
+      ];
+    }
+
     // Extract actual values from FilterOption objects if present
     // This supports both new format (FilterOption[]) and legacy format (string[])
     let isTextSearch = false;

--- a/packages/api-client/src/utils/search-utils.ts
+++ b/packages/api-client/src/utils/search-utils.ts
@@ -489,13 +489,11 @@ export class LegacyColumnFilterUtils {
     return result;
   }
 
-  private static buildExistsQueryCriteria(
-    fieldName: string,
-    values: unknown[],
-    existsQuery: string
-  ): BaseCriteria[] {
+  private static buildExistsQueryCriteria(fieldName: string, values: unknown[], existsQuery: string): BaseCriteria[] {
     const ids = values
-      .filter((v) => typeof v === "object" && v !== null && "id" in v && !(v as Record<string, unknown>).isCharacteristic)
+      .filter(
+        (v) => typeof v === "object" && v !== null && "id" in v && !(v as Record<string, unknown>).isCharacteristic
+      )
       .map((v) => String((v as { id: unknown }).id));
     if (ids.length === 0) return [];
     return [
@@ -513,7 +511,8 @@ export class LegacyColumnFilterUtils {
     if (values.length === 0) return [];
 
     // Check for special existsQuery criteria (e.g. Product Characteristics tree filter)
-    const firstObj = typeof values[0] === "object" && values[0] !== null ? (values[0] as Record<string, unknown>) : null;
+    const firstObj =
+      typeof values[0] === "object" && values[0] !== null ? (values[0] as Record<string, unknown>) : null;
     if (firstObj?.existsQuery) {
       return LegacyColumnFilterUtils.buildExistsQueryCriteria(fieldName, values, String(firstObj.existsQuery));
     }

--- a/playwright-tests/e2e/smoke/01_Sales/SALbAddSalesInvoicePaymentTest.spec.ts
+++ b/playwright-tests/e2e/smoke/01_Sales/SALbAddSalesInvoicePaymentTest.spec.ts
@@ -81,6 +81,14 @@ test.describe("Sales Invoice - Add Payment", () => {
     await page.keyboard.press("Enter");
     await formInitDone;
 
+    // Wait for callout to finish populating fields (UOM, Tax, Price) after product selection.
+    // The FormInitializationComponent response arrives first, but the callout may still be
+    // applying values. Wait for the UOM field to be populated as a reliable signal.
+    await expect(page.locator('[aria-describedby="UOM-help"]')).toContainText(/.+/, { timeout: 15_000 });
+
+    // Also wait for network to settle — callout responses may still be in flight
+    await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {});
+
     // Set Invoiced Quantity: 100 (large qty ensures gross≈220 far exceeds any accumulated
     // Customer A credits from FINb test runs, preventing silent auto-payment of the invoice)
     await page.locator('[data-testid="TextInput__2999"]').waitFor({ state: "visible", timeout: 15_000 });
@@ -95,9 +103,10 @@ test.describe("Sales Invoice - Add Payment", () => {
       input.dispatchEvent(new Event("input", { bubbles: true }));
       input.dispatchEvent(new Event("change", { bubbles: true }));
     });
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(1000);
 
-    // Save line
+    // Save line — wait for network to settle before saving to avoid race with pending callouts
+    await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => {});
     await page.locator("button.toolbar-button-save").last().click();
     await closeToastIfPresent(page);
 

--- a/playwright-tests/e2e/smoke/03_Procurement/PROcPurchaseInvoiceAddPaymentTest.spec.ts
+++ b/playwright-tests/e2e/smoke/03_Procurement/PROcPurchaseInvoiceAddPaymentTest.spec.ts
@@ -147,14 +147,40 @@ test.describe("Purchase Invoice with payment registration @smoke", () => {
         .first()
         .click();
 
-      // Execute payment
+      // Execute — set up toast watcher BEFORE clicking so we don't miss it
+      const successToast = page
+        .waitForSelector('[data-sonner-toast][data-type="success"]', {
+          state: "visible",
+          timeout: 30_000,
+        })
+        .catch(() => null);
       await page.locator('[data-testid^="ExecuteButton"][data-testid$="__761503"]').click();
 
       // ── Step 7: Verify payment success ───────────────────────────────────────
-      // Verify payment creation via success toast — same pattern as SALbAddSalesInvoicePaymentTest
+      // Wait for modal to close (indicates execution completed)
+      await page
+        .locator(".fixed.inset-0")
+        .waitFor({ state: "hidden", timeout: 30_000 })
+        .catch(() => null);
+      await successToast; // resolves or null if toast already dismissed
+
+      // ── Step 8: Verify Payment Plan tab ──────────────────────────────────────
+      // The success toast (Step 7) already confirms the payment was created.
+      // Here we just verify the Payment Plan grid shows a record with a non-zero Paid Amount.
+      await page.locator('button[title="Payment Plan"]').waitFor({ state: "visible", timeout: 15_000 });
+      await page.locator('button[title="Payment Plan"]').click();
+
+      await page
+        .locator("button.toolbar-button-refresh")
+        .filter({ visible: true })
+        .first()
+        .waitFor({ state: "visible", timeout: 10_000 });
+      await page.locator("button.toolbar-button-refresh").filter({ visible: true }).first().click();
+
+      // Confirm at least one payment plan row is visible (Lines table rows are hidden while Payment Plan is active)
       await expect(
-        page.locator('[data-sonner-toast][data-type="success"]').filter({ hasText: /Created Payment:\s*\d+\./ })
-      ).toBeVisible({ timeout: 30_000 });
+        page.locator("tbody.MuiTableBody-root tr.MuiTableRow-root").filter({ visible: true }).first()
+      ).toBeVisible({ timeout: 10_000 });
     }
   );
 });

--- a/playwright-tests/e2e/smoke/03_Procurement/PROcPurchaseInvoiceAddPaymentTest.spec.ts
+++ b/playwright-tests/e2e/smoke/03_Procurement/PROcPurchaseInvoiceAddPaymentTest.spec.ts
@@ -147,40 +147,14 @@ test.describe("Purchase Invoice with payment registration @smoke", () => {
         .first()
         .click();
 
-      // Execute — set up toast watcher BEFORE clicking so we don't miss it
-      const successToast = page
-        .waitForSelector('[data-sonner-toast][data-type="success"]', {
-          state: "visible",
-          timeout: 30_000,
-        })
-        .catch(() => null);
+      // Execute payment
       await page.locator('[data-testid^="ExecuteButton"][data-testid$="__761503"]').click();
 
       // ── Step 7: Verify payment success ───────────────────────────────────────
-      // Wait for modal to close (indicates execution completed)
-      await page
-        .locator(".fixed.inset-0")
-        .waitFor({ state: "hidden", timeout: 30_000 })
-        .catch(() => null);
-      await successToast; // resolves or null if toast already dismissed
-
-      // ── Step 8: Verify Payment Plan tab ──────────────────────────────────────
-      // The success toast (Step 7) already confirms the payment was created.
-      // Here we just verify the Payment Plan grid shows a record with a non-zero Paid Amount.
-      await page.locator('button[title="Payment Plan"]').waitFor({ state: "visible", timeout: 15_000 });
-      await page.locator('button[title="Payment Plan"]').click();
-
-      await page
-        .locator("button.toolbar-button-refresh")
-        .filter({ visible: true })
-        .first()
-        .waitFor({ state: "visible", timeout: 10_000 });
-      await page.locator("button.toolbar-button-refresh").filter({ visible: true }).first().click();
-
-      // Confirm at least one payment plan row is visible (Lines table rows are hidden while Payment Plan is active)
+      // Verify payment creation via success toast — same pattern as SALbAddSalesInvoicePaymentTest
       await expect(
-        page.locator("tbody.MuiTableBody-root tr.MuiTableRow-root").filter({ visible: true }).first()
-      ).toBeVisible({ timeout: 10_000 });
+        page.locator('[data-sonner-toast][data-type="success"]').filter({ hasText: /Created Payment:\s*\d+\./ })
+      ).toBeVisible({ timeout: 30_000 });
     }
   );
 });


### PR DESCRIPTION
Summary

  This PR implements two missing field reference types from Etendo Classic and adds a tree-aware
  column filter for Product Characteristics.

  New Reference Types

  Assignment (ref 33) — S_ResourceAssignment_ID fields used in Resource Booking / Manufacturing
  windows.
  - Mapped to existing TableDirSelector (uses TableDirDomainType in Classic)
  - Works in FormView, grid cell editor, and grid column filter (all as TableDir dropdown)

  Tree Reference (ref 8C57A4A2...) — Hierarchical FK selector for M_Ch_Value_ID (Characteristic
  Value) fields.
  - New TreeSelector component in FormView with:
    - Indented tree hierarchy (root nodes bold + non-selectable, children selectable)
    - Expand/collapse chevrons on parent nodes
    - Search with ancestor chain preservation
    - Keyboard navigation that skips non-selectable nodes
  - Grid column mapped to TABLEDIR for inline editing and standard dropdown filter

  Product Characteristics Column Filter

  The characteristicDescription column in the Product grid (ref C632F1CFF5A1453EB28BDF44A70478F8)
  now has a tree-aware dropdown filter instead of a plain text filter:
  - TreeColumnFilter component with hierarchical rendering, expand/collapse, and search
  - Loads data from the Product Characteristics datasource (BE2735798ECC4EF88D131F16F1C4EC72)
  - Builds special exists criteria with HQL subquery for backend filtering (same format as Classic)

  Test Plan

  - Assignment field (ref 33): Open a window with S_ResourceAssignment_ID field (Resource Booking /
   Manufacturing). Verify it renders as a TableDir dropdown in form view and grid.
  - Tree Reference field (ref 8C57...): Open a window with M_Ch_Value_ID field (Product > Product
  Characteristics subtab). Verify tree dropdown with hierarchy, expand/collapse, and search.
  - Product grid — Characteristic Description column filter: Open Product window. Click the filter
  dropdown on "Characteristic Description" column. Verify:
    - Tree loads with characteristics as root nodes (bold, non-selectable) and values as children
  (selectable)
    - Selecting a value (e.g., "Uva") filters products correctly
    - Expand/collapse chevrons work
    - Search preserves ancestor context
  - No regressions: Open Sales Order (TableDir fields), Business Partner (Select/List fields).
  Verify existing selectors and filters still work correctly.