### PR TITLE
Feature ETP-3770: Add optimistic locking via updated timestamp

### DIFF
--- a/packages/ComponentLibrary/src/locales/en.ts
+++ b/packages/ComponentLibrary/src/locales/en.ts
@@ -137,6 +137,7 @@ const en = {
     noRecordsError: "There is no records selected",
     noRecords: "Please create a new record",
     copyError: "Copy failed! Please try again or contact support.",
+    staleObjectError: "The record has been modified by another user or process. Please refresh and try again.",
   },
   errors: {
     tableError: {

--- a/packages/ComponentLibrary/src/locales/es.ts
+++ b/packages/ComponentLibrary/src/locales/es.ts
@@ -136,6 +136,8 @@ const es = {
     noRecordsError: "No hay registros seleccionados",
     noRecords: "Por favor, crea un nuevo registro",
     copyError: "¡Copiado erróneo! Inténtelo nuevamente o contáctese con soporte.",
+    staleObjectError:
+      "El registro ha sido modificado por otro usuario o proceso. Por favor, actualice e intente nuevamente.",
   },
   errors: {
     tableError: {

--- a/packages/MainUI/components/Table/utils/saveOperations.ts
+++ b/packages/MainUI/components/Table/utils/saveOperations.ts
@@ -46,7 +46,7 @@ export function isStaleObjectError(errorMessage: string | undefined): boolean {
  * @param tab The tab metadata to filter valid fields
  * @returns The formatted payload
  */
-function buildSavePayload({
+export function buildSavePayload({
   values,
   oldValues,
   mode,

--- a/packages/MainUI/components/Table/utils/saveOperations.ts
+++ b/packages/MainUI/components/Table/utils/saveOperations.ts
@@ -28,6 +28,16 @@ import { getMergedRowData } from "./editingRowUtils";
 import { validateRowForSave } from "./validationUtils";
 
 /**
+ * Detects stale-object (optimistic lock) errors returned by Etendo Classic.
+ * The backend throws OBStaleObjectException with message "@OBJSON_StaleDate@",
+ * which Classic's Utility.translateError may resolve to a human-readable string.
+ */
+export function isStaleObjectError(errorMessage: string | undefined): boolean {
+  if (!errorMessage) return false;
+  return errorMessage.includes("OBJSON_StaleDate") || errorMessage.includes("APRM_StaleDate");
+}
+
+/**
  * Builds the payload for saving a record via the datasource servlet
  * @param values The record data to save
  * @param oldValues The original record data (for updates)
@@ -49,11 +59,10 @@ function buildSavePayload({
   csrfToken: string;
   tab?: Tab;
 }) {
-  // Fields that should be excluded from the payload
-  const auditFields = ["creationDate", "createdBy", "updated", "updatedBy"];
-
-  // When creating a new record (add operation), exclude the id field as well
-  const excludedFields = mode === FormMode.NEW ? [...auditFields, "id"] : auditFields;
+  // Fields that should be excluded from the payload.
+  // In EDIT mode, "updated" is kept so the backend can detect stale-object conflicts.
+  const alwaysExcluded = ["creationDate", "createdBy", "updatedBy"];
+  const excludedFields = mode === FormMode.NEW ? [...alwaysExcluded, "updated", "id"] : alwaysExcluded;
 
   // Build a set of valid field names from tab.fields (using hqlName)
   // This will filter out display names like "Transaction Document" and keep only "transactionDocument"
@@ -131,7 +140,7 @@ function buildSavePayload({
 
   if (mode !== FormMode.NEW && oldValues) {
     const filteredOldValues = Object.entries(oldValues).reduce((acc, [key, value]) => {
-      if (!auditFields.includes(key)) {
+      if (!excludedFields.includes(key)) {
         acc[key] = value;
       }
       return acc;
@@ -244,8 +253,11 @@ function shouldAbortRetry(result: SaveResult, attempt: number, maxRetries: numbe
   // Don't retry validation errors - they won't change
   const hasValidationErrors = result.errors?.some((error) => error.type === "server" && error.field !== "_general");
 
-  // Return true if there are validation errors or we've reached max retries
-  return (hasValidationErrors ?? false) || attempt === maxRetries;
+  // Don't retry stale-object conflicts — they require user action (refresh)
+  const hasStaleError = result.errors?.some((error) => isStaleObjectError(error.message));
+
+  // Return true if there are validation/stale errors or we've reached max retries
+  return (hasValidationErrors ?? false) || (hasStaleError ?? false) || attempt === maxRetries;
 }
 
 /**
@@ -392,6 +404,8 @@ function prepareSaveData(
   mode: FormMode
 ): { values: EntityData; oldValues?: EntityData } {
   const shouldRemoveId = shouldRemoveIdFields(tab.entityName, mode);
+  // `saveOperation.data` is Partial<EntityData>; the cast is intentional — at save
+  // time the accumulated edits form a complete record subset (no undefined values).
   let processedValues: EntityData = { ...saveOperation.data } as EntityData;
   let processedOriginalData: EntityData | undefined = saveOperation.originalData
     ? ({ ...saveOperation.originalData } as EntityData)

--- a/packages/MainUI/hooks/useFormAction.ts
+++ b/packages/MainUI/hooks/useFormAction.ts
@@ -25,6 +25,7 @@ import { useUserStore } from "@/stores/userStore";
 import { useUserContext } from "@/hooks/useUserContext";
 import { normalizeDates } from "@/utils/form/normalizeDates";
 import { DEFAULT_CSRF_TOKEN_ERROR, DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR } from "@/utils/session/constants";
+import { isStaleObjectError } from "@/components/Table/utils/saveOperations";
 import { useTranslation } from "./useTranslation";
 import type { SaveOptions } from "@/contexts/ToolbarContext";
 
@@ -138,6 +139,10 @@ export const useFormAction = ({
           logout();
           setLoginErrorText(t("login.errors.noAccessTableNoView.title"));
           setLoginErrorDescription(t("login.errors.noAccessTableNoView.description"));
+          return;
+        }
+        if (isStaleObjectError(errorMessage)) {
+          onError?.(t("status.staleObjectError"));
           return;
         }
         onError?.(String(err));

--- a/packages/MainUI/utils/index.ts
+++ b/packages/MainUI/utils/index.ts
@@ -23,12 +23,8 @@ import {
   type Tab,
   type WindowMetadata,
 } from "@workspaceui/api-client/src/api/types";
-import {
-  FIELD_REFERENCE_CODES,
-  getPasswordFieldNames,
-  shouldExcludePasswordField,
-  PASSWORD_PLACEHOLDER,
-} from "./form/constants";
+import { FIELD_REFERENCE_CODES } from "./form/constants";
+import { buildSavePayload } from "@/components/Table/utils/saveOperations";
 
 export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -359,49 +355,10 @@ export const buildFormPayload = ({
   csrfToken: string;
   tab?: Tab;
 }) => {
-  // In EDIT mode, "updated" is kept so the backend can detect stale-object conflicts.
-  const alwaysExcluded = ["creationDate", "createdBy", "updatedBy"];
-  const excludedFields = mode === FormMode.NEW ? [...alwaysExcluded, "updated", "id"] : alwaysExcluded;
-  const passwordFields = getPasswordFieldNames(tab);
-  const isNewRecord = mode === FormMode.NEW;
-
-  const filteredValues = Object.entries(values).reduce((acc, [key, value]) => {
-    if (!excludedFields.includes(key)) {
-      if (shouldExcludePasswordField(key, value, passwordFields, isNewRecord)) {
-        return acc;
-      }
-      acc[key] = value;
-      if (passwordFields.has(key) && value && value !== PASSWORD_PLACEHOLDER) {
-        acc[`${key}_cleartext`] = value;
-      }
-    }
-    return acc;
-  }, {} as EntityData);
+  const payload = buildSavePayload({ values, oldValues, mode, csrfToken, tab });
 
   if (tab?.fields) {
-    applyExtensionFieldMappings(filteredValues, tab.fields);
-  }
-
-  const payload: any = {
-    dataSource: "isc_OBViewDataSource_0",
-    operationType: mode === FormMode.NEW ? "add" : "update",
-    componentId: "isc_OBViewForm_0",
-    data: {
-      accountingDate: new Date(),
-      ...filteredValues,
-    },
-    csrfToken,
-  };
-
-  if (mode !== FormMode.NEW && oldValues) {
-    const filteredOldValues = Object.entries(oldValues).reduce((acc, [key, value]) => {
-      if (!excludedFields.includes(key)) {
-        acc[key] = value;
-      }
-      return acc;
-    }, {} as EntityData);
-
-    payload.oldValues = filteredOldValues;
+    applyExtensionFieldMappings(payload.data, tab.fields);
   }
 
   return payload;

--- a/packages/MainUI/utils/index.ts
+++ b/packages/MainUI/utils/index.ts
@@ -359,8 +359,9 @@ export const buildFormPayload = ({
   csrfToken: string;
   tab?: Tab;
 }) => {
-  const auditFields = ["creationDate", "createdBy", "updated", "updatedBy"];
-  const excludedFields = mode === FormMode.NEW ? [...auditFields, "id"] : auditFields;
+  // In EDIT mode, "updated" is kept so the backend can detect stale-object conflicts.
+  const alwaysExcluded = ["creationDate", "createdBy", "updatedBy"];
+  const excludedFields = mode === FormMode.NEW ? [...alwaysExcluded, "updated", "id"] : alwaysExcluded;
   const passwordFields = getPasswordFieldNames(tab);
   const isNewRecord = mode === FormMode.NEW;
 
@@ -394,7 +395,7 @@ export const buildFormPayload = ({
 
   if (mode !== FormMode.NEW && oldValues) {
     const filteredOldValues = Object.entries(oldValues).reduce((acc, [key, value]) => {
-      if (!auditFields.includes(key)) {
+      if (!excludedFields.includes(key)) {
         acc[key] = value;
       }
       return acc;


### PR DESCRIPTION
## Summary
- Send the `updated` field in EDIT save payloads so the backend's `JsonToDataConverter` can detect stale-object conflicts (`OBStaleObjectException`)
- Detect `OBJSON_StaleDate` / `APRM_StaleDate` error responses and show a dedicated, translated message instead of a raw server error
- Prevent stale-object errors from being retried (they require user action)
- Fix minor Sonar issues (unnecessary type assertions in `saveOperations.ts`)

## Test plan
- [ ] Open a record in form view, edit a field but don't save
- [ ] In another tab/session, edit and save the same record
- [ ] Go back to the first tab and save — verify the stale object error message appears
- [ ] Repeat in grid inline edit mode
- [ ] Verify new records (NEW mode) still save correctly without sending `updated`
- [ ] Verify the error message is translated in both EN and ES

🤖 Generated with [Claude Code](https://claude.com/claude-code)