### PR TITLE
Feature ETP-3772: Fix session race conditions, widget params, and callout error display

### DIFF
--- a/packages/MainUI/app/api/auth/login/route.ts
+++ b/packages/MainUI/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 export const runtime = "nodejs";
-import { setErpSessionCookie } from "@/app/api/_utils/sessionStore";
+import { setErpSessionCookie, setErpCsrfToken } from "@/app/api/_utils/sessionStore";
 import { extractBearerToken } from "@/lib/auth";
 import { joinUrl } from "../../_utils/url";
 import { handleLoginError } from "../../_utils/sessionErrors";
@@ -53,30 +53,37 @@ async function fetchErpLogin(
 }
 
 function extractJSessionId(erpResponse: Response): string | null {
-  const jsession: string | null = null;
+  // getSetCookie() is the correct Node.js 18+ API for multiple Set-Cookie headers
+  const cookies = (erpResponse.headers as any).getSetCookie?.() as string[] | undefined;
+  if (cookies) {
+    for (const cookie of cookies) {
+      const match = cookie.match(/JSESSIONID=([^;]+)/);
+      if (match) return match[1];
+    }
+  }
 
+  // Fallback: headers.get concatenates Set-Cookie values with ", "
   const single = erpResponse.headers.get("set-cookie");
   if (single) {
     const match = single.match(/JSESSIONID=([^;]+)/);
     if (match) return match[1];
   }
 
-  for (const [key, value] of erpResponse.headers.entries()) {
-    if (key.toLowerCase() === "set-cookie") {
-      const match = value.match(/JSESSIONID=([^;]+)/);
-      if (match) return match[1];
-    }
-  }
-
-  return jsession;
+  return null;
 }
 
 function storeCookieForToken(erpResponse: Response, data: any): void {
   try {
     const jsession = extractJSessionId(erpResponse);
     const csrfToken = erpResponse.headers.get("X-CSRF-Token") || erpResponse.headers.get("x-csrf-token") || null;
-    const cookieHeader = `JSESSIONID=${jsession}`;
-    setErpSessionCookie(data.token, { cookieHeader, csrfToken });
+    if (!jsession) {
+      // No JSESSIONID in response — store only CSRF token, don't poison the store with "JSESSIONID=null"
+      if (csrfToken) {
+        setErpCsrfToken(data.token, csrfToken);
+      }
+      return;
+    }
+    setErpSessionCookie(data.token, { cookieHeader: `JSESSIONID=${jsession}`, csrfToken });
   } catch (e) {
     console.error("Error storing session cookie:", e);
     throw new Error("Failed to store session cookie");
@@ -91,13 +98,8 @@ export async function POST(request: NextRequest) {
     const erpLoginUrl = joinUrl(process.env.ETENDO_CLASSIC_URL, "/sws/login");
 
     const userToken = extractBearerToken(request);
-    let cookieHeader: string | null = null;
-
-    if (userToken) {
-      cookieHeader = "JSESSIONID=null";
-    }
-
-    const erpResponse = await fetchErpLogin(erpLoginUrl, body, cookieHeader || undefined, userToken || undefined);
+    // ponytail: don't send "JSESSIONID=null" — let the backend create a fresh session from the Bearer token
+    const erpResponse = await fetchErpLogin(erpLoginUrl, body, undefined, userToken || undefined);
 
     if (!erpResponse || !erpResponse.ok) {
       throw new Error("ERP login failed", { cause: erpResponse });

--- a/packages/MainUI/app/api/auth/login/route.ts
+++ b/packages/MainUI/app/api/auth/login/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 export const runtime = "nodejs";
-import { setErpSessionCookie, setErpCsrfToken } from "@/app/api/_utils/sessionStore";
+import { setErpSessionCookie, setErpCsrfToken, getErpSessionCookie } from "@/app/api/_utils/sessionStore";
 import { extractBearerToken } from "@/lib/auth";
 import { joinUrl } from "../../_utils/url";
 import { handleLoginError } from "../../_utils/sessionErrors";
@@ -98,8 +98,9 @@ export async function POST(request: NextRequest) {
     const erpLoginUrl = joinUrl(process.env.ETENDO_CLASSIC_URL, "/sws/login");
 
     const userToken = extractBearerToken(request);
-    // ponytail: don't send "JSESSIONID=null" — let the backend create a fresh session from the Bearer token
-    const erpResponse = await fetchErpLogin(erpLoginUrl, body, undefined, userToken || undefined);
+    // Forward the existing JSESSIONID (if any) so the backend can associate/invalidate the old session
+    const existingCookie = userToken ? getErpSessionCookie(userToken) : null;
+    const erpResponse = await fetchErpLogin(erpLoginUrl, body, existingCookie || undefined, userToken || undefined);
 
     if (!erpResponse || !erpResponse.ok) {
       throw new Error("ERP login failed", { cause: erpResponse });

--- a/packages/MainUI/components/Table/hooks/__tests__/useInlineCallout.test.ts
+++ b/packages/MainUI/components/Table/hooks/__tests__/useInlineCallout.test.ts
@@ -52,8 +52,8 @@ describe("useInlineCallout – error detection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (globalCalloutManager.isSuppressed as jest.Mock).mockReturnValue(false);
-    (globalCalloutManager.executeCallout as jest.Mock).mockImplementation(
-      (_name: string, fn: () => Promise<void>) => fn()
+    (globalCalloutManager.executeCallout as jest.Mock).mockImplementation((_name: string, fn: () => Promise<void>) =>
+      fn()
     );
   });
 

--- a/packages/MainUI/components/Table/hooks/__tests__/useInlineCallout.test.ts
+++ b/packages/MainUI/components/Table/hooks/__tests__/useInlineCallout.test.ts
@@ -1,0 +1,110 @@
+import { renderHook, act } from "@testing-library/react";
+import { toast } from "sonner";
+import { Metadata } from "@workspaceui/api-client/src/api/metadata";
+import { useInlineCallout } from "../useInlineCallout";
+import { globalCalloutManager } from "@/services/callouts";
+
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn() },
+}));
+jest.mock("@workspaceui/api-client/src/api/metadata", () => ({
+  Metadata: {
+    kernelClient: { post: jest.fn() },
+  },
+}));
+jest.mock("@/utils/logger");
+jest.mock("@/utils/debug", () => ({ isDebugCallouts: () => false }));
+jest.mock("@/utils", () => ({
+  buildPayloadByInputName: jest.fn(() => ({ inpField1: "newVal" })),
+}));
+jest.mock("@workspaceui/api-client/src/utils/metadata", () => ({
+  getFieldsByColumnName: jest.fn(() => ({
+    entityKeyCol: { inputName: "inpKeyName" },
+  })),
+}));
+jest.mock("@/services/callouts", () => ({
+  globalCalloutManager: {
+    isSuppressed: jest.fn(() => false),
+    executeCallout: jest.fn((_name: string, fn: () => Promise<void>) => fn()),
+    suppress: jest.fn(),
+    resume: jest.fn(),
+  },
+}));
+
+const mockTab = {
+  id: "tab1",
+  table: "table1",
+  entityName: "TestEntity",
+  window: "window1",
+  fields: {
+    id: { columnName: "entityKeyCol" },
+    field1: { column: { dbColumnName: "field1", entityKey: false }, inputName: "inpField1" },
+  },
+} as any;
+
+const mockField = {
+  inputName: "inpField1",
+  hqlName: "field1",
+  column: { callout: "SomeCallout", entityKey: false },
+} as any;
+
+describe("useInlineCallout – error detection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (globalCalloutManager.isSuppressed as jest.Mock).mockReturnValue(false);
+    (globalCalloutManager.executeCallout as jest.Mock).mockImplementation(
+      (_name: string, fn: () => Promise<void>) => fn()
+    );
+  });
+
+  it("should show toast and not apply values when backend returns status -1", async () => {
+    (Metadata.kernelClient.post as jest.Mock).mockResolvedValue({
+      data: { response: { status: -1, error: { message: "Inline validation failed" } } },
+    });
+
+    const mockOnApply = jest.fn();
+    const { result } = renderHook(() =>
+      useInlineCallout({
+        field: mockField,
+        tab: mockTab,
+        rowId: "row1",
+        parentId: "parent1",
+        session: { inpRole: "role1" },
+        currentRowData: { inpField1: "oldVal" },
+        onApplyCalloutValues: mockOnApply,
+      })
+    );
+
+    await act(async () => {
+      await result.current("newVal");
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Inline validation failed");
+    expect(mockOnApply).not.toHaveBeenCalled();
+  });
+
+  it("should apply column values and not show toast on successful callout", async () => {
+    (Metadata.kernelClient.post as jest.Mock).mockResolvedValue({
+      data: { columnValues: { inpField2: { value: "set-by-callout" } } },
+    });
+
+    const mockOnApply = jest.fn();
+    const { result } = renderHook(() =>
+      useInlineCallout({
+        field: mockField,
+        tab: mockTab,
+        rowId: "row1",
+        session: { inpRole: "role1" },
+        currentRowData: { inpField1: "oldVal" },
+        onApplyCalloutValues: mockOnApply,
+      })
+    );
+
+    await act(async () => {
+      await result.current("newVal");
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mockOnApply).toHaveBeenCalledWith({ inpField2: { value: "set-by-callout" } });
+  });
+});

--- a/packages/MainUI/components/Table/hooks/useInlineCallout.ts
+++ b/packages/MainUI/components/Table/hooks/useInlineCallout.ts
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useRef } from "react";
+import { toast } from "sonner";
 import type { Field, FormInitializationResponse, Tab } from "@workspaceui/api-client/src/api/types";
 import { Metadata } from "@workspaceui/api-client/src/api/metadata";
 import { logger } from "@/utils/logger";
@@ -69,6 +70,14 @@ export const useInlineCallout = ({
 
         if (!response?.data) {
           throw new Error(`No data returned from callout for field "${field.inputName}".`);
+        }
+
+        const rawData = response.data;
+        if (rawData?.response?.status === -1) {
+          const errorMsg = rawData.response.error?.message || "Unknown callout error";
+          logger.warn(`[InlineCallout] Backend callout error for "${field.inputName}": ${errorMsg}`);
+          toast.error(errorMsg);
+          return null;
         }
 
         return response.data as FormInitializationResponse;

--- a/packages/MainUI/components/Toolbar/Modals/EmailSendModal.tsx
+++ b/packages/MainUI/components/Toolbar/Modals/EmailSendModal.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from "react";
+import type React from "react";
+import { useRef, useState } from "react";
 import { useForm, Controller } from "react-hook-form";
 import Modal from "../../Modal";
 import Button from "../../../../ComponentLibrary/src/components/Button/Button";

--- a/packages/MainUI/components/Toolbar/Modals/__tests__/EmailSendModal.test.tsx
+++ b/packages/MainUI/components/Toolbar/Modals/__tests__/EmailSendModal.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import EmailSendModal from "../EmailSendModal";
 import "@testing-library/jest-dom";

--- a/packages/MainUI/components/Toolbar/Toolbar.tsx
+++ b/packages/MainUI/components/Toolbar/Toolbar.tsx
@@ -43,7 +43,6 @@ import {
   type ProcessResponse,
 } from "../ProcessModal/types";
 import { LegacyProcessUnresolvedError } from "@/utils/processes/manual/errors";
-import EmailIcon from "@mui/icons-material/Email";
 import EmailSendModal, { type EmailFormData } from "./Modals/EmailSendModal";
 import ProcessMenu from "./Menus/ProcessMenu";
 import SaveViewMenu from "./Menus/SaveViewMenu";

--- a/packages/MainUI/components/Toolbar/__testUtils__/toolbarMocks.tsx
+++ b/packages/MainUI/components/Toolbar/__testUtils__/toolbarMocks.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const UseSelectedMock = {
   useSelected: () => ({ graph: { getChildren: () => [] } }),
 };

--- a/packages/MainUI/contexts/window.tsx
+++ b/packages/MainUI/contexts/window.tsx
@@ -19,8 +19,7 @@
 import { useEffect, useRef, useCallback, useMemo } from "react";
 import { FocusProvider } from "@/contexts/focus";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { MRT_VisibilityState, MRT_ColumnFiltersState, MRT_SortingState } from "material-react-table";
-import { type TabFormState } from "@/utils/url/constants";
+import type { TabFormState } from "@/utils/url/constants";
 import {
   type WindowState,
   type TableState,

--- a/packages/MainUI/hooks/__tests__/useCallout.test.ts
+++ b/packages/MainUI/hooks/__tests__/useCallout.test.ts
@@ -20,6 +20,7 @@ import { renderHook } from "@testing-library/react";
 import { useCallout } from "../useCallout";
 import { useTabContext } from "@/contexts/tab";
 import { Metadata } from "@workspaceui/api-client/src/api/metadata";
+import { toast } from "sonner";
 
 // Mocks
 jest.mock("@/contexts/tab");
@@ -29,6 +30,9 @@ jest.mock("@workspaceui/api-client/src/api/metadata", () => ({
   },
 }));
 jest.mock("@/utils/logger");
+jest.mock("sonner", () => ({
+  toast: { error: jest.fn() },
+}));
 
 describe("useCallout hook", () => {
   const mockTab = { id: "tab1" } as any;
@@ -64,15 +68,45 @@ describe("useCallout hook", () => {
     expect(response).toEqual({ columnValues: { f1: "v1" } });
   });
 
-  it("should handle backend error status", async () => {
+  it("should handle backend error status and show toast", async () => {
     (Metadata.kernelClient.post as jest.Mock).mockResolvedValue({
-      data: { response: { status: -1, error: { message: "Error" } } },
+      data: { response: { status: -1, error: { message: "Validation failed" } } },
     });
 
     const { result } = renderHook(() => useCallout({ field: mockField }));
     const response = await result.current({});
 
     expect(response).toBeUndefined();
+    expect(toast.error).toHaveBeenCalledWith("Validation failed");
+  });
+
+  it("should not show toast on successful callout", async () => {
+    (Metadata.kernelClient.post as jest.Mock).mockResolvedValue({
+      data: { columnValues: { f1: "v1" } },
+    });
+
+    const { result } = renderHook(() => useCallout({ field: mockField }));
+    await result.current({});
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("should show separate toast for each failing callout", async () => {
+    (Metadata.kernelClient.post as jest.Mock)
+      .mockResolvedValueOnce({
+        data: { response: { status: -1, error: { message: "Error on field A" } } },
+      })
+      .mockResolvedValueOnce({
+        data: { response: { status: -1, error: { message: "Error on field B" } } },
+      });
+
+    const { result } = renderHook(() => useCallout({ field: mockField }));
+    await result.current({});
+    await result.current({});
+
+    expect(toast.error).toHaveBeenCalledTimes(2);
+    expect(toast.error).toHaveBeenCalledWith("Error on field A");
+    expect(toast.error).toHaveBeenCalledWith("Error on field B");
   });
 
   it("should handle network or other errors", async () => {

--- a/packages/MainUI/hooks/useCallout.ts
+++ b/packages/MainUI/hooks/useCallout.ts
@@ -20,6 +20,7 @@ import type { Field, FormInitializationResponse } from "@workspaceui/api-client/
 import { Metadata } from "@workspaceui/api-client/src/api/metadata";
 import type { FieldValues } from "react-hook-form";
 import { logger } from "@/utils/logger";
+import { toast } from "sonner";
 import { useTabContext } from "@/contexts/tab";
 
 export interface UseCalloutProps {
@@ -60,6 +61,7 @@ export const useCallout = ({ field, parentId = "null", rowId = "null", changedCo
         if (rawData?.response?.status === -1) {
           const errorMsg = rawData.response.error?.message || "Unknown callout error";
           logger.warn(`Backend callout error for "${field.inputName}": ${errorMsg}`);
+          toast.error(errorMsg);
           return undefined;
         }
 

--- a/packages/MainUI/hooks/useMenu.ts
+++ b/packages/MainUI/hooks/useMenu.ts
@@ -41,12 +41,14 @@ export const useMenu = (token: string | null, currentRole?: CurrentRole, languag
     [showLoading, hideLoading]
   );
 
+  // ponytail: use currentRole.id (primitive) as dep, not the object ref — avoids double-fire
+  // when language and currentRole change in separate render cycles during role switch
+  const currentRoleId = currentRole?.id;
   useEffect(() => {
-    if (token && currentRole) {
+    if (token && currentRoleId) {
       fetchMenu(true);
     }
-    // ponytail: token is a guard, not a trigger — currentRole changes only after the session is fully initialized
-  }, [currentRole, fetchMenu, language]);
+  }, [currentRoleId, fetchMenu, language]);
 
   return menu;
 };

--- a/packages/MainUI/hooks/useMenu.ts
+++ b/packages/MainUI/hooks/useMenu.ts
@@ -45,7 +45,8 @@ export const useMenu = (token: string | null, currentRole?: CurrentRole, languag
     if (token && currentRole) {
       fetchMenu(true);
     }
-  }, [token, currentRole, fetchMenu, language]);
+    // ponytail: token is a guard, not a trigger — currentRole changes only after the session is fully initialized
+  }, [currentRole, fetchMenu, language]);
 
   return menu;
 };

--- a/packages/api-client/src/api/dashboard.ts
+++ b/packages/api-client/src/api/dashboard.ts
@@ -399,7 +399,7 @@ export async function updateWidgetParams(
   const response = await Metadata.client.request(
     `${DASHBOARD_BASE}/dashboard/widget/${encodeURIComponent(instanceId)}/params`,
     {
-      method: "PATCH",
+      method: "PUT",
       body: JSON.stringify({ parameters }),
       headers: JSON_HEADERS,
     }

--- a/packages/api-client/src/api/metadata.ts
+++ b/packages/api-client/src/api/metadata.ts
@@ -30,6 +30,7 @@ export class Metadata {
   public static datasourceServletClient = new Client();
   private static cache = new CacheStore(API_DEFAULT_CACHE_DURATION, "etendo_metadata_");
   private static currentRoleId: string | null = null;
+  private static pendingMenuRequest: Promise<Etendo.Menu[]> | null = null;
   public static loginClient = new Client();
   private static language: string | null = null;
   public static locationClient = new LocationClient();
@@ -227,17 +228,28 @@ export class Metadata {
     if (!forceRefresh && cached && cached.length && currentRoleId === Metadata.currentRoleId) {
       return cached;
     }
-    try {
-      const { data } = await Metadata.client.post("meta/menu", { role: currentRoleId });
-      const menu = data.menu;
-      Metadata.cache.set("OBMenu", menu);
-      Metadata.currentRoleId = currentRoleId;
 
-      return menu;
-    } catch (error) {
-      console.error("Error fetching menu:", error);
-      throw error;
+    // Deduplicate concurrent requests — second caller reuses the in-flight promise
+    if (Metadata.pendingMenuRequest) {
+      return Metadata.pendingMenuRequest;
     }
+
+    Metadata.pendingMenuRequest = (async () => {
+      try {
+        const { data } = await Metadata.client.post("meta/menu", { role: currentRoleId });
+        const menu = data.menu;
+        Metadata.cache.set("OBMenu", menu);
+        Metadata.currentRoleId = currentRoleId;
+        return menu;
+      } catch (error) {
+        console.error("Error fetching menu:", error);
+        throw error;
+      } finally {
+        Metadata.pendingMenuRequest = null;
+      }
+    })();
+
+    return Metadata.pendingMenuRequest;
   }
 
   public static async refreshMenuOnLogin(): Promise<void> {

--- a/playwright-tests/e2e/helpers/etendo.helpers.ts
+++ b/playwright-tests/e2e/helpers/etendo.helpers.ts
@@ -1,4 +1,4 @@
-import { type Page, type Frame, type FrameLocator, expect } from "@playwright/test";
+import type { Page, Frame, FrameLocator } from "@playwright/test";
 import { DEFAULT_USER, DEFAULT_PASSWORD, IFRAME_URL } from "../../playwright.config";
 
 // ─── Auth ────────────────────────────────────────────────────────────────────

--- a/playwright-tests/e2e/smoke/05_Financial/FINbInvoiceToPaymentTest.spec.ts
+++ b/playwright-tests/e2e/smoke/05_Financial/FINbInvoiceToPaymentTest.spec.ts
@@ -187,7 +187,7 @@ test.describe("Financial Test 2 - Sales Invoice to Payment In @smoke", () => {
     const outstandingInput = page.locator('input[name="outstandingAmount"]').first();
     await outstandingInput.waitFor({ state: "attached", timeout: 10_000 });
     const invoiceTotalStr = await outstandingInput.inputValue();
-    const invoiceTotal = parseFloat(invoiceTotalStr) || 0;
+    const invoiceTotal = Number.parseFloat(invoiceTotalStr) || 0;
 
     // Payment is intentionally set to invoiceTotal + 1.74 to generate a credit of 1.74.
     // This tests Etendo's overpayment/credit tracking feature.

--- a/playwright-tests/e2e/smoke/05_Financial/FINdPaymentProposalTest.spec.ts
+++ b/playwright-tests/e2e/smoke/05_Financial/FINdPaymentProposalTest.spec.ts
@@ -31,7 +31,7 @@ test.describe("Financial - Payment Proposal - Select Expected Payments @smoke", 
       await navigateToPurchaseInvoice(page);
 
       // New Record
-      let newBtn = page.locator("button.toolbar-button-new").filter({ hasText: "New Record" }).first();
+      const newBtn = page.locator("button.toolbar-button-new").filter({ hasText: "New Record" }).first();
       await newBtn.waitFor({ state: "visible", timeout: 15_000 });
       await newBtn.click();
       await expect(page.getByRole("tab", { name: "Main Section" })).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## Summary

- **Fix JSESSIONID=null poisoning on role switch** — prevents `JSESSIONID=null` from being sent to backend after switching roles
- **Fix menu fetch race condition on role switch** — ensures menu data loads after session is fully established
- **Fix role switch session and menu race conditions** — consolidates session + menu sequencing to avoid stale state
- **Use PUT instead of PATCH for widget params update** — fixes widget parameter persistence
- **Show toast on callout error in FormView and inline table editing** — callout backend errors (`status: -1`) are now surfaced to the user via Sonner toast instead of being silently logged

## Test Cases

### Session / Role Switch
- [ ] Switch roles from the profile dropdown → verify no `JSESSIONID=null` appears in network requests
- [ ] Switch roles → verify the menu loads correctly without stale entries from the previous role
- [ ] Switch roles rapidly multiple times → verify no race conditions (menu matches the selected role)

### Widget Parameters
- [ ] Open a dashboard widget with configurable parameters → change a parameter → verify it persists after page reload

### Callout Error Display
- [ ] Edit a field that triggers a callout configured to return an error → verify a toast notification appears with the backend error message
- [ ] Edit a field that triggers a successful callout → verify no toast appears and field values update normally
- [ ] In grid/table inline editing, trigger a callout error → verify toast appears and invalid column values are NOT applied
- [ ] Trigger multiple failing callouts in sequence → verify each one gets its own toast (they stack)

## Spec
- `docs/superpowers/specs/2026-06-23-callout-warning-error-display-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)