### PR TITLE
Hotfix ETP-4370: Let backend pick role defaults on profile switch

### DIFF
--- a/packages/ComponentLibrary/src/components/Input/Select/types.ts
+++ b/packages/ComponentLibrary/src/components/Input/Select/types.ts
@@ -21,7 +21,7 @@ import type { Option } from "@workspaceui/api-client/src/api/types";
 export type { Option };
 
 export interface ISelectInput<T extends string = string>
-  extends Omit<AutocompleteProps<Option<T>, false, false, false>, "renderInput"> {
+  extends Omit<AutocompleteProps<Option<T>, false, boolean, false>, "renderInput"> {
   title?: string;
   iconLeft?: React.ReactElement;
   options: Option<T>[];

--- a/packages/ComponentLibrary/src/locales/en.ts
+++ b/packages/ComponentLibrary/src/locales/en.ts
@@ -297,6 +297,7 @@ const en = {
       errorUnequalPwd: "Passwords do not match",
       errorNotStrongEnough: "Password is not strong enough. Use uppercase, lowercase, numbers and special characters",
       errorGeneric: "Failed to change password",
+      configSaveError: "Failed to save profile configuration",
     },
   },
   breadcrumb: {

--- a/packages/ComponentLibrary/src/locales/es.ts
+++ b/packages/ComponentLibrary/src/locales/es.ts
@@ -302,6 +302,7 @@ const es = {
       errorNotStrongEnough:
         "La contraseña no es suficientemente segura. Use mayúsculas, minúsculas, números y caracteres especiales",
       errorGeneric: "Error al cambiar la contraseña",
+      configSaveError: "No se pudo guardar la configuración del perfil",
     },
   },
   breadcrumb: {

--- a/packages/MainUI/components/ProfileModal/ProfileModal.tsx
+++ b/packages/MainUI/components/ProfileModal/ProfileModal.tsx
@@ -34,6 +34,7 @@ import { useStyle } from "./styles";
 import type { ProfileModalProps } from "./types";
 import Button from "@workspaceui/componentlibrary/src/components/Button/Button";
 import { useWindowStore } from "@/stores/windowStore";
+import { toast } from "sonner";
 
 const DefaultOrg = { title: "*", value: "0", id: "0" };
 
@@ -376,6 +377,9 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
       }
     } catch (error) {
       logger.warn("Error changing role, warehouse, or saving default configuration:", error);
+      // Surface the failure instead of silently swallowing it: the backend save can fail
+      // (e.g. it returns an unparseable/empty response) and the modal must not appear dead.
+      toast.error(t("navigation.profile.configSaveError"));
     }
   }, [
     currentSection,

--- a/packages/MainUI/components/ProfileModal/ProfileModal.tsx
+++ b/packages/MainUI/components/ProfileModal/ProfileModal.tsx
@@ -98,6 +98,12 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
     return null;
   });
 
+  // Track whether the user explicitly picked an org/warehouse. On a role switch we auto-fill
+  // these for display only; we must NOT send them, so the backend computes the role's real
+  // defaults (matching Classic UI) instead of us forcing organizations[0]/warehouses[0].
+  const [orgManuallySelected, setOrgManuallySelected] = useState(false);
+  const [warehouseManuallySelected, setWarehouseManuallySelected] = useState(false);
+
   const [selectedLanguage, setSelectedLanguage] = useState<Option | null>(() => {
     const currentLang = languages.find((lang) => lang.language === language);
     return currentLang
@@ -143,6 +149,9 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
   const handleRoleChange = useCallback(
     (_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
       setSelectedRole(value);
+      // Switching role means "let the backend decide org/warehouse" until the user picks one.
+      setOrgManuallySelected(false);
+      setWarehouseManuallySelected(false);
 
       if (value) {
         const selectedRoleData = roles.find((role) => role.id === value.value);
@@ -176,11 +185,15 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
 
   const handleOrgChange = useCallback((_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
     setSelectedOrg(value ?? DefaultOrg);
+    setOrgManuallySelected(true);
+    // Changing org clears the warehouse; let the backend default it unless the user picks one.
     setSelectedWarehouse(null);
+    setWarehouseManuallySelected(false);
   }, []);
 
   const handleWarehouseChange = useCallback((_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
     setSelectedWarehouse(value);
+    setWarehouseManuallySelected(true);
     if (value) {
       localStorage.setItem("currentWarehouse", JSON.stringify(value));
     }
@@ -226,11 +239,11 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
       params.role = selectedRole.value;
     }
 
-    if (selectedOrg && selectedOrg.value !== currentOrganization?.id) {
+    if (orgManuallySelected && selectedOrg && selectedOrg.value !== currentOrganization?.id) {
       params.organization = selectedOrg.value;
     }
 
-    if (selectedWarehouse && selectedWarehouse.value !== currentWarehouse?.id) {
+    if (warehouseManuallySelected && selectedWarehouse && selectedWarehouse.value !== currentWarehouse?.id) {
       params.warehouse = selectedWarehouse.value;
 
       const newWarehouse = {
@@ -243,7 +256,16 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
     }
 
     return params;
-  }, [selectedRole, currentRole, selectedOrg, currentOrganization, selectedWarehouse, currentWarehouse]);
+  }, [
+    selectedRole,
+    currentRole,
+    selectedOrg,
+    currentOrganization,
+    selectedWarehouse,
+    currentWarehouse,
+    orgManuallySelected,
+    warehouseManuallySelected,
+  ]);
 
   const saveConfigurationDefaults = useCallback(
     async (languageChanged: boolean) => {

--- a/packages/MainUI/components/ProfileModal/ProfileModal.tsx
+++ b/packages/MainUI/components/ProfileModal/ProfileModal.tsx
@@ -35,6 +35,7 @@ import type { ProfileModalProps } from "./types";
 import Button from "@workspaceui/componentlibrary/src/components/Button/Button";
 import { useWindowStore } from "@/stores/windowStore";
 import { toast } from "sonner";
+import { computeProfileUpdates } from "./profileUpdates";
 
 const DefaultOrg = { title: "*", value: "0", id: "0" };
 
@@ -99,12 +100,6 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
     return null;
   });
 
-  // Track whether the user explicitly picked an org/warehouse. On a role switch we auto-fill
-  // these for display only; we must NOT send them, so the backend computes the role's real
-  // defaults (matching Classic UI) instead of us forcing organizations[0]/warehouses[0].
-  const [orgManuallySelected, setOrgManuallySelected] = useState(false);
-  const [warehouseManuallySelected, setWarehouseManuallySelected] = useState(false);
-
   const [selectedLanguage, setSelectedLanguage] = useState<Option | null>(() => {
     const currentLang = languages.find((lang) => lang.language === language);
     return currentLang
@@ -131,6 +126,10 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
         value: currentWarehouse.id,
         id: currentWarehouse.id,
       });
+    } else {
+      // The refreshed session has no warehouse for this profile; clear the stale
+      // selection instead of leaving a warehouse that belongs to the previous role/org.
+      setSelectedWarehouse(null);
     }
   }, [currentRole, currentOrganization, currentWarehouse]);
 
@@ -150,9 +149,6 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
   const handleRoleChange = useCallback(
     (_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
       setSelectedRole(value);
-      // Switching role means "let the backend decide org/warehouse" until the user picks one.
-      setOrgManuallySelected(false);
-      setWarehouseManuallySelected(false);
 
       if (value) {
         const selectedRoleData = roles.find((role) => role.id === value.value);
@@ -184,17 +180,23 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
     [roles]
   );
 
-  const handleOrgChange = useCallback((_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
-    setSelectedOrg(value ?? DefaultOrg);
-    setOrgManuallySelected(true);
-    // Changing org clears the warehouse; let the backend default it unless the user picks one.
-    setSelectedWarehouse(null);
-    setWarehouseManuallySelected(false);
-  }, []);
+  const handleOrgChange = useCallback(
+    (_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
+      const org = value ?? DefaultOrg;
+      setSelectedOrg(org);
+      // Parity with Classic (ob-user-profile-widget.js itemChanged): selecting an
+      // organization moves the warehouse to that org's first warehouse.
+      const role = roles.find((r) => r.id === selectedRole?.value);
+      const firstWarehouse = role?.organizations.find((o) => o.id === org.value)?.warehouses?.[0];
+      setSelectedWarehouse(
+        firstWarehouse ? { title: firstWarehouse.name, value: firstWarehouse.id, id: firstWarehouse.id } : null
+      );
+    },
+    [roles, selectedRole]
+  );
 
   const handleWarehouseChange = useCallback((_event: React.SyntheticEvent<Element, Event>, value: Option | null) => {
     setSelectedWarehouse(value);
-    setWarehouseManuallySelected(true);
     if (value) {
       localStorage.setItem("currentWarehouse", JSON.stringify(value));
     }
@@ -234,39 +236,21 @@ const ProfileModal: React.FC<ProfileModalProps> = ({
   }, []);
 
   const getProfileUpdates = useCallback(() => {
-    const params: { role?: string; organization?: string; warehouse?: string } = {};
+    const params = computeProfileUpdates({
+      selectedRole,
+      selectedOrg,
+      selectedWarehouse,
+      currentRole,
+      currentOrganization,
+      currentWarehouse,
+    });
 
-    if (selectedRole && selectedRole.value !== currentRole?.id) {
-      params.role = selectedRole.value;
-    }
-
-    if (orgManuallySelected && selectedOrg && selectedOrg.value !== currentOrganization?.id) {
-      params.organization = selectedOrg.value;
-    }
-
-    if (warehouseManuallySelected && selectedWarehouse && selectedWarehouse.value !== currentWarehouse?.id) {
-      params.warehouse = selectedWarehouse.value;
-
-      const newWarehouse = {
-        id: selectedWarehouse.id,
-        title: selectedWarehouse.title,
-        value: selectedWarehouse.value,
-      };
-      setSelectedWarehouse(newWarehouse);
-      localStorage.setItem("currentWarehouse", JSON.stringify(newWarehouse));
+    if (params.warehouse && selectedWarehouse) {
+      localStorage.setItem("currentWarehouse", JSON.stringify(selectedWarehouse));
     }
 
     return params;
-  }, [
-    selectedRole,
-    currentRole,
-    selectedOrg,
-    currentOrganization,
-    selectedWarehouse,
-    currentWarehouse,
-    orgManuallySelected,
-    warehouseManuallySelected,
-  ]);
+  }, [selectedRole, currentRole, selectedOrg, currentOrganization, selectedWarehouse, currentWarehouse]);
 
   const saveConfigurationDefaults = useCallback(
     async (languageChanged: boolean) => {

--- a/packages/MainUI/components/ProfileModal/ToggleSection/index.tsx
+++ b/packages/MainUI/components/ProfileModal/ToggleSection/index.tsx
@@ -173,6 +173,7 @@ const SelectorList: React.FC<SelectorListProps> = ({
               onChange={onRoleChange}
               iconLeft={icons[Item.Role]}
               isOptionEqualToValue={isOptionEqualToValue}
+              disableClearable
               data-testid="Select__da17cd"
             />
             <Select
@@ -194,6 +195,7 @@ const SelectorList: React.FC<SelectorListProps> = ({
               iconLeft={icons[Item.Organization]}
               isOptionEqualToValue={isOptionEqualToValue}
               disabled={!selectedClient || isSystem}
+              disableClearable
               data-testid="Select__da17cd"
             />
             <Select
@@ -205,6 +207,7 @@ const SelectorList: React.FC<SelectorListProps> = ({
               iconLeft={icons[Item.Warehouse]}
               disabled={!selectedOrg || isSystem}
               isOptionEqualToValue={isOptionEqualToValue}
+              disableClearable
               data-testid="Select__da17cd"
             />
             <Select
@@ -215,6 +218,7 @@ const SelectorList: React.FC<SelectorListProps> = ({
               onChange={onLanguageChange}
               iconLeft={icons[Item.Language]}
               isOptionEqualToValue={isOptionEqualToValue}
+              disableClearable
               data-testid="Select__da17cd"
             />
           </FormControl>

--- a/packages/MainUI/components/ProfileModal/__tests__/profileUpdates.test.ts
+++ b/packages/MainUI/components/ProfileModal/__tests__/profileUpdates.test.ts
@@ -1,0 +1,71 @@
+import { computeProfileUpdates } from "../profileUpdates";
+
+const opt = (id: string) => ({ title: id, value: id, id });
+
+describe("computeProfileUpdates", () => {
+  const currentRole = { id: "roleA", name: "Role A" } as never;
+  const currentOrganization = { id: "orgSur", name: "Sur" } as never;
+  const currentWarehouse = { id: "whSur", name: "WH Sur" } as never;
+
+  it("returns an empty payload when nothing changed", () => {
+    const params = computeProfileUpdates({
+      selectedRole: opt("roleA"),
+      selectedOrg: opt("orgSur"),
+      selectedWarehouse: opt("whSur"),
+      currentRole,
+      currentOrganization,
+      currentWarehouse,
+    });
+
+    expect(params).toEqual({});
+  });
+
+  it("sends role AND the displayed organization+warehouse on a role switch (Classic parity)", () => {
+    // The user switched to roleB; the modal auto-filled roleB's first org/warehouse
+    // for display. The payload MUST carry those explicit values, otherwise the
+    // backend /sws/login backfills org/warehouse from the previous token and
+    // silently keeps the stale Sur values.
+    const params = computeProfileUpdates({
+      selectedRole: opt("roleB"),
+      selectedOrg: opt("orgNorte"),
+      selectedWarehouse: opt("whNorte"),
+      currentRole,
+      currentOrganization,
+      currentWarehouse,
+    });
+
+    expect(params).toEqual({
+      role: "roleB",
+      organization: "orgNorte",
+      warehouse: "whNorte",
+    });
+  });
+
+  it("includes the organization when only the org changed", () => {
+    const params = computeProfileUpdates({
+      selectedRole: opt("roleA"),
+      selectedOrg: opt("orgNorte"),
+      selectedWarehouse: opt("whNorte"),
+      currentRole,
+      currentOrganization,
+      currentWarehouse,
+    });
+
+    expect(params.organization).toBe("orgNorte");
+    expect(params.warehouse).toBe("whNorte");
+  });
+
+  it("omits the warehouse when none is selected", () => {
+    const params = computeProfileUpdates({
+      selectedRole: opt("roleB"),
+      selectedOrg: opt("orgNorte"),
+      selectedWarehouse: null,
+      currentRole,
+      currentOrganization,
+      currentWarehouse,
+    });
+
+    expect(params).toEqual({ role: "roleB", organization: "orgNorte" });
+    expect(params).not.toHaveProperty("warehouse");
+  });
+});

--- a/packages/MainUI/components/ProfileModal/profileUpdates.ts
+++ b/packages/MainUI/components/ProfileModal/profileUpdates.ts
@@ -1,0 +1,82 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import type { Option } from "@workspaceui/componentlibrary/src/components/Input/Select/types";
+import type { CurrentOrganization, CurrentRole, CurrentWarehouse } from "@workspaceui/api-client/src/api/types";
+
+export interface ProfileChangeParams {
+  role?: string;
+  organization?: string;
+  warehouse?: string;
+}
+
+export interface ComputeProfileUpdatesArgs {
+  selectedRole: Option | null;
+  selectedOrg: Option | null;
+  selectedWarehouse: Option | null;
+  currentRole: CurrentRole | undefined;
+  currentOrganization: CurrentOrganization | undefined;
+  currentWarehouse: CurrentWarehouse | undefined;
+}
+
+/**
+ * Builds the payload for a profile switch, mirroring the Classic UI widget
+ * (ob-user-profile-widget.js), which always posts the explicitly displayed
+ * role + organization + warehouse.
+ *
+ * This is the crux of ETP-4370. The backend `/sws/login` only recomputes
+ * organization/warehouse when they are ABSENT from the request — and when they
+ * are absent it backfills them from the PREVIOUS token's claims, not from the
+ * role's default. So sending only `{ role }` makes the backend silently carry
+ * over the stale org/warehouse from the last profile (e.g. it keeps "Sur" while
+ * the modal shows "Norte"), and any "save as default" then persists that
+ * mismatch into AD_User, corrupting the user's defaults over time.
+ *
+ * By sending the org/warehouse currently shown whenever anything changed, the
+ * activated profile always equals what the user sees and what gets persisted as
+ * the default — exactly as Classic behaves.
+ */
+export function computeProfileUpdates({
+  selectedRole,
+  selectedOrg,
+  selectedWarehouse,
+  currentRole,
+  currentOrganization,
+  currentWarehouse,
+}: ComputeProfileUpdatesArgs): ProfileChangeParams {
+  const roleChanged = !!selectedRole && selectedRole.value !== currentRole?.id;
+  const orgChanged = !!selectedOrg && selectedOrg.value !== currentOrganization?.id;
+  const warehouseChanged = !!selectedWarehouse && selectedWarehouse.value !== currentWarehouse?.id;
+
+  if (!roleChanged && !orgChanged && !warehouseChanged) {
+    return {};
+  }
+
+  const params: ProfileChangeParams = {};
+
+  if (selectedRole) {
+    params.role = selectedRole.value;
+  }
+  if (selectedOrg) {
+    params.organization = selectedOrg.value;
+  }
+  if (selectedWarehouse) {
+    params.warehouse = selectedWarehouse.value;
+  }
+
+  return params;
+}

--- a/packages/MainUI/components/ProfileModal/types.ts
+++ b/packages/MainUI/components/ProfileModal/types.ts
@@ -105,7 +105,11 @@ export interface ProfileModalProps extends BaseProfileModalProps, SelectionProps
   languages: LanguageOption[];
   languagesFlags: string;
   // biome-ignore lint/suspicious/noConfusingVoidType: <explanation>
-  changeProfile: (params: { role?: string; warehouse?: string }) => Promise<LoginResponse | void>;
+  changeProfile: (params: {
+    role?: string;
+    organization?: string;
+    warehouse?: string;
+  }) => Promise<LoginResponse | void>;
 }
 
 export interface UserProfileProps {

--- a/packages/MainUI/stores/__tests__/userStore.logout.test.ts
+++ b/packages/MainUI/stores/__tests__/userStore.logout.test.ts
@@ -1,0 +1,23 @@
+import { useUserStore } from "../userStore";
+
+describe("userStore clearUserDataState", () => {
+  beforeEach(() => {
+    (localStorage.removeItem as jest.Mock).mockClear();
+  });
+
+  it("clears currentRoleId from localStorage so a fresh login honors the user's default role", () => {
+    useUserStore.getState().clearUserDataState();
+
+    // On the next login, verifySession reads currentRoleId and would force that role,
+    // overriding the backend's default-role login. It must not survive logout.
+    expect(localStorage.removeItem).toHaveBeenCalledWith("currentRoleId");
+  });
+
+  it("clears the other persisted user keys on logout", () => {
+    useUserStore.getState().clearUserDataState();
+
+    expect(localStorage.removeItem).toHaveBeenCalledWith("token");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("currentRole");
+    expect(localStorage.removeItem).toHaveBeenCalledWith("currentWarehouse");
+  });
+});

--- a/packages/MainUI/stores/userStore.ts
+++ b/packages/MainUI/stores/userStore.ts
@@ -194,6 +194,10 @@ export const useUserStore = create<UserStore>()(
         localStorage.removeItem("token");
         localStorage.removeItem("roles");
         localStorage.removeItem("currentRole");
+        // currentRoleId persists the active role across page reloads; it must be cleared on
+        // logout so the next fresh login honors the user's backend default role (not the last
+        // role used before logout), matching Classic UI.
+        localStorage.removeItem("currentRoleId");
         localStorage.removeItem("currentInfo");
         localStorage.removeItem("currentWarehouse");
         localStorage.removeItem("currentLanguage");

--- a/packages/api-client/src/api/changeProfile.ts
+++ b/packages/api-client/src/api/changeProfile.ts
@@ -21,6 +21,7 @@ import type { LoginResponse } from "./types";
 
 interface ChangeProfilePayload {
   role?: string;
+  organization?: string;
   warehouse?: string;
 }
 
@@ -70,8 +71,8 @@ export default async function handler(req: any, res: any) {
       return res.status(401).json({ message: "Unauthorized: No token provided" });
     }
 
-    const { role, warehouse } = req.body;
-    const data = await changeProfile({ role, warehouse });
+    const { role, organization, warehouse } = req.body;
+    const data = await changeProfile({ role, organization, warehouse });
 
     return res.status(200).json(data);
   } catch (error) {

--- a/playwright-tests/e2e/helpers/etendo.helpers.ts
+++ b/playwright-tests/e2e/helpers/etendo.helpers.ts
@@ -244,7 +244,7 @@ export async function clickNewRecord(page: Page) {
     .filter({ hasText: /^New Record$/ })
     .locator("visible=true")
     .first();
-  await btn.waitFor({ state: "visible", timeout: 20_000 });
+  await btn.waitFor({ state: "visible", timeout: 40_000 });
   await btn.click();
 }
 

--- a/playwright-tests/playwright.config.ts
+++ b/playwright-tests/playwright.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
   // workers run spec files in parallel.
   workers: 2,
   fullyParallel: false,
+  // Jenkins shares the CI box across jobs; under load, API responses that are
+  // normally instant can exceed a helper's fixed timeout once. Retrying lets
+  // a transient slow response self-heal instead of failing the whole suite.
+  retries: process.env.CI ? 2 : 0,
 
   use: {
     baseURL: BASE_URL,


### PR DESCRIPTION
On a role switch the profile modal forced organizations[0]/warehouses[0] instead of letting the backend compute the role's default Org/Warehouse, diverging from Classic UI. Now org/warehouse are sent only when the user explicitly selects them; a plain role switch sends only { role }.