### PR TITLE
Hotfix ETP-4361: Escape closes only the modal in Form View

### DIFF
--- a/packages/MainUI/components/Modal.tsx
+++ b/packages/MainUI/components/Modal.tsx
@@ -43,14 +43,18 @@ export default function Modal({
     if (open) {
       const handler = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
+          // Capture phase + stopPropagation so this Escape closes only the modal and does not
+          // also reach the form's document-level Escape handler (which would navigate to Grid).
+          // ponytail: closes the outermost modal if two custom Modals ever stack; not a case today.
+          e.stopPropagation();
           onClose?.();
         }
       };
 
-      document.addEventListener("keydown", handler);
+      document.addEventListener("keydown", handler, true);
 
       return () => {
-        document.removeEventListener("keydown", handler);
+        document.removeEventListener("keydown", handler, true);
       };
     }
   }, [onClose, open]);


### PR DESCRIPTION
## Problem

Pressing **Escape** while a process modal is open in Form View closed **both** the modal and the form, navigating the user back to Grid view in a single keypress.

Root cause: the modal (`Modal.tsx`) and the form (`FormActions.tsx` via `useKeyboardShortcuts`) each register a `document`-level `keydown` listener in the bubble phase, and neither stops propagation — so one Escape triggers both handlers.

## Fix

`Modal.tsx` now listens for Escape in the **capture phase** and calls `stopPropagation()`. Capture runs before bubble, so the form's Escape handler no longer fires while the modal is open.

- First Escape → closes only the modal, stays in Form View.
- Second Escape → reaches the form handler → returns to Grid.

Single-file change; the form is untouched.

## Test plan

- [x] Open a process modal in Form View, press Escape → modal closes, still in Form View.
- [x] Press Escape again → navigates back to Grid.
- [x] Escape with no modal open still returns to Grid (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)