### PR TITLE
Hotfix ETP-4620: contextual Help widget with layout-push panel

### DIFF
--- a/docs/superpowers/plans/2026-08-03-help-widget-frontend.md
+++ b/docs/superpowers/plans/2026-08-03-help-widget-frontend.md
@@ -1,0 +1,807 @@
+# Help Widget (Frontend) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a navbar Help access, visible only when the active window has help text, that opens a right-side drawer showing the window's help content (window description + per-tab description + per-field help), sourced entirely from metadata the frontend already fetches.
+
+**Architecture:** A pure content-building util (`buildHelpContent.ts`) turns `WindowMetadata` into ordered/filtered sections. A presentational `HelpButton` (ComponentLibrary, mirrors the existing `AboutButton`) is the trigger icon. A `HelpDrawer` (MainUI) renders the sanitized content inside the existing `Modal` portal, styled as a right-side sliding panel instead of a centered dialog. A `HelpAccess` orchestrator (MainUI) wires active-window state to both, and is mounted as one new sibling in `navigation.tsx` — no changes to `About`'s existing flow.
+
+**Tech Stack:** React/TypeScript (Next.js App Router), existing `Modal.tsx` portal, DOMPurify (`sanitizeMessageHtml`), Zustand-backed `useMetadataContext`, Jest + React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-help-widget-frontend-design.md` (and backend data contract: `com.etendoerp.metadata` repo, `docs/superpowers/plans/2026-08-03-help-widget-data-contract.md` — 0 backend changes, already verified live).
+
+**Branch:** `hotfix/ETP-4620` (created from `main`). Commit messages use the `Hotfix ETP-4620: <description>` format per this repo's Git Police convention.
+
+---
+
+### Task 1: Type the metadata fields the feature depends on
+
+**Files:**
+- Modify: `packages/api-client/src/api/types.ts:452-511` (`Tab` interface)
+- Modify: `packages/api-client/src/api/types.ts:513-521` (`WindowMetadata` interface)
+
+No test-first step here — this is a pure type addition (no runtime behavior), verified by the build/typecheck instead of a unit test.
+
+- [ ] **Step 1: Add `helpComment` and `sequenceNumber` to `Tab`**
+
+In `packages/api-client/src/api/types.ts`, inside `export interface Tab { ... }` (starts line 452), add:
+
+```ts
+  /** AD_Tab.HELP, translated (FULL_TRANSLATABLE). Always present on the wire, null when empty. */
+  helpComment?: string | null;
+  /** AD_Tab column position — used to order tabs the same way Classic's Help view does. */
+  sequenceNumber?: number;
+```
+
+- [ ] **Step 2: Add `helpComment` to `WindowMetadata`**
+
+In the same file, inside `export interface WindowMetadata { ... }` (starts line 513), add:
+
+```ts
+  /** AD_Window.HELP, translated (FULL_TRANSLATABLE). Always present on the wire, null when empty. */
+  helpComment?: string | null;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @workspaceui/api-client build`
+Expected: succeeds with no type errors (this is a pure additive change to optional fields, nothing else references them yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/api-client/src/api/types.ts
+git commit -m "Hotfix ETP-4620: type window/tab helpComment and sequenceNumber"
+```
+
+---
+
+### Task 2: Pure content-building util
+
+**Files:**
+- Create: `packages/MainUI/utils/help/buildHelpContent.ts`
+- Test: `packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts`
+
+This is the core logic: ordering, filtering (omit fields with no help text and no column fallback, omit audit fields), and the window-level visibility rule. Fully unit-testable with no DOM/React involved.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+import { buildHelpSections, shouldShowHelp } from "../buildHelpContent";
+import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
+
+describe("shouldShowHelp", () => {
+  it("returns true for non-empty helpComment", () => {
+    expect(shouldShowHelp({ helpComment: "Some help" })).toBe(true);
+  });
+
+  it("returns false for null/undefined/empty/whitespace helpComment", () => {
+    expect(shouldShowHelp({ helpComment: null })).toBe(false);
+    expect(shouldShowHelp({ helpComment: undefined })).toBe(false);
+    expect(shouldShowHelp({ helpComment: "" })).toBe(false);
+    expect(shouldShowHelp({ helpComment: "   " })).toBe(false);
+  });
+
+  it("returns false for a null/undefined window", () => {
+    expect(shouldShowHelp(null)).toBe(false);
+    expect(shouldShowHelp(undefined)).toBe(false);
+  });
+});
+
+describe("buildHelpSections", () => {
+  it("orders tabs by sequenceNumber regardless of array order", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("orders fields within a tab by sequenceNumber", () => {
+    const field20 = createMockField({ id: "f20", name: "Second", sequenceNumber: 20, helpComment: "help" });
+    const field10 = createMockField({ id: "f10", name: "First", sequenceNumber: 10, helpComment: "help" });
+    const tab = createMockTab({ id: "t1", sequenceNumber: 10, fields: { field20, field10 } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields.map((f) => f.id)).toEqual(["f10", "f20"]);
+  });
+
+  it("omits fields with no helpComment and no column fallback", () => {
+    const withHelp = createMockField({ id: "f1", helpComment: "has help", column: { helpComment: undefined } });
+    const withoutHelp = createMockField({ id: "f2", helpComment: "", column: { helpComment: undefined } });
+    const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields.map((f) => f.id)).toEqual(["f1"]);
+  });
+
+  it("falls back to column.helpComment when field.helpComment is empty", () => {
+    const field = createMockField({ id: "f1", helpComment: "", column: { helpComment: "column help text" } });
+    const tab = createMockTab({ id: "t1", fields: { field } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([{ id: "f1", name: field.name, helpComment: "column help text" }]);
+  });
+
+  it("omits audit synthetic fields regardless of help content", () => {
+    const auditField = createMockField({ id: "f1", helpComment: "audit help", isAuditField: true });
+    const tab = createMockTab({ id: "t1", fields: { auditField } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([]);
+  });
+
+  it("returns empty-string tab helpComment (not null/undefined) when tab has none", () => {
+    const tab = createMockTab({ id: "t1", helpComment: null, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].helpComment).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test:mainui -- buildHelpContent`
+Expected: FAIL — `Cannot find module '../buildHelpContent'`
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/MainUI/utils/help/buildHelpContent.ts
+import type { Field, Tab, WindowMetadata } from "@workspaceui/api-client/src/api/types";
+
+export interface HelpField {
+  id: string;
+  name: string;
+  helpComment: string;
+}
+
+export interface HelpTabSection {
+  id: string;
+  name: string;
+  helpComment: string;
+  fields: HelpField[];
+}
+
+export function shouldShowHelp(window: { helpComment?: string | null } | null | undefined): boolean {
+  return Boolean(window?.helpComment?.trim());
+}
+
+// field.column is typed as required in Field, but live metadata has shown it can
+// genuinely be null/undefined at runtime for some field kinds — read defensively.
+function getFieldHelp(field: Field): string {
+  const own = field.helpComment?.trim();
+  if (own) return own;
+  return (field.column as Field["column"] | null | undefined)?.helpComment?.trim() ?? "";
+}
+
+export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
+  const orderedTabs = [...window.tabs].sort(
+    (a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0)
+  );
+
+  return orderedTabs.map((tab: Tab) => {
+    const fields = Object.values(tab.fields)
+      .filter((field) => !field.isAuditField)
+      .map((field) => ({ field, help: getFieldHelp(field) }))
+      .filter(({ help }) => help.length > 0)
+      .sort((a, b) => a.field.sequenceNumber - b.field.sequenceNumber)
+      .map(({ field, help }) => ({ id: field.id, name: field.name, helpComment: help }));
+
+    return {
+      id: tab.id,
+      name: tab.name,
+      helpComment: tab.helpComment?.trim() ?? "",
+      fields,
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test:mainui -- buildHelpContent`
+Expected: PASS (8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/utils/help/buildHelpContent.ts packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+git commit -m "Hotfix ETP-4620: add pure Help content builder"
+```
+
+---
+
+### Task 3: `HelpButton` (presentational trigger icon, ComponentLibrary)
+
+**Files:**
+- Create: `packages/ComponentLibrary/src/components/Help/HelpButton.tsx`
+- Create: `packages/ComponentLibrary/src/components/Help/types.ts`
+- Test: `packages/ComponentLibrary/src/components/Help/HelpButton.test.tsx`
+- Modify: `packages/ComponentLibrary/src/components/index.ts` (barrel export)
+
+Mirrors `About/AboutButton.tsx` exactly — dumb presentational component, no visibility logic (the caller decides whether to mount it, same as `{isCopilotInstalled && <CopilotButton .../>}` in `navigation.tsx:212`).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// packages/ComponentLibrary/src/components/Help/HelpButton.test.tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import HelpButton from "./HelpButton";
+
+jest.mock("../../assets/icons/help-circle.svg", () => {
+  return function HelpIcon() {
+    return <svg data-testid="help-icon" />;
+  };
+});
+
+describe("HelpButton", () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    mockOnClick.mockClear();
+  });
+
+  it("renders with default tooltip and aria-label", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-label", "Help");
+  });
+
+  it("calls onClick when clicked", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the help icon", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+    expect(screen.getByTestId("help-icon")).toBeInTheDocument();
+  });
+
+  it("respects a custom tooltip", () => {
+    render(<HelpButton onClick={mockOnClick} tooltip="Window help" />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-label", "Window help");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:component-library -- HelpButton`
+Expected: FAIL — `Cannot find module './HelpButton'`
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/ComponentLibrary/src/components/Help/types.ts
+export interface HelpButtonProps {
+  onClick: () => void;
+  tooltip?: string;
+  disabled?: boolean;
+  iconButtonClassName?: string;
+}
+```
+
+```tsx
+// packages/ComponentLibrary/src/components/Help/HelpButton.tsx
+import IconButton from "../IconButton";
+import HelpIcon from "../../assets/icons/help-circle.svg";
+import type { HelpButtonProps } from "./types";
+
+const HelpButton: React.FC<HelpButtonProps> = ({
+  onClick,
+  tooltip = "Help",
+  disabled = false,
+  iconButtonClassName = "w-10 h-10",
+}) => {
+  return (
+    <IconButton
+      onClick={onClick}
+      tooltip={tooltip}
+      disabled={disabled}
+      className={iconButtonClassName}
+      ariaLabel={tooltip}>
+      <HelpIcon />
+    </IconButton>
+  );
+};
+
+export default HelpButton;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:component-library -- HelpButton`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Export from the barrel**
+
+In `packages/ComponentLibrary/src/components/index.ts`:
+- Add near the `AboutButtonComp` import: `import HelpButtonComp from "./Help/HelpButton";`
+- Add near `const AboutButton = AboutButtonComp;`: `const HelpButton = HelpButtonComp;`
+- Add `HelpButton,` to the `export { ... }` list (next to `AboutButton,`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ComponentLibrary/src/components/Help packages/ComponentLibrary/src/components/index.ts
+git commit -m "Hotfix ETP-4620: add HelpButton presentational component"
+```
+
+---
+
+### Task 4: `HelpDrawer` (content view, MainUI)
+
+**Files:**
+- Create: `packages/MainUI/components/HelpDrawer/HelpDrawer.tsx`
+- Test: `packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx`
+
+Reuses `Modal.tsx` (`packages/MainUI/components/Modal.tsx`) for the portal + Escape-close behavior — no new generic Drawer primitive. Styles its content as a right-anchored panel instead of `Modal`'s default centered usage. Sanitizes with `sanitizeMessageHtml` (`packages/MainUI/utils/processes/definition/sanitizeHtml.ts`) — **not** `RichTextSelector`'s permissive default DOMPurify call (see design doc rationale: `<a>`/images are out of scope for Help content).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+import { render, screen } from "@testing-library/react";
+import HelpDrawer from "../HelpDrawer";
+import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("../../Modal", () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="mock-modal">{children}</div> : null,
+}));
+
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="close-icon" />,
+}));
+
+describe("HelpDrawer", () => {
+  const mockOnClose = jest.fn();
+
+  it("renders nothing when closed", () => {
+    const window = createMockWindowMetadata("W1");
+    render(<HelpDrawer open={false} window={window} onClose={mockOnClose} />);
+    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+  });
+
+  it("renders the window title and sanitized window helpComment", () => {
+    const window = { ...createMockWindowMetadata("W1"), helpComment: "<p>Window help</p><script>alert(1)</script>" };
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByText(/Window W1/)).toBeInTheDocument();
+    expect(screen.getByText("Window help")).toBeInTheDocument();
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+  });
+
+  it("renders tabs ordered by sequenceNumber with their field help", () => {
+    const field = createMockField({ id: "f1", name: "Document No.", helpComment: "Field help text" });
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, helpComment: "Lines help", fields: {} });
+    const tabB = createMockTab({
+      id: "b",
+      name: "Header",
+      sequenceNumber: 10,
+      helpComment: "Header help",
+      fields: { f1: field },
+    });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual(["Header", "Lines"]);
+    expect(screen.getByText("Document No.")).toBeInTheDocument();
+    expect(screen.getByText("Field help text")).toBeInTheDocument();
+  });
+
+  it("omits fields with no help content", () => {
+    const withHelp = createMockField({ id: "f1", name: "Has Help", helpComment: "yes" });
+    const withoutHelp = createMockField({ id: "f2", name: "No Help", helpComment: "", column: { helpComment: undefined } });
+    const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByText("Has Help")).toBeInTheDocument();
+    expect(screen.queryByText("No Help")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:mainui -- HelpDrawer`
+Expected: FAIL — `Cannot find module '../HelpDrawer'`
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+"use client";
+
+import Modal from "../Modal";
+import { sanitizeMessageHtml } from "@/utils/processes/definition/sanitizeHtml";
+import { buildHelpSections } from "@/utils/help/buildHelpContent";
+import { useTranslation } from "@/hooks/useTranslation";
+import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import type { WindowMetadata } from "@workspaceui/api-client/src/api/types";
+
+export interface HelpDrawerProps {
+  open: boolean;
+  window: WindowMetadata | null | undefined;
+  onClose: () => void;
+}
+
+const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
+  const { t } = useTranslation();
+  const sections = window ? buildHelpSections(window) : [];
+  const windowHelp = window?.helpComment?.trim() ?? "";
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div className="fixed inset-0 bg-black/20" onClick={onClose}>
+        <div
+          className="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-lg overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center justify-between p-4 border-b border-gray-200">
+            <h2 className="text-lg font-bold">
+              {t("common.helpFor")} {window?.name}
+            </h2>
+            <button type="button" onClick={onClose} aria-label={t("common.close")}>
+              <CloseIcon className="w-4 h-4" />
+            </button>
+          </div>
+          <div className="p-4 space-y-6">
+            {windowHelp && (
+              // biome-ignore lint: sanitized via sanitizeMessageHtml above
+              <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
+            )}
+            {sections.map((tab) => (
+              <section key={tab.id}>
+                <h3 className="font-semibold">{tab.name}</h3>
+                {tab.helpComment && (
+                  // biome-ignore lint: sanitized via sanitizeMessageHtml above
+                  <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                )}
+                {tab.fields.length > 0 && (
+                  <ul className="mt-2 space-y-2">
+                    {tab.fields.map((field) => (
+                      <li key={field.id}>
+                        <strong>{field.name}</strong>
+                        {/* biome-ignore lint: sanitized via sanitizeMessageHtml above */}
+                        <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default HelpDrawer;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:mainui -- HelpDrawer`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/HelpDrawer
+git commit -m "Hotfix ETP-4620: add HelpDrawer content view"
+```
+
+---
+
+### Task 5: `HelpAccess` orchestrator (MainUI)
+
+**Files:**
+- Create: `packages/MainUI/components/Header/HelpAccess.tsx`
+- Test: `packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx`
+
+Wires active-window state (`useMetadataContext`) to `HelpButton` (only mounted when `shouldShowHelp` is true) and `HelpDrawer`. Also owns the "close the drawer if the active window changes while it's open" rule from the spec.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import HelpAccess from "../HelpAccess";
+import { createMockWindowMetadata } from "@/utils/tests/mockHelpers";
+
+const mockUseMetadataContext = jest.fn();
+jest.mock("@/contexts/metadata", () => ({
+  useMetadataContext: () => mockUseMetadataContext(),
+}));
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/help-circle.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="help-icon" />,
+}));
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="close-icon" />,
+}));
+jest.mock("../../Modal", () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="mock-modal">{children}</div> : null,
+}));
+
+describe("HelpAccess", () => {
+  beforeEach(() => {
+    mockUseMetadataContext.mockReset();
+  });
+
+  it("renders nothing when the active window has no helpComment", () => {
+    mockUseMetadataContext.mockReturnValue({ windowId: "w1", window: createMockWindowMetadata("w1") });
+    render(<HelpAccess />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders the trigger when the active window has helpComment", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    render(<HelpAccess />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("opens the drawer when the trigger is clicked", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    render(<HelpAccess />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
+  });
+
+  it("closes the drawer when the active window changes", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    const { rerender } = render(<HelpAccess />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
+
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w2",
+      window: { ...createMockWindowMetadata("w2"), helpComment: "Other help" },
+    });
+    rerender(<HelpAccess />);
+
+    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:mainui -- HelpAccess`
+Expected: FAIL — `Cannot find module '../HelpAccess'`
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// packages/MainUI/components/Header/HelpAccess.tsx
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMetadataContext } from "@/contexts/metadata";
+import { useTranslation } from "@/hooks/useTranslation";
+import { HelpButton } from "@workspaceui/componentlibrary/src/components";
+import HelpDrawer from "../HelpDrawer/HelpDrawer";
+import { shouldShowHelp } from "@/utils/help/buildHelpContent";
+
+const HelpAccess: React.FC = () => {
+  const { t } = useTranslation();
+  const { window, windowId } = useMetadataContext();
+  const [open, setOpen] = useState(false);
+  const previousWindowId = useRef(windowId);
+
+  useEffect(() => {
+    if (open && previousWindowId.current !== windowId) {
+      setOpen(false);
+    }
+    previousWindowId.current = windowId;
+  }, [windowId, open]);
+
+  if (!shouldShowHelp(window)) {
+    return null;
+  }
+
+  return (
+    <>
+      <HelpButton onClick={() => setOpen(true)} tooltip={t("common.help")} />
+      <HelpDrawer open={open} window={window} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export default HelpAccess;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:mainui -- HelpAccess`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/Header/HelpAccess.tsx packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
+git commit -m "Hotfix ETP-4620: add HelpAccess orchestrator"
+```
+
+---
+
+### Task 6: Translations
+
+**Files:**
+- Modify: `packages/ComponentLibrary/src/locales/en.ts:49` (after the `about` key)
+- Modify: `packages/ComponentLibrary/src/locales/es.ts:48` (after the `about` key)
+
+No test — these are static string tables already covered indirectly by the mocked-translation component tests above; add a quick manual check instead.
+
+- [ ] **Step 1: Add English keys**
+
+In `packages/ComponentLibrary/src/locales/en.ts`, inside `common: { ... }`, right after `about: "About",` (line 49):
+
+```ts
+    help: "Help",
+    helpFor: "Help for",
+```
+
+- [ ] **Step 2: Add Spanish keys**
+
+In `packages/ComponentLibrary/src/locales/es.ts`, inside `common: { ... }`, right after `about: "Acerca de",` (line 48):
+
+```ts
+    help: "Ayuda",
+    helpFor: "Ayuda de",
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @workspaceui/componentlibrary build`
+
+**Known pre-existing failure, not caused by this task:** this command currently fails on this
+branch with ~30 TS errors (missing `*.svg?react` module declarations, several `__tests__`
+files with type mismatches unrelated to translations) — confirmed present identically on
+`main` at `99268dcdb` (before any Help widget work), via a throwaway worktree build. This is
+pre-existing repo tech debt, out of scope for this hotfix. Don't attempt to fix it here.
+
+Use instead, as the actual verification for this task: `pnpm test:component-library` (jest —
+passes; jest's transform doesn't hit the same `tsc`-only failures) and
+`cd packages/MainUI && npx tsc --noEmit` (must be clean — this is what actually proves the
+`common.help`/`common.helpFor` keys resolve correctly for real consumers, `HelpAccess.tsx`
+and `HelpDrawer.tsx`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ComponentLibrary/src/locales/en.ts packages/ComponentLibrary/src/locales/es.ts
+git commit -m "Hotfix ETP-4620: add help/helpFor translation keys"
+```
+
+---
+
+### Task 7: Wire `HelpAccess` into the navbar
+
+**Files:**
+- Modify: `packages/MainUI/components/navigation.tsx:37` (import)
+- Modify: `packages/MainUI/components/navigation.tsx:209-220` (render)
+
+This is the only change to `navigation.tsx` — one import, one new sibling element next to `ConfigurationSection`. No new test file: `navigation.tsx` has no existing test (heavy transitive deps — Copilot, user store, etc.) and `HelpAccess` itself is already fully tested in Task 5; this step is covered by manual verification (Step 3 below).
+
+- [ ] **Step 1: Add the import**
+
+In `packages/MainUI/components/navigation.tsx`, after line 37 (`import ConfigurationSection from "./Header/ConfigurationSection";`):
+
+```ts
+import HelpAccess from "./Header/HelpAccess";
+```
+
+- [ ] **Step 2: Render it next to `ConfigurationSection`**
+
+Change (`navigation.tsx:220`):
+
+```tsx
+        <ConfigurationSection data-testid="ConfigurationSection__120cc9" />
+```
+
+to:
+
+```tsx
+        <ConfigurationSection data-testid="ConfigurationSection__120cc9" />
+        <HelpAccess data-testid="HelpAccess__120cc9" />
+```
+
+- [ ] **Step 3: Manual verification**
+
+Run: `pnpm --filter @workspaceui/mainui dev`
+
+In the browser:
+1. Open a window whose `AD_WINDOW.HELP` is set (e.g. Sales Order) — confirm the Help icon appears in the navbar, next to the gear/config icon.
+2. Click it — confirm the drawer slides in from the right, background stays interactive (click a grid row behind it), shows window help + tabs ordered correctly + only fields with real help text.
+3. Press Escape — confirm it closes.
+4. Open a window with no `AD_WINDOW.HELP` (or Home) — confirm the icon does not render.
+5. With the drawer open, navigate to a different window — confirm the drawer closes.
+
+- [ ] **Step 4: Run the full MainUI suite**
+
+Run: `pnpm test:mainui`
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/navigation.tsx
+git commit -m "Hotfix ETP-4620: mount HelpAccess in the navbar"
+```
+
+---
+
+## Out of scope (per design doc)
+
+- Backend / `com.etendoerp.metadata` module — 0 changes, already verified live.
+- Any change to `About`'s existing iframe modal flow.
+- A generic reusable `Drawer` primitive (checked: the existing `Drawer` export in `packages/ComponentLibrary/src/components/Drawer` is the main left-nav menu drawer, unrelated and not reusable here).
+- Tab-level or field-level Help triggers (window-level only, per spec §3).
+- Per-tab index/anchors inside the drawer.
+
+## Status: implemented (2026-08-04)
+
+All 7 tasks done, each through spec-compliance + code-quality review (two real bugs caught
+and fixed along the way: a missing icon-render test in `HelpButton`, and a dead/unreachable
+`onKeyDown` Escape handler in `HelpDrawer`). Full final review across the whole diff found
+no cross-task issues (no duplicated logic, sanitizer discipline holds everywhere, barrel
+exports resolve correctly, no dead code). `pnpm test:mainui` (386 suites/5072 tests) and
+`pnpm test:component-library` (78 suites/706 tests) both green; `tsc --noEmit` clean.
+
+**Known fast-follow, not fixed here (user decision 2026-08-04):** `HelpDrawer` reuses
+`Modal.tsx`'s scale/fade transition (built for centered dialogs) rather than a translate —
+during the ~200ms open/close animation this may read as a zoom instead of a slide-in from
+the right (functionally harmless: Escape, click-outside, and background-stays-interactive
+all verified working; this is purely about the transition's visual character, unverified in
+a live browser). Fix if a visual check confirms it's noticeable: give `HelpDrawer`'s panel
+its own `translate-x` transition instead of relying on `Modal`'s wrapper transform.
+
+**Also pending:** manual browser QA (plan Task 7, Step 3) — not done in this session (no
+live app instance driven end-to-end here), still worth a human pass before considering this
+fully done.

--- a/docs/superpowers/plans/2026-08-03-help-widget-frontend.md
+++ b/docs/superpowers/plans/2026-08-03-help-widget-frontend.md
@@ -805,3 +805,308 @@ its own `translate-x` transition instead of relying on `Modal`'s wrapper transfo
 **Also pending:** manual browser QA (plan Task 7, Step 3) — not done in this session (no
 live app instance driven end-to-end here), still worth a human pass before considering this
 fully done.
+
+---
+
+### Task 8: Tab index sidebar + active-section highlight in `HelpDrawer`
+
+**User feedback (2026-08-04):** Classic's help view has heavy cross-references between
+tabs/fields; without a way to jump around, the flat scrollable version from Task 4 is
+"pesado de leer". Widen the drawer and add a left-hand tab index (sidebar) that jumps to
+each tab's section and highlights whichever section is currently at the top of the content
+pane.
+
+**Files:**
+- Modify: `packages/MainUI/components/HelpDrawer/HelpDrawer.tsx` (full rewrite of the render, same props/exports)
+- Modify: `packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx` (additions only — the 6 existing tests are unaffected, see rationale below)
+
+**Design decisions:**
+- Width: `max-w-md` (28rem/448px) → `max-w-2xl` (42rem/672px) — room for a ~12rem sidebar
+  plus a comfortable reading column, without ballooning to a near-fullscreen panel.
+- Layout: header (title/close) and window-level help stay full-width, non-scrolling, at the
+  top. Below them, a flex row: a fixed-width sidebar (tab names as buttons, independently
+  scrollable if there are many tabs) and a content pane (tab sections, independently
+  scrollable) — a standard two-pane docs layout.
+- **Scroll-spy mechanism: plain `onScroll` + `getBoundingClientRect`, NOT
+  `IntersectionObserver`.** Investigated `IntersectionObserver` first and rejected it: `Modal`
+  (reused for portal/Escape) mounts `children` asynchronously — `Modal`'s own `useEffect`
+  calls `setVisible(true)` in response to `open` becoming true, which triggers a *second*
+  render before the section DOM nodes actually exist. An observer set up in `HelpDrawer`'s
+  own effect (keyed on `[open, sections]`) would very plausibly run before that second render
+  commits, observing nothing. Working around that reliably needs `requestAnimationFrame`
+  deferral or ref-triggered lazy observer creation — real complexity to buy correctness for a
+  polish feature. A direct `onScroll` handler on the content pane has no such timing hazard
+  (it's wired via a JSX prop, evaluated fresh on every render, no imperative setup/teardown
+  to race against Modal's async mount) and is just as cheap given the tab count here is
+  always small (a handful of tabs per window, not a virtualized list) — no debounce needed.
+- Active tab resets to the first tab every time the drawer transitions from closed to open
+  (not on every content recompute) — because `Modal` fully unmounts the content 300ms after
+  closing, the content pane always remounts scrolled to the top on reopen, so the sidebar
+  highlight must match that, not remember a stale tab from a previous session.
+- No `IntersectionObserver`, no debounce/throttle utility, no separate "active section"
+  context or store — this is entirely local `HelpDrawer` state, consistent with the rest of
+  this component's scope.
+
+- [ ] **Step 1: Write the additional failing tests**
+
+The 6 existing tests in `HelpDrawer.test.tsx` are **not modified** — sidebar items are
+rendered as `<button>` elements (not headings), so `getAllByRole("heading", { level: 3 })`
+still resolves only to the content pane's tab headings, and no existing test queries a bare
+tab name via `getByText` (which would otherwise become ambiguous now that a tab's name
+appears twice: once as a sidebar button, once as a content heading). Add a new `describe`
+block with these tests, appended to the existing file (keep existing imports/mocks, add
+`Element.prototype.scrollIntoView = jest.fn();` once near the top since jsdom doesn't
+implement it):
+
+```tsx
+// Add near the top of the file, after the existing jest.mock(...) calls:
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+// Add as a new describe block, after the existing `describe("HelpDrawer", ...)`:
+describe("HelpDrawer tab index sidebar", () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it("renders one sidebar button per tab, in sequenceNumber order", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId("help-toc-item-b")).toHaveTextContent("Header");
+    expect(screen.getByTestId("help-toc-item-a")).toHaveTextContent("Lines");
+  });
+
+  it("marks the first tab (by sequenceNumber) as active by default", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
+    expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
+  });
+
+  it("scrolls the matching section into view when a sidebar item is clicked", () => {
+    const tab = createMockTab({ id: "t1", name: "Header", fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByTestId("help-toc-item-t1"));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("updates the active tab as the content pane is scrolled", () => {
+    const tabA = createMockTab({ id: "a", name: "Header", sequenceNumber: 10, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Lines", sequenceNumber: 20, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    const content = screen.getByTestId("help-drawer-content");
+    const headerSection = screen.getByRole("heading", { name: "Header" }).closest("section") as HTMLElement;
+    const linesSection = screen.getByRole("heading", { name: "Lines" }).closest("section") as HTMLElement;
+
+    jest.spyOn(content, "getBoundingClientRect").mockReturnValue({ top: 0 } as unknown as DOMRect);
+    jest.spyOn(headerSection, "getBoundingClientRect").mockReturnValue({ top: -100 } as unknown as DOMRect);
+    jest.spyOn(linesSection, "getBoundingClientRect").mockReturnValue({ top: 10 } as unknown as DOMRect);
+
+    fireEvent.scroll(content);
+
+    expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
+    expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail (existing 6 still pass)**
+
+Run: `pnpm test:mainui -- HelpDrawer`
+Expected: the pre-existing 6 tests PASS unchanged; the 4 new tests FAIL (sidebar/testids don't exist yet).
+
+- [ ] **Step 3: Rewrite `HelpDrawer.tsx`**
+
+```tsx
+// packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+"use client";
+
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import Modal from "../Modal";
+import { sanitizeMessageHtml } from "@/utils/processes/definition/sanitizeHtml";
+import { buildHelpSections } from "@/utils/help/buildHelpContent";
+import { useTranslation } from "@/hooks/useTranslation";
+import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import type { WindowMetadata } from "@workspaceui/api-client/src/api/types";
+
+export interface HelpDrawerProps {
+  open: boolean;
+  window: WindowMetadata | null | undefined;
+  onClose: () => void;
+}
+
+const ACTIVE_TAB_THRESHOLD_PX = 16;
+
+/**
+ * Right-anchored panel showing contextual Help for the active window: window-level
+ * help text, then a tab index (left) and, for each tab, its help text and field list
+ * (right, scrollable). Clicking a tab in the index scrolls its section into view; the
+ * index highlights whichever section is currently scrolled to the top of the content
+ * pane (plain onScroll + getBoundingClientRect — see Task 8 in the plan for why this
+ * was chosen over IntersectionObserver).
+ *
+ * Reuses `Modal` purely for its portal + Escape-close plumbing; the right-anchored
+ * panel look and click-outside-to-close behavior are this component's own (Modal's
+ * own usage elsewhere is a centered dialog).
+ *
+ * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down allowlist
+ * (no `<a>`, no images) used for admin-authored documentation prose, not
+ * `RichTextSelector`'s permissive default DOMPurify call.
+ */
+const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
+  const { t } = useTranslation();
+  const sections = window ? buildHelpSections(window) : [];
+  const windowHelp = window?.helpComment?.trim() ?? "";
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setActiveTabId(sections[0]?.id ?? null);
+    }
+    // sections' identity changes every render (buildHelpSections returns a new array);
+    // reset only when the drawer transitions to open, not on every content recompute.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const scrollToTab = (tabId: string) => {
+    sectionRefs.current.get(tabId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const handleContentScroll = () => {
+    const containerTop = contentRef.current?.getBoundingClientRect().top ?? 0;
+    let current = sections[0]?.id ?? null;
+    for (const tab of sections) {
+      const el = sectionRefs.current.get(tab.id);
+      if (!el) continue;
+      const top = el.getBoundingClientRect().top - containerTop;
+      if (top <= ACTIVE_TAB_THRESHOLD_PX) {
+        current = tab.id;
+      } else {
+        break;
+      }
+    }
+    setActiveTabId(current);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: Modal already owns Escape-handling via a capture-phase document listener (Modal.tsx), so this overlay's click-only close doesn't need a redundant keyboard handler here. */}
+      <div
+        className="fixed inset-0 bg-black/20"
+        onClick={onClose}
+        role="presentation"
+        data-testid="help-drawer-overlay">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops the overlay's onClose click from firing; not itself an actionable control */}
+        <div
+          className="absolute right-0 top-0 h-full w-full max-w-2xl bg-white shadow-lg flex flex-col"
+          onClick={(e) => e.stopPropagation()}
+          role="presentation"
+          data-testid="help-drawer-panel">
+          <div className="flex items-center justify-between p-4 border-b border-gray-200">
+            <h2 className="text-lg font-bold">
+              {t("common.helpFor")} {window?.name}
+            </h2>
+            <button type="button" onClick={onClose} aria-label={t("common.close")}>
+              <CloseIcon className="w-4 h-4" />
+            </button>
+          </div>
+          {windowHelp && (
+            <div className="p-4 border-b border-gray-200">
+              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+              <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
+            </div>
+          )}
+          <div className="flex flex-1 min-h-0">
+            <nav
+              className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
+              aria-label={t("common.helpFor")}>
+              {sections.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => scrollToTab(tab.id)}
+                  className={`block w-full text-left px-2 py-1 rounded text-sm ${
+                    activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
+                  }`}
+                  data-testid={`help-toc-item-${tab.id}`}
+                  aria-current={activeTabId === tab.id ? "true" : undefined}>
+                  {tab.name}
+                </button>
+              ))}
+            </nav>
+            <div
+              ref={contentRef}
+              onScroll={handleContentScroll}
+              className="flex-1 overflow-y-auto p-4 space-y-6"
+              data-testid="help-drawer-content">
+              {sections.map((tab) => (
+                <section
+                  key={tab.id}
+                  ref={(el) => {
+                    if (el) {
+                      sectionRefs.current.set(tab.id, el);
+                    } else {
+                      sectionRefs.current.delete(tab.id);
+                    }
+                  }}>
+                  <h3 className="font-semibold">{tab.name}</h3>
+                  {tab.helpComment && (
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+                    <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                  )}
+                  {tab.fields.length > 0 && (
+                    <ul className="mt-2 space-y-2">
+                      {tab.fields.map((field) => (
+                        <li key={field.id}>
+                          <strong>{field.name}</strong>
+                          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+                          <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default HelpDrawer;
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+Run: `pnpm test:mainui -- HelpDrawer`
+Expected: PASS — all 6 pre-existing tests + 4 new tests (10 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/MainUI/components/HelpDrawer
+git commit -m "Hotfix ETP-4620: add tab index sidebar to HelpDrawer"
+```

--- a/docs/superpowers/specs/2026-08-03-help-widget-frontend-design.md
+++ b/docs/superpowers/specs/2026-08-03-help-widget-frontend-design.md
@@ -1,0 +1,170 @@
+# Help widget — frontend design
+
+> Data contract and backend verification: see the `com.etendoerp.metadata` repo,
+> `docs/superpowers/plans/2026-08-03-help-widget-data-contract.md`. Backend requires
+> **0 changes** (verified live against a running instance: `helpComment` already present at
+> window/tab/field levels).
+
+## Problem
+
+Classic Openbravo shows contextual Help for the active window via a navbar widget
+(`OBHelpAbout`) that opens `DisplayHelp.html`: window description + per-tab description +
+per-tab field list, all pre-translated. WorkspaceUI (the new UI) has no equivalent — users
+lose this documentation access when moving off Classic.
+
+The window metadata JSON the frontend already fetches carries all three levels of
+`helpComment` (window/tab/field), so no new endpoint is needed. What's missing is purely
+frontend: a trigger and a view.
+
+## Solution
+
+### Part 1: Trigger — navbar icon, not the toolbar
+
+**Location:** `packages/MainUI/components/navigation.tsx`, as a new standalone icon button,
+sibling to `CopilotButton` / `ConfigurationSection` / `ProfileModal` (around line 209-248).
+**Not** nested inside `ConfigurationModal`'s gear menu (where `About` currently lives).
+
+**Why navbar over toolbar:**
+- Help's trigger/content are window-level (once per active window). The Toolbar is
+  mounted once per visible tab level, and two instances can coexist simultaneously
+  (parent grid + expanded child) — putting Help there would need dedup logic for no gain.
+- The Toolbar is already visually packed (8-12 icon buttons in tight 32px pills). The
+  navbar has room.
+- Semantically Help is documentation/meta content, same category as About — not a
+  record/grid action like Save/Delete/Filter.
+
+**Why navbar icon over nesting inside the gear/config menu (like About):**
+- Help is used more frequently than About; burying it inside a settings dropdown adds a
+  click and visibility cost that doesn't match its usage frequency.
+
+**Icon:** reuse the existing `help-circle.svg` from `packages/ComponentLibrary/src/assets/icons`
+(no new asset needed), via the same `IconButton` + SVG pattern `CopilotButton` already uses
+for its own standalone navbar icon.
+
+**Visibility rule (spec §3 of the data-contract doc):**
+```ts
+const showHelp = Boolean(window?.helpComment?.trim());
+```
+Render nothing (not a disabled button) when false — including on Home/no-window screens.
+Source: `useMetadataContext().window` (Zustand-backed hook, callable directly from the
+navbar with no extra Provider wiring).
+
+**Click:** opens `HelpDrawer` with the active `window` metadata.
+
+### Part 2: Content — `HelpDrawer` component
+
+**Location (new file):** `packages/MainUI/components/HelpDrawer/HelpDrawer.tsx`
+
+Self-contained component: portal-based, overlay, slides in from the right, closes on
+Escape or overlay click. Modeled after `packages/MainUI/components/Modal.tsx`'s
+portal/Escape-handling approach, but implemented as its own component rather than a new
+generic `Drawer` primitive — there's a single consumer today; extract a shared primitive
+only if a second drawer use case shows up.
+
+**Why drawer over modal:** background UI stays usable/visible while Help is open — you can
+read a field's help text side-by-side with the form, instead of Help blocking the screen.
+
+**Content, in order:**
+1. Title: `Help for <window.name>`.
+2. `window.helpComment`, sanitized via the existing
+   `packages/MainUI/utils/processes/definition/sanitizeHtml.ts` (`sanitizeMessageHtml`) —
+   **not** `RichTextSelector.tsx`'s bare `DOMPurify.sanitize()`. The two are not
+   interchangeable: `sanitizeMessageHtml` locks down to `b/i/em/strong/br/span/p/ul/ol/li/code`
+   and forbids `<a>`; the bare call uses DOMPurify's default allowlist (links, images,
+   tables, headings all pass). Help text is system/admin-authored documentation prose
+   (mirrors Classic's `AD_*.HELP` columns, observed live content is plain `<p>` text) —
+   the locked-down allowlist is the safer default. **Links and images are out of scope**
+   for Help content in this version; if a real need for links surfaces later, extend
+   `sanitizeMessageHtml`'s allowlist deliberately rather than switching to the permissive
+   default.
+3. Per tab, **ordered by `tab.sequenceNumber`** (flatten across `tabLevel`, matching
+   Classic): tab name + sanitized `tab.helpComment`, then its field list.
+4. Per field within a tab, **ordered by `field.sequenceNumber`**: only fields where help
+   text exists — `field.helpComment || field.column?.helpComment` — non-help fields are
+   omitted (see rationale below). Audit synthetic fields (`isAuditField: true`) are
+   omitted entirely.
+5. No per-tab index/anchors in this version (optional per data-contract spec) — single
+   scrollable column.
+6. If the active window changes while the drawer is open (e.g. user opens a new window
+   from a link/menu), the drawer closes rather than silently swapping to the new window's
+   content — avoids showing stale or mismatched help without warning.
+
+**Why omit fields without help text:** Classic lists every field regardless of whether it
+has help. Replicating that here would pad the drawer with entries like "Delivered" (no
+help text) for every checkbox/flag field, adding noise without adding documentation value.
+The data-contract spec explicitly allows either choice for audit fields and treats the
+regular-field fallback as optional/front's call — showing only fields that actually carry
+help content keeps this a useful reference instead of a full field manifest.
+
+**Why the `field.column.helpComment` fallback:** confirmed against a live instance (Sales
+Order window, fields `taxableAmount` and `businessPartner`) that some fields have no
+`AD_FIELD.HELP` but do have `AD_COLUMN.HELP`. One extra `||` recovers real content that
+would otherwise silently disappear.
+
+### Part 3: Types
+
+**Location:** `packages/api-client/src/api/types.ts`
+
+- `WindowMetadata` (currently lines 513-521): add `helpComment?: string | null;`
+- `Tab` (currently lines 452-511): add `helpComment?: string | null;` **and**
+  `sequenceNumber: number;` — `Tab` currently has neither field typed, and tab ordering
+  (Part 2, item 3) depends on it. Verified live (Sales Order window, `etendo_26`) that the
+  backend sends `sequenceNumber` per tab already (e.g. Header tab → `10`, Lines → `20`) —
+  same as the already-confirmed `helpComment`, just not yet reflected in the type.
+- `Field` and `ADColumn` already have `helpComment` (and `Field` already has
+  `sequenceNumber`) — no change needed there.
+- `WindowMetadata.helpComment`/`Tab.helpComment` use `string | null` (not just
+  `string | undefined`) because the backend contract confirms the converter always writes
+  the key, valued JSON `null` when empty — it's never omitted. `window?.helpComment?.trim()`
+  works unchanged either way (optional chaining short-circuits on `null` same as
+  `undefined`). `Field.helpComment` (required `string`) and `ADColumn.helpComment`
+  (`string?`) are left as-is — pre-existing, intentional non-change, not an oversight;
+  existing `field.helpComment || ...` fallback call sites already tolerate either shape at
+  runtime.
+
+No backend change. No new API call — this data already arrives on the existing
+`Metadata.getWindow()` response; the fields were simply untyped/unused until now.
+
+## What is NOT changed
+
+- Backend / `com.etendoerp.metadata` module (0 changes, verified live).
+- `About`'s existing iframe-based modal (`AboutModal`, `ConfigurationModal`) — untouched,
+  Help does not reuse or modify that flow.
+- No generic `Drawer` primitive extracted from `HelpDrawer` — single consumer for now.
+- No tab-level or field-level trigger (spec §3: trigger is window-level only for this
+  version; extending to "help exists at any level" needs no backend work if done later).
+- No edit-help capability (out of scope, lives in Classic's compatibility module).
+
+## Test Cases
+
+### Trigger visibility (navbar icon)
+- `window.helpComment` = non-empty string → icon renders.
+- `window.helpComment` = `""` or whitespace-only → icon does not render.
+- `window.helpComment` = `null`/`undefined` → icon does not render.
+- No active window (Home screen) → icon does not render.
+- Clicking the icon opens `HelpDrawer` scoped to the currently active window's metadata
+  (end-to-end: trigger click → drawer open → content matches `window.name`/`helpComment`).
+
+### HelpDrawer content ordering
+- Tabs render ordered by `sequenceNumber`, regardless of `tabLevel` or original array order.
+- Fields within a tab render ordered by `sequenceNumber`.
+
+### HelpDrawer content filtering
+- Field with `helpComment` set → rendered with its own text.
+- Field with `helpComment` empty but `column.helpComment` set → rendered with the column's
+  text (fallback).
+- Field with neither → omitted from the list.
+- Field with `isAuditField: true` → omitted regardless of help content.
+- Tab with empty `helpComment` → tab name still renders as a section header; no empty
+  paragraph shown; its field list (if any qualifying fields) still renders.
+
+### Sanitization
+- `helpComment` containing `<script>` or on* attributes → stripped before render.
+- `helpComment` containing allowed formatting tags (e.g. `<p>`, `<b>`) → preserved.
+- `helpComment` containing `<a href="...">` → tag stripped (out of scope per `sanitizeMessageHtml`'s allowlist), text content preserved.
+
+### Drawer interaction
+- Escape key closes the drawer.
+- Click outside (overlay) closes the drawer.
+- Background UI (grid/form) remains interactive while drawer is open.
+- Switching the active window while the drawer is open closes it (no stale content shown).

--- a/docs/superpowers/specs/2026-08-04-help-drawer-layout-push-design.md
+++ b/docs/superpowers/specs/2026-08-04-help-drawer-layout-push-design.md
@@ -1,0 +1,225 @@
+# Help drawer — layout-push architecture
+
+> Builds on `docs/superpowers/specs/2026-08-03-help-widget-frontend-design.md` and
+> `docs/superpowers/plans/2026-08-03-help-widget-frontend.md` (Tasks 1-8, already
+> implemented and committed on `hotfix/ETP-4620` through commit `edddfe01d`). This doc
+> covers ONLY the architecture change described below — everything else already built
+> (types, `buildHelpContent`, `HelpButton`, the tab-index sidebar + scroll-spy inside
+> `HelpDrawer`, translations, sanitization) stays as-is.
+
+## Problem
+
+`HelpDrawer` (Task 4/8) is currently overlay-based: portal-rendered via `Modal`
+(`position: fixed`, `createPortal` to `document.body`), with a full-screen click-catching
+backdrop (`fixed inset-0 bg-black/20`, `onClick={onClose}`). This **contradicts the original
+intent** ("background UI stays usable while Help is open" — design doc, Part 2): the
+backdrop currently captures every click behind the drawer, so a user can *see* the
+table/grid but cannot *click into it* while Help is open — the opposite of "read Help and
+work at the same time."
+
+**User request (2026-08-04):** make the Help panel behave like the app's existing left-hand
+navigation `Drawer` (`packages/ComponentLibrary/src/components/Drawer`) — a panel that
+takes real layout space and **pushes** the main content area to shrink, rather than floating
+on top of it. This lets the user navigate/read Help and interact with the grid/table
+simultaneously, matching how the left nav drawer already behaves.
+
+## Investigation findings (informs the design below)
+
+- The left-nav Drawer's push mechanism is a plain flex row, not CSS Grid: the drawer is a
+  real (non-`fixed`, non-portal) flex child with an animated `width`
+  (`DRAWER_OPEN_WIDTH = 16.25rem` / `DRAWER_CLOSED_WIDTH = 3.5rem`,
+  `transition-all duration-500`), and its sibling has `flex-1` — the browser's box model
+  does the "pushing" for free (`packages/ComponentLibrary/src/components/Drawer/index.tsx:124-128`).
+- That Drawer is rendered from `packages/MainUI/components/layout.tsx` (`LayoutContent`), as
+  a **direct sibling** of the flex-col wrapper containing `Navigation` + `{children}`
+  (the window/table content):
+  ```tsx
+  <div className="flex w-full h-full relative overflow-hidden">
+    <Sidebar /> {/* renders <Drawer> */}
+    <div className="flex flex-1 flex-col ...">
+      <div className="w-full h-14 ..."><Navigation /></div>
+      <div className="flex flex-1 ...">{children}</div>
+    </div>
+    <ProcessStackHost />
+  </div>
+  ```
+- **`HelpAccess`/`HelpDrawer` currently render from deep inside `Navigation`**, which is
+  nested *inside* the content-column wrapper — not a sibling of `Sidebar`/`{children}`. A
+  component that deep cannot make a non-adjacent tree branch resize via plain CSS/flexbox.
+  Achieving the same push effect requires **moving where `HelpDrawer` actually renders** —
+  up into `LayoutContent`, as a new sibling — while the trigger button stays in `Navigation`.
+- The left-nav Drawer's open/closed flag is local `useState` in `Drawer` itself (persisted
+  only to `localStorage`, not reactive elsewhere) — there is **no existing shared
+  store/context** for "is a panel open" that a new Help panel could reuse. One needs to be
+  created.
+- No existing responsive/mobile fallback exists for the left-nav Drawer (it always pushes,
+  never becomes an overlay on narrow viewports) — this design intentionally does not invent
+  one for Help either, for consistency with the existing accepted tradeoff.
+
+## Solution
+
+### Part 1: New Zustand store — `useHelpPanelStore`
+
+**Location (new file):** `packages/MainUI/stores/helpPanelStore.ts`
+
+```ts
+interface HelpPanelState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+```
+
+Wrap with the `devtools` middleware, matching the existing convention (e.g.
+`packages/MainUI/stores/loadingStore.ts` uses `devtools(...)` from `zustand/middleware`) —
+for consistency, not because this store needs debugging beyond what any other store gets.
+
+Necessary because `HelpAccess` (trigger, stays inside `Navigation`) and the panel itself
+(moves to `LayoutContent`) are in non-adjacent branches of the tree — local state or prop
+drilling can't bridge that, and this app has no layout-level React Context to reuse. A small
+dedicated Zustand store matches the codebase's own established pattern for this kind of
+cross-tree UI state (see `windowStore`, `userStore`, `preferencesStore`, etc. — all small,
+single-purpose stores, not one mega-store).
+
+### Part 2: `HelpDrawer` moves into `LayoutContent`, becomes a real layout element
+
+**Modify:** `packages/MainUI/components/layout.tsx` — add `HelpDrawer` as a third sibling,
+after the content column:
+
+```tsx
+<div className="flex w-full h-full relative overflow-hidden">
+  <Sidebar />
+  <div className="flex flex-1 flex-col ...">
+    <div className="w-full h-14 ..."><Navigation /></div>
+    <div className="flex flex-1 ...">{children}</div>
+  </div>
+  <HelpDrawer /> {/* new: reads useHelpPanelStore + useMetadataContext itself */}
+  <ProcessStackHost />
+</div>
+```
+
+**Rewrite `HelpDrawer.tsx`:** no more `Modal`, no portal, no `position: fixed`, no backdrop.
+Instead, a real flex child with an animated `width` — same mechanical pattern as the
+left-nav `Drawer` (`width: isOpen ? "42rem" : "0"`, `transition-all duration-500`,
+`overflow-hidden` while closed so content doesn't leak/reflow oddly during the collapse).
+`HelpDrawer` now reads `isOpen` from `useHelpPanelStore` and `window` from
+`useMetadataContext()` directly (previously these were passed down as props from
+`HelpAccess` — now there's no parent-child relationship between them, so `HelpDrawer`
+becomes self-sufficient, the same way the left-nav `Drawer`/`Sidebar` don't need window
+metadata piped in from `Navigation` either).
+
+All internal content (header, window help, tab-index sidebar, scroll-spy content pane,
+sanitization) is **unchanged** — only the outer wrapper changes from
+`fixed`/portal/backdrop to a real, width-animated flex child.
+
+`HelpDrawer`'s own X-button and Escape handler now call `useHelpPanelStore().close()`
+directly — it no longer receives `onClose` as a prop (there's no longer a parent-child
+relationship with `HelpAccess` to pass one down from).
+
+**Behavior change from today, worth calling out explicitly:** `HelpDrawer` now mounts
+unconditionally in `layout.tsx` (previously it only rendered as a child when `HelpAccess`'s
+own `shouldShowHelp` gate passed). This is safe — `buildHelpSections`/`windowHelp` already
+null-guard a missing/helpless window — but a fresh implementer should know this is an
+intentional shift, not an oversight: the panel itself always exists in the tree now (at
+`width: 0` when closed or when there's nothing to show), only the *trigger button* in
+`Navigation` is conditionally rendered.
+
+### Part 3: `HelpAccess` becomes trigger-only
+
+**Modify:** `packages/MainUI/components/Header/HelpAccess.tsx` — drops `HelpDrawer`
+rendering and its own `open`/`useEffect` close-on-window-change logic entirely (the panel no
+longer lives here, so there's nothing local left to own). Keeps: reading `window` from
+`useMetadataContext()` to gate whether `HelpButton` renders at all (`shouldShowHelp`), and
+now calls `useHelpPanelStore().toggle()` on click instead of local `setOpen(true)`.
+
+**Toggle behavior (user confirmed 2026-08-04):** clicking the Help icon again closes the
+panel — it's a toggle, not just an "open" trigger. `HelpButton` itself doesn't need to
+change (it's still a dumb `onClick` prop); `HelpAccess` just wires that click to
+`toggle()` instead of `open()`.
+
+**Close-on-window-change:** the original rule ("if the active window changes while Help is
+open, close it") still applies. Home it in `HelpDrawer` (a `windowId`-keyed effect, same
+shape as the current `HelpAccess` one, just moved) — per Part 2, `HelpDrawer` is now the
+component with direct access to both `isOpen` (via the store) and the active window (via
+`useMetadataContext()`), so it's the natural, sole owner of this rule; no other component
+needs to be involved.
+
+**Close affordances now:** the explicit close (X) button, Escape key, and the toggle button
+itself. **Click-outside-to-close is intentionally dropped** — there is no more "outside"
+being covered once the panel takes real layout space instead of floating over content; this
+mirrors the left-nav Drawer's own behavior (it has no click-outside-to-close either, since
+nothing is covered).
+
+### Part 4: Escape-to-close
+
+Since `Modal` is no longer reused, `HelpDrawer` needs its own minimal Escape-key handling
+(a small `useEffect` with a `document.addEventListener("keydown", ...)`, scoped to only
+attach while `isOpen` is true). This is a few lines — not worth extracting a shared
+hook/primitive for a single consumer (same YAGNI reasoning as the original decision not to
+build a generic `Drawer` primitive).
+
+## What is NOT changed
+
+- `buildHelpContent.ts` (ordering/filtering logic) — untouched.
+- `HelpButton` (ComponentLibrary presentational component) — untouched, still a dumb
+  `onClick` wrapper.
+- The tab-index sidebar, scroll-spy (`onScroll`/`getBoundingClientRect`), and all
+  sanitization (`sanitizeMessageHtml`, all 3 call sites) inside `HelpDrawer` — unchanged,
+  just re-parented into the new non-portal wrapper.
+- The existing left-nav `Drawer` component itself — not modified; only its *pattern* is
+  mirrored for the new Help panel.
+- No responsive/mobile fallback added (consistent with the existing Drawer's own lack of
+  one).
+- Translation keys (`common.help`, `common.helpFor`) — untouched.
+- No backend changes (still 0, unaffected by this frontend-only architecture shift).
+
+## Test cases
+
+### `useHelpPanelStore` (new, unit)
+- `open()` sets `isOpen: true`; `close()` sets `isOpen: false`; `toggle()` flips it either
+  direction.
+- Initial state is `isOpen: false`.
+
+### `HelpAccess` (rewritten)
+- Still renders nothing when `shouldShowHelp(window)` is false (unchanged rule).
+- Clicking the button calls `useHelpPanelStore().toggle()` (not `open()`).
+- No longer owns/tests any drawer-open local state or close-on-window-change effect (moved
+  out — those tests move to wherever that logic now lives, per Part 3).
+
+### `HelpDrawer` (rewritten)
+- Renders with `width: 0`-equivalent (collapsed) when `useHelpPanelStore().isOpen` is false;
+  expanded width when true. (Adjust the concrete assertion to however "collapsed" is
+  expressed in the implementation — e.g. a class name or inline style — once decided in the
+  plan.)
+- All existing content-rendering tests from Tasks 4/8 (title, sanitization, tab ordering,
+  field filtering, sidebar index, scroll-spy) continue to apply unchanged in substance —
+  only the mocking setup changes (mock `useHelpPanelStore` and `useMetadataContext` instead
+  of receiving `open`/`window`/`onClose` as props).
+- Escape key closes the panel (new: no longer inherited for free from `Modal`, must be
+  directly tested here).
+- **Removed**: "calls onClose when clicking the overlay" / "does not call onClose when
+  clicking inside the panel" — these tested backdrop/click-catching behavior that no longer
+  exists.
+- Close-on-window-change (wherever it ends up living per Part 3) still has a test proving
+  the panel closes when the active window changes while open.
+
+### `layout.tsx` (integration, if this repo has layout-level tests — check before writing new
+ones; may only be verifiable via the manual QA step given the file's existing test coverage)
+- `HelpDrawer` renders as a sibling of the content column, not inside `Navigation`.
+- Opening Help visibly shrinks the content column's available width (manual/visual
+  verification — not easily unit-testable without a real browser layout engine; jsdom
+  doesn't compute real layout).
+
+## Manual QA (blocking before considering this done, same caveat as the original plan)
+
+- Open a window with help configured, click the Help icon: panel opens by pushing the grid
+  content over (not floating on top with a dimmed background).
+- Click a row/cell in the grid while Help is open: it responds normally (this is the whole
+  point of this rework — confirm it actually works, not just that nothing crashes).
+- Click the Help icon again: panel closes (toggle).
+- Press Escape: panel closes.
+- Change the active window while Help is open: panel closes.
+- Left nav Drawer open + Help panel open at the same time: confirm the three-way layout
+  (nav Drawer | content | Help panel) doesn't visually break (content column doesn't
+  collapse to zero/negative width on a typical viewport).

--- a/packages/ComponentLibrary/src/components/Help/HelpButton.test.tsx
+++ b/packages/ComponentLibrary/src/components/Help/HelpButton.test.tsx
@@ -1,0 +1,76 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import HelpButton from "./HelpButton";
+
+jest.mock("../../assets/icons/help-circle.svg", () => {
+  return function HelpIcon() {
+    return <svg data-testid="help-icon" />;
+  };
+});
+
+describe("HelpButton", () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    mockOnClick.mockClear();
+  });
+
+  it("renders with default props", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-label", "Help");
+  });
+
+  it("calls onClick when clicked", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the help icon", () => {
+    render(<HelpButton onClick={mockOnClick} />);
+    expect(screen.getByTestId("help-icon")).toBeInTheDocument();
+  });
+
+  it("applies custom tooltip", () => {
+    render(<HelpButton onClick={mockOnClick} tooltip="Custom Tooltip" />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-label", "Custom Tooltip");
+  });
+
+  it("respects disabled prop", () => {
+    render(<HelpButton onClick={mockOnClick} disabled={true} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+  });
+
+  it("applies custom className", () => {
+    render(<HelpButton onClick={mockOnClick} iconButtonClassName="custom-class" />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveClass("custom-class");
+  });
+});

--- a/packages/ComponentLibrary/src/components/Help/HelpButton.tsx
+++ b/packages/ComponentLibrary/src/components/Help/HelpButton.tsx
@@ -1,0 +1,40 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import IconButton from "../IconButton";
+import HelpIcon from "../../assets/icons/help-circle.svg";
+import type { HelpButtonProps } from "./types";
+
+const HelpButton: React.FC<HelpButtonProps> = ({
+  onClick,
+  tooltip = "Help",
+  disabled = false,
+  iconButtonClassName = "w-10 h-10",
+}) => {
+  return (
+    <IconButton
+      onClick={onClick}
+      tooltip={tooltip}
+      disabled={disabled}
+      className={iconButtonClassName}
+      ariaLabel={tooltip}>
+      <HelpIcon />
+    </IconButton>
+  );
+};
+
+export default HelpButton;

--- a/packages/ComponentLibrary/src/components/Help/types.ts
+++ b/packages/ComponentLibrary/src/components/Help/types.ts
@@ -1,0 +1,23 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+export interface HelpButtonProps {
+  onClick: () => void;
+  tooltip?: string;
+  disabled?: boolean;
+  iconButtonClassName?: string;
+}

--- a/packages/ComponentLibrary/src/components/index.ts
+++ b/packages/ComponentLibrary/src/components/index.ts
@@ -36,6 +36,7 @@ import CopilotPopupCustom from "./Copilot/CopilotPopup";
 import RadioGridCustom from "./RadioGrid";
 import AboutButtonComp from "./About/AboutButton";
 import AboutModalComp from "./About/AboutModal";
+import HelpButtonComp from "./Help/HelpButton";
 import LinkedItemsCustom from "./LinkedItems";
 import { RecordCounterBar, RecordCounter, SelectionCounter } from "./Table/RecordCounters";
 
@@ -60,6 +61,7 @@ const CopilotPopup = CopilotPopupCustom;
 const RadioGrid = RadioGridCustom;
 const AboutButton = AboutButtonComp;
 const AboutModal = AboutModalComp;
+const HelpButton = HelpButtonComp;
 const LinkedItems = LinkedItemsCustom;
 
 export {
@@ -84,6 +86,7 @@ export {
   RadioGrid,
   AboutButton,
   AboutModal,
+  HelpButton,
   LinkedItems,
   RecordCounterBar,
   RecordCounter,

--- a/packages/ComponentLibrary/src/locales/en.ts
+++ b/packages/ComponentLibrary/src/locales/en.ts
@@ -49,6 +49,7 @@ const en = {
     about: "About",
     help: "Help",
     helpFor: "Help for",
+    backToTop: "Go to the top",
     clone: "Clone",
     cloneWithChildren: "Clone With Children",
     change: "Change",

--- a/packages/ComponentLibrary/src/locales/en.ts
+++ b/packages/ComponentLibrary/src/locales/en.ts
@@ -47,6 +47,8 @@ const en = {
     records: "records",
     version: "Version: ",
     about: "About",
+    help: "Help",
+    helpFor: "Help for",
     clone: "Clone",
     cloneWithChildren: "Clone With Children",
     change: "Change",

--- a/packages/ComponentLibrary/src/locales/es.ts
+++ b/packages/ComponentLibrary/src/locales/es.ts
@@ -46,6 +46,8 @@ const es = {
     records: "registros",
     version: "Versión: ",
     about: "Acerca de",
+    help: "Ayuda",
+    helpFor: "Ayuda de",
     clone: "Clonar",
     cloneWithChildren: "Clonar con hijos",
     change: "Cambiar",

--- a/packages/ComponentLibrary/src/locales/es.ts
+++ b/packages/ComponentLibrary/src/locales/es.ts
@@ -48,6 +48,7 @@ const es = {
     about: "Acerca de",
     help: "Ayuda",
     helpFor: "Ayuda de",
+    backToTop: "Ir arriba",
     clone: "Clonar",
     cloneWithChildren: "Clonar con hijos",
     change: "Cambiar",

--- a/packages/MainUI/__tests__/app/layout.test.tsx
+++ b/packages/MainUI/__tests__/app/layout.test.tsx
@@ -37,6 +37,12 @@ jest.mock("@/components/Layout/GlobalLoading", () => {
   };
 });
 
+jest.mock("@/components/HelpDrawer/HelpDrawer", () => {
+  return function MockHelpDrawer(props: any) {
+    return <div {...props}>HelpDrawer</div>;
+  };
+});
+
 describe("Layout Component", () => {
   const mockChildren = <div data-testid="test-children">Test Content</div>;
 

--- a/packages/MainUI/components/Header/HelpAccess.tsx
+++ b/packages/MainUI/components/Header/HelpAccess.tsx
@@ -39,7 +39,7 @@ const HelpAccess: React.FC = () => {
     return null;
   }
 
-  return <HelpButton onClick={toggle} tooltip={t("common.help")} />;
+  return <HelpButton onClick={toggle} tooltip={t("common.help")} data-testid="HelpButton__ad3365" />;
 };
 
 export default HelpAccess;

--- a/packages/MainUI/components/Header/HelpAccess.tsx
+++ b/packages/MainUI/components/Header/HelpAccess.tsx
@@ -17,43 +17,29 @@
 
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { useMetadataContext } from "@/contexts/metadata";
 import { useTranslation } from "@/hooks/useTranslation";
 import { HelpButton } from "@workspaceui/componentlibrary/src/components";
 import { shouldShowHelp } from "@/utils/help/buildHelpContent";
-import HelpDrawer from "../HelpDrawer/HelpDrawer";
+import { useHelpPanelStore } from "@/stores/helpPanelStore";
 
 /**
- * Orchestrates access to contextual Help for the active window: decides
- * whether the Help trigger should be mounted at all (`shouldShowHelp`),
- * owns the drawer's open/close state, and closes the drawer whenever the
- * active window changes while it's open — a stale window's help content
- * should never linger onscreen after the user navigates away from it.
+ * Trigger for contextual Help on the active window: decides whether the Help
+ * button should be mounted at all (`shouldShowHelp`) and toggles the shared
+ * `useHelpPanelStore`. The panel itself (`HelpDrawer`) renders elsewhere in
+ * the tree (`layout.tsx`) since it needs to sit as a layout sibling of the
+ * content column, not nested inside `Navigation`.
  */
 const HelpAccess: React.FC = () => {
   const { t } = useTranslation();
-  const { window, windowId } = useMetadataContext();
-  const [open, setOpen] = useState(false);
-  const previousWindowId = useRef(windowId);
-
-  useEffect(() => {
-    if (open && previousWindowId.current !== windowId) {
-      setOpen(false);
-    }
-    previousWindowId.current = windowId;
-  }, [windowId, open]);
+  const { window } = useMetadataContext();
+  const toggle = useHelpPanelStore((state) => state.toggle);
 
   if (!shouldShowHelp(window)) {
     return null;
   }
 
-  return (
-    <>
-      <HelpButton onClick={() => setOpen(true)} tooltip={t("common.help")} />
-      <HelpDrawer open={open} window={window} onClose={() => setOpen(false)} />
-    </>
-  );
+  return <HelpButton onClick={toggle} tooltip={t("common.help")} />;
 };
 
 export default HelpAccess;

--- a/packages/MainUI/components/Header/HelpAccess.tsx
+++ b/packages/MainUI/components/Header/HelpAccess.tsx
@@ -1,0 +1,59 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMetadataContext } from "@/contexts/metadata";
+import { useTranslation } from "@/hooks/useTranslation";
+import { HelpButton } from "@workspaceui/componentlibrary/src/components";
+import { shouldShowHelp } from "@/utils/help/buildHelpContent";
+import HelpDrawer from "../HelpDrawer/HelpDrawer";
+
+/**
+ * Orchestrates access to contextual Help for the active window: decides
+ * whether the Help trigger should be mounted at all (`shouldShowHelp`),
+ * owns the drawer's open/close state, and closes the drawer whenever the
+ * active window changes while it's open — a stale window's help content
+ * should never linger onscreen after the user navigates away from it.
+ */
+const HelpAccess: React.FC = () => {
+  const { t } = useTranslation();
+  const { window, windowId } = useMetadataContext();
+  const [open, setOpen] = useState(false);
+  const previousWindowId = useRef(windowId);
+
+  useEffect(() => {
+    if (open && previousWindowId.current !== windowId) {
+      setOpen(false);
+    }
+    previousWindowId.current = windowId;
+  }, [windowId, open]);
+
+  if (!shouldShowHelp(window)) {
+    return null;
+  }
+
+  return (
+    <>
+      <HelpButton onClick={() => setOpen(true)} tooltip={t("common.help")} />
+      <HelpDrawer open={open} window={window} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export default HelpAccess;

--- a/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
+++ b/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
@@ -40,8 +40,11 @@ describe("HelpAccess", () => {
     useHelpPanelStore.setState({ isOpen: false });
   });
 
-  it("renders nothing when the active window has no helpComment", () => {
-    mockUseMetadataContext.mockReturnValue({ windowId: "w1", window: createMockWindowMetadata("w1") });
+  it("renders nothing when the active window has no help content anywhere", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: null, tabs: [] },
+    });
     render(<HelpAccess />);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
@@ -50,6 +53,15 @@ describe("HelpAccess", () => {
     mockUseMetadataContext.mockReturnValue({
       windowId: "w1",
       window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    render(<HelpAccess />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("renders the trigger when window-level help is blank but a field has help text (e.g. Toolbar)", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: null },
     });
     render(<HelpAccess />);
     expect(screen.getByRole("button")).toBeInTheDocument();

--- a/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
+++ b/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
@@ -1,0 +1,92 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import HelpAccess from "../HelpAccess";
+import { createMockWindowMetadata } from "@/utils/tests/mockHelpers";
+
+const mockUseMetadataContext = jest.fn();
+jest.mock("@/contexts/metadata", () => ({
+  useMetadataContext: () => mockUseMetadataContext(),
+}));
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/help-circle.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="help-icon" />,
+}));
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="close-icon" />,
+}));
+jest.mock("../../Modal", () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="mock-modal">{children}</div> : null,
+}));
+
+describe("HelpAccess", () => {
+  beforeEach(() => {
+    mockUseMetadataContext.mockReset();
+  });
+
+  it("renders nothing when the active window has no helpComment", () => {
+    mockUseMetadataContext.mockReturnValue({ windowId: "w1", window: createMockWindowMetadata("w1") });
+    render(<HelpAccess />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("renders the trigger when the active window has helpComment", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    render(<HelpAccess />);
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("opens the drawer when the trigger is clicked", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    render(<HelpAccess />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
+  });
+
+  it("closes the drawer when the active window changes", () => {
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w1",
+      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
+    });
+    const { rerender } = render(<HelpAccess />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
+
+    mockUseMetadataContext.mockReturnValue({
+      windowId: "w2",
+      window: { ...createMockWindowMetadata("w2"), helpComment: "Other help" },
+    });
+    rerender(<HelpAccess />);
+
+    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+  });
+});

--- a/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
+++ b/packages/MainUI/components/Header/__tests__/HelpAccess.test.tsx
@@ -17,6 +17,7 @@
 
 import { render, screen, fireEvent } from "@testing-library/react";
 import HelpAccess from "../HelpAccess";
+import { useHelpPanelStore } from "@/stores/helpPanelStore";
 import { createMockWindowMetadata } from "@/utils/tests/mockHelpers";
 
 const mockUseMetadataContext = jest.fn();
@@ -32,19 +33,11 @@ jest.mock("@workspaceui/componentlibrary/src/assets/icons/help-circle.svg", () =
   __esModule: true,
   default: () => <svg data-testid="help-icon" />,
 }));
-jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
-  __esModule: true,
-  default: () => <svg data-testid="close-icon" />,
-}));
-jest.mock("../../Modal", () => ({
-  __esModule: true,
-  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
-    open ? <div data-testid="mock-modal">{children}</div> : null,
-}));
 
 describe("HelpAccess", () => {
   beforeEach(() => {
     mockUseMetadataContext.mockReset();
+    useHelpPanelStore.setState({ isOpen: false });
   });
 
   it("renders nothing when the active window has no helpComment", () => {
@@ -62,31 +55,17 @@ describe("HelpAccess", () => {
     expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
-  it("opens the drawer when the trigger is clicked", () => {
+  it("toggles the help panel store when the trigger is clicked", () => {
     mockUseMetadataContext.mockReturnValue({
       windowId: "w1",
       window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
     });
     render(<HelpAccess />);
+
     fireEvent.click(screen.getByRole("button"));
-    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
-  });
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
 
-  it("closes the drawer when the active window changes", () => {
-    mockUseMetadataContext.mockReturnValue({
-      windowId: "w1",
-      window: { ...createMockWindowMetadata("w1"), helpComment: "Some help" },
-    });
-    const { rerender } = render(<HelpAccess />);
     fireEvent.click(screen.getByRole("button"));
-    expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
-
-    mockUseMetadataContext.mockReturnValue({
-      windowId: "w2",
-      window: { ...createMockWindowMetadata("w2"), helpComment: "Other help" },
-    });
-    rerender(<HelpAccess />);
-
-    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
   });
 });

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -18,6 +18,7 @@
 "use client";
 
 import type React from "react";
+import { useEffect, useRef, useState } from "react";
 import Modal from "../Modal";
 import { sanitizeMessageHtml } from "@/utils/processes/definition/sanitizeHtml";
 import { buildHelpSections } from "@/utils/help/buildHelpContent";
@@ -31,23 +32,62 @@ export interface HelpDrawerProps {
   onClose: () => void;
 }
 
+const ACTIVE_TAB_THRESHOLD_PX = 16;
+
 /**
- * Right-anchored panel showing contextual Help for the active window:
- * window-level help text, followed by each tab's help text and the list of
- * fields (within that tab) that carry help content.
+ * Right-anchored panel showing contextual Help for the active window: window-level
+ * help text, then a tab index (left) and, for each tab, its help text and field list
+ * (right, scrollable). Clicking a tab in the index scrolls its section into view; the
+ * index highlights whichever section is currently scrolled to the top of the content
+ * pane (plain onScroll + getBoundingClientRect — see Task 8 in the plan for why this
+ * was chosen over IntersectionObserver).
  *
- * Reuses `Modal` purely for its portal + Escape-close plumbing; the
- * right-anchored panel look and click-outside-to-close behavior are this
- * component's own (Modal's own usage elsewhere is a centered dialog).
+ * Reuses `Modal` purely for its portal + Escape-close plumbing; the right-anchored
+ * panel look and click-outside-to-close behavior are this component's own (Modal's
+ * own usage elsewhere is a centered dialog).
  *
- * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down
- * allowlist (no `<a>`, no images) used for admin-authored documentation
- * prose, not `RichTextSelector`'s permissive default DOMPurify call.
+ * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down allowlist
+ * (no `<a>`, no images) used for admin-authored documentation prose, not
+ * `RichTextSelector`'s permissive default DOMPurify call.
  */
 const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
   const { t } = useTranslation();
   const sections = window ? buildHelpSections(window) : [];
   const windowHelp = window?.helpComment?.trim() ?? "";
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+
+  // sections' identity changes every render (buildHelpSections returns a new array);
+  // reset only when the drawer transitions to open, not on every content recompute.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset only on open transition, not on every sections recompute (sections is a new array identity every render)
+  useEffect(() => {
+    if (open) {
+      setActiveTabId(sections[0]?.id ?? null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const scrollToTab = (tabId: string) => {
+    sectionRefs.current.get(tabId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const handleContentScroll = () => {
+    const containerTop = contentRef.current?.getBoundingClientRect().top ?? 0;
+    let current = sections[0]?.id ?? null;
+    for (const tab of sections) {
+      const el = sectionRefs.current.get(tab.id);
+      if (!el) continue;
+      const top = el.getBoundingClientRect().top - containerTop;
+      if (top <= ACTIVE_TAB_THRESHOLD_PX) {
+        current = tab.id;
+      } else {
+        break;
+      }
+    }
+    setActiveTabId(current);
+  };
 
   return (
     <Modal open={open} onClose={onClose}>
@@ -59,7 +99,7 @@ const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
         data-testid="help-drawer-overlay">
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops the overlay's onClose click from firing; not itself an actionable control */}
         <div
-          className="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-lg overflow-y-auto"
+          className="absolute right-0 top-0 h-full w-full max-w-2xl bg-white shadow-lg flex flex-col"
           onClick={(e) => e.stopPropagation()}
           role="presentation"
           data-testid="help-drawer-panel">
@@ -71,31 +111,64 @@ const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
               <CloseIcon className="w-4 h-4" />
             </button>
           </div>
-          <div className="p-4 space-y-6">
-            {windowHelp && (
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+          {windowHelp && (
+            <div className="p-4 border-b border-gray-200">
+              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
               <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
-            )}
-            {sections.map((tab) => (
-              <section key={tab.id}>
-                <h3 className="font-semibold">{tab.name}</h3>
-                {tab.helpComment && (
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
-                  <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
-                )}
-                {tab.fields.length > 0 && (
-                  <ul className="mt-2 space-y-2">
-                    {tab.fields.map((field) => (
-                      <li key={field.id}>
-                        <strong>{field.name}</strong>
-                        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
-                        <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
-            ))}
+            </div>
+          )}
+          <div className="flex flex-1 min-h-0">
+            <nav
+              className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
+              aria-label={t("common.helpFor")}>
+              {sections.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => scrollToTab(tab.id)}
+                  className={`block w-full text-left px-2 py-1 rounded text-sm ${
+                    activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
+                  }`}
+                  data-testid={`help-toc-item-${tab.id}`}
+                  aria-current={activeTabId === tab.id ? "true" : undefined}>
+                  {tab.name}
+                </button>
+              ))}
+            </nav>
+            <div
+              ref={contentRef}
+              onScroll={handleContentScroll}
+              className="flex-1 overflow-y-auto p-4 space-y-6"
+              data-testid="help-drawer-content">
+              {sections.map((tab) => (
+                <section
+                  key={tab.id}
+                  ref={(el) => {
+                    if (el) {
+                      sectionRefs.current.set(tab.id, el);
+                    } else {
+                      sectionRefs.current.delete(tab.id);
+                    }
+                  }}>
+                  <h3 className="font-semibold">{tab.name}</h3>
+                  {tab.helpComment && (
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+                    <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                  )}
+                  {tab.fields.length > 0 && (
+                    <ul className="mt-2 space-y-2">
+                      {tab.fields.map((field) => (
+                        <li key={field.id}>
+                          <strong>{field.name}</strong>
+                          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+                          <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -19,55 +19,78 @@
 
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
-import Modal from "../Modal";
 import { sanitizeMessageHtml } from "@/utils/processes/definition/sanitizeHtml";
 import { buildHelpSections } from "@/utils/help/buildHelpContent";
 import { useTranslation } from "@/hooks/useTranslation";
+import { useMetadataContext } from "@/contexts/metadata";
+import { useHelpPanelStore } from "@/stores/helpPanelStore";
 import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
-import type { WindowMetadata } from "@workspaceui/api-client/src/api/types";
-
-export interface HelpDrawerProps {
-  open: boolean;
-  window: WindowMetadata | null | undefined;
-  onClose: () => void;
-}
 
 const ACTIVE_TAB_THRESHOLD_PX = 16;
+const PANEL_WIDTH = "42rem";
 
 /**
- * Right-anchored panel showing contextual Help for the active window: window-level
+ * Right-hand panel showing contextual Help for the active window: window-level
  * help text, then a tab index (left) and, for each tab, its help text and field list
  * (right, scrollable). Clicking a tab in the index scrolls its section into view; the
  * index highlights whichever section is currently scrolled to the top of the content
- * pane (plain onScroll + getBoundingClientRect — see Task 8 in the plan for why this
- * was chosen over IntersectionObserver).
+ * pane (plain onScroll + getBoundingClientRect — see Task 8 of the original plan for
+ * why this was chosen over IntersectionObserver).
  *
- * Reuses `Modal` purely for its portal + Escape-close plumbing; the right-anchored
- * panel look and click-outside-to-close behavior are this component's own (Modal's
- * own usage elsewhere is a centered dialog).
+ * Renders as a real flex sibling in `layout.tsx` (not a portal/overlay) so opening it
+ * pushes the content column instead of covering it — width-animated like the left-nav
+ * `Drawer`, though (unlike that Drawer, which only animates between two non-zero
+ * widths) this one collapses fully to 0, so an inner fixed-width wrapper keeps the
+ * header/content from visibly squishing mid-transition. Self-sufficient: reads
+ * `isOpen` from `useHelpPanelStore` and the active window from `useMetadataContext()`
+ * directly, since it has no parent-child relationship with the trigger button
+ * (`HelpAccess`, which lives in `Navigation`).
  *
  * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down allowlist
  * (no `<a>`, no images) used for admin-authored documentation prose, not
  * `RichTextSelector`'s permissive default DOMPurify call.
  */
-const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
+const HelpDrawer: React.FC = () => {
   const { t } = useTranslation();
+  const { window, windowId } = useMetadataContext();
+  const isOpen = useHelpPanelStore((state) => state.isOpen);
+  const close = useHelpPanelStore((state) => state.close);
+
   const sections = window ? buildHelpSections(window) : [];
   const windowHelp = window?.helpComment?.trim() ?? "";
 
   const contentRef = useRef<HTMLDivElement | null>(null);
   const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const previousWindowId = useRef(windowId);
 
   // sections' identity changes every render (buildHelpSections returns a new array);
   // reset only when the drawer transitions to open, not on every content recompute.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset only on open transition, not on every sections recompute (sections is a new array identity every render)
   useEffect(() => {
-    if (open) {
+    if (isOpen) {
       setActiveTabId(sections[0]?.id ?? null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [isOpen]);
+
+  // A stale window's help content should never linger onscreen after the user
+  // navigates away from it while the panel is open.
+  useEffect(() => {
+    if (isOpen && previousWindowId.current !== windowId) {
+      close();
+    }
+    previousWindowId.current = windowId;
+  }, [windowId, isOpen, close]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, close]);
 
   const scrollToTab = (tabId: string) => {
     sectionRefs.current.get(tabId)?.scrollIntoView({ behavior: "smooth", block: "start" });
@@ -90,89 +113,80 @@ const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
   };
 
   return (
-    <Modal open={open} onClose={onClose}>
-      {/* biome-ignore lint/a11y/useKeyWithClickEvents: Modal already owns Escape-handling via a capture-phase document listener (Modal.tsx), so this overlay's click-only close doesn't need a redundant keyboard handler here. */}
-      <div
-        className="fixed inset-0 bg-black/20"
-        onClick={onClose}
-        role="presentation"
-        data-testid="help-drawer-overlay">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops the overlay's onClose click from firing; not itself an actionable control */}
-        <div
-          className="absolute right-0 top-0 h-full w-full max-w-2xl bg-white shadow-lg flex flex-col"
-          onClick={(e) => e.stopPropagation()}
-          role="presentation"
-          data-testid="help-drawer-panel">
-          <div className="flex items-center justify-between p-4 border-b border-gray-200">
-            <h2 className="text-lg font-bold">
-              {t("common.helpFor")} {window?.name}
-            </h2>
-            <button type="button" onClick={onClose} aria-label={t("common.close")}>
-              <CloseIcon className="w-4 h-4" />
-            </button>
+    <div
+      className="h-full shrink-0 overflow-hidden transition-all duration-500 ease-in-out bg-white border-l border-gray-200 flex flex-col"
+      style={{ width: isOpen ? PANEL_WIDTH : "0" }}
+      data-testid="help-drawer-panel">
+      <div className="w-[42rem] h-full flex flex-col min-h-0">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <h2 className="text-lg font-bold">
+            {t("common.helpFor")} {window?.name}
+          </h2>
+          <button type="button" onClick={close} aria-label={t("common.close")}>
+            <CloseIcon className="w-4 h-4" />
+          </button>
+        </div>
+        {windowHelp && (
+          <div className="p-4 border-b border-gray-200">
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+            <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
           </div>
-          {windowHelp && (
-            <div className="p-4 border-b border-gray-200">
-              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
-              <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
-            </div>
-          )}
-          <div className="flex flex-1 min-h-0">
-            <nav
-              className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
-              aria-label={t("common.helpFor")}>
-              {sections.map((tab) => (
-                <button
-                  key={tab.id}
-                  type="button"
-                  onClick={() => scrollToTab(tab.id)}
-                  className={`block w-full text-left px-2 py-1 rounded text-sm ${
-                    activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
-                  }`}
-                  data-testid={`help-toc-item-${tab.id}`}
-                  aria-current={activeTabId === tab.id ? "true" : undefined}>
-                  {tab.name}
-                </button>
-              ))}
-            </nav>
-            <div
-              ref={contentRef}
-              onScroll={handleContentScroll}
-              className="flex-1 overflow-y-auto p-4 space-y-6"
-              data-testid="help-drawer-content">
-              {sections.map((tab) => (
-                <section
-                  key={tab.id}
-                  ref={(el) => {
-                    if (el) {
-                      sectionRefs.current.set(tab.id, el);
-                    } else {
-                      sectionRefs.current.delete(tab.id);
-                    }
-                  }}>
-                  <h3 className="font-semibold">{tab.name}</h3>
-                  {tab.helpComment && (
-                    // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
-                    <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
-                  )}
-                  {tab.fields.length > 0 && (
-                    <ul className="mt-2 space-y-2">
-                      {tab.fields.map((field) => (
-                        <li key={field.id}>
-                          <strong>{field.name}</strong>
-                          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
-                          <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </section>
-              ))}
-            </div>
+        )}
+        <div className="flex flex-1 min-h-0">
+          <nav
+            className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
+            aria-label={t("common.helpFor")}>
+            {sections.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => scrollToTab(tab.id)}
+                className={`block w-full text-left px-2 py-1 rounded text-sm ${
+                  activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
+                }`}
+                data-testid={`help-toc-item-${tab.id}`}
+                aria-current={activeTabId === tab.id ? "true" : undefined}>
+                {tab.name}
+              </button>
+            ))}
+          </nav>
+          <div
+            ref={contentRef}
+            onScroll={handleContentScroll}
+            className="flex-1 overflow-y-auto p-4 space-y-6"
+            data-testid="help-drawer-content">
+            {sections.map((tab) => (
+              <section
+                key={tab.id}
+                ref={(el) => {
+                  if (el) {
+                    sectionRefs.current.set(tab.id, el);
+                  } else {
+                    sectionRefs.current.delete(tab.id);
+                  }
+                }}>
+                <h3 className="font-semibold">{tab.name}</h3>
+                {tab.helpComment && (
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+                  <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                )}
+                {tab.fields.length > 0 && (
+                  <ul className="mt-2 space-y-2">
+                    {tab.fields.map((field) => (
+                      <li key={field.id}>
+                        <strong>{field.name}</strong>
+                        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+                        <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))}
           </div>
         </div>
       </div>
-    </Modal>
+    </div>
   );
 };
 

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -123,7 +123,7 @@ const HelpDrawer: React.FC = () => {
             {t("common.helpFor")} {window?.name}
           </h2>
           <button type="button" onClick={close} aria-label={t("common.close")}>
-            <CloseIcon className="w-4 h-4" />
+            <CloseIcon className="w-4 h-4" data-testid="CloseIcon__e7d68f" />
           </button>
         </div>
         {windowHelp && (

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -1,0 +1,106 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+"use client";
+
+import type React from "react";
+import Modal from "../Modal";
+import { sanitizeMessageHtml } from "@/utils/processes/definition/sanitizeHtml";
+import { buildHelpSections } from "@/utils/help/buildHelpContent";
+import { useTranslation } from "@/hooks/useTranslation";
+import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import type { WindowMetadata } from "@workspaceui/api-client/src/api/types";
+
+export interface HelpDrawerProps {
+  open: boolean;
+  window: WindowMetadata | null | undefined;
+  onClose: () => void;
+}
+
+/**
+ * Right-anchored panel showing contextual Help for the active window:
+ * window-level help text, followed by each tab's help text and the list of
+ * fields (within that tab) that carry help content.
+ *
+ * Reuses `Modal` purely for its portal + Escape-close plumbing; the
+ * right-anchored panel look and click-outside-to-close behavior are this
+ * component's own (Modal's own usage elsewhere is a centered dialog).
+ *
+ * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down
+ * allowlist (no `<a>`, no images) used for admin-authored documentation
+ * prose, not `RichTextSelector`'s permissive default DOMPurify call.
+ */
+const HelpDrawer: React.FC<HelpDrawerProps> = ({ open, window, onClose }) => {
+  const { t } = useTranslation();
+  const sections = window ? buildHelpSections(window) : [];
+  const windowHelp = window?.helpComment?.trim() ?? "";
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: Modal already owns Escape-handling via a capture-phase document listener (Modal.tsx), so this overlay's click-only close doesn't need a redundant keyboard handler here. */}
+      <div
+        className="fixed inset-0 bg-black/20"
+        onClick={onClose}
+        role="presentation"
+        data-testid="help-drawer-overlay">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: stops the overlay's onClose click from firing; not itself an actionable control */}
+        <div
+          className="absolute right-0 top-0 h-full w-full max-w-md bg-white shadow-lg overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+          role="presentation"
+          data-testid="help-drawer-panel">
+          <div className="flex items-center justify-between p-4 border-b border-gray-200">
+            <h2 className="text-lg font-bold">
+              {t("common.helpFor")} {window?.name}
+            </h2>
+            <button type="button" onClick={onClose} aria-label={t("common.close")}>
+              <CloseIcon className="w-4 h-4" />
+            </button>
+          </div>
+          <div className="p-4 space-y-6">
+            {windowHelp && (
+              // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+              <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
+            )}
+            {sections.map((tab) => (
+              <section key={tab.id}>
+                <h3 className="font-semibold">{tab.name}</h3>
+                {tab.helpComment && (
+                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+                  <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                )}
+                {tab.fields.length > 0 && (
+                  <ul className="mt-2 space-y-2">
+                    {tab.fields.map((field) => (
+                      <li key={field.id}>
+                        <strong>{field.name}</strong>
+                        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+                        <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default HelpDrawer;

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -133,9 +133,7 @@ const HelpDrawer: React.FC = () => {
           </div>
         )}
         <div className="flex flex-1 min-h-0">
-          <nav
-            className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
-            aria-label={t("common.helpFor")}>
+          <nav className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2" aria-label={t("common.helpFor")}>
             {sections.map((tab) => (
               <button
                 key={tab.id}

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { useMetadataContext } from "@/contexts/metadata";
 import { useHelpPanelStore } from "@/stores/helpPanelStore";
 import CloseIcon from "@workspaceui/componentlibrary/src/assets/icons/x.svg";
+import ChevronUpIcon from "@workspaceui/componentlibrary/src/assets/icons/chevron-up.svg";
 
 const ACTIVE_TAB_THRESHOLD_PX = 16;
 const PANEL_WIDTH = "42rem";
@@ -69,6 +70,7 @@ const HelpDrawer: React.FC = () => {
 
   const contentRef = useRef<HTMLDivElement | null>(null);
   const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const fieldRefs = useRef<Map<string, HTMLElement>>(new Map());
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const previousWindowId = useRef(windowId);
 
@@ -102,6 +104,14 @@ const HelpDrawer: React.FC = () => {
 
   const scrollToTab = (tabId: string) => {
     sectionRefs.current.get(tabId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const scrollToField = (fieldId: string) => {
+    fieldRefs.current.get(fieldId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const scrollToTop = () => {
+    contentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const handleContentScroll = () => {
@@ -174,15 +184,46 @@ const HelpDrawer: React.FC = () => {
                       sectionRefs.current.delete(tab.id);
                     }
                   }}>
-                  <h3 className="font-semibold">{tab.name}</h3>
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold">{tab.name}</h3>
+                    <button
+                      type="button"
+                      onClick={scrollToTop}
+                      aria-label={t("common.backToTop")}
+                      data-testid={`help-back-to-top-${tab.id}`}>
+                      <ChevronUpIcon className="w-4 h-4" data-testid={`ChevronUpIcon__${tab.id}`} />
+                    </button>
+                  </div>
                   {tab.helpComment && (
                     // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
                     <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
                   )}
                   {tab.fields.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-x-2 gap-y-1 text-sm">
+                      {tab.fields.map((field) => (
+                        <button
+                          key={field.id}
+                          type="button"
+                          onClick={() => scrollToField(field.id)}
+                          className="text-blue-700 hover:underline"
+                          data-testid={`help-field-link-${field.id}`}>
+                          [{field.name}]
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {tab.fields.length > 0 && (
                     <ul className="mt-2 space-y-2">
                       {tab.fields.map((field) => (
-                        <li key={field.id}>
+                        <li
+                          key={field.id}
+                          ref={(el) => {
+                            if (el) {
+                              fieldRefs.current.set(field.id, el);
+                            } else {
+                              fieldRefs.current.delete(field.id);
+                            }
+                          }}>
                           <strong>{field.name}</strong>
                           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
                           <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />

--- a/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
+++ b/packages/MainUI/components/HelpDrawer/HelpDrawer.tsx
@@ -46,6 +46,14 @@ const PANEL_WIDTH = "42rem";
  * directly, since it has no parent-child relationship with the trigger button
  * (`HelpAccess`, which lives in `Navigation`).
  *
+ * Only the OUTER wrapper (the width-animated div) mounts unconditionally — its inner
+ * content (header, Close button, tab nav, sections) renders only while `isOpen`. This
+ * matters beyond avoiding wasted work: an interactive "Close" button sitting in the DOM
+ * at all times, even visually clipped to zero width, is still reachable by broad
+ * accessibility-tree queries (e.g. Playwright's `getByRole("button", { name: "Close" })`
+ * with no scoping) — it was mistakenly always rendered once, which caused an E2E test to
+ * hang clicking a clipped, unhittable button instead of the dialog's own Close button.
+ *
  * All rich text is sanitized with `sanitizeMessageHtml` — the locked-down allowlist
  * (no `<a>`, no images) used for admin-authored documentation prose, not
  * `RichTextSelector`'s permissive default DOMPurify call.
@@ -117,73 +125,77 @@ const HelpDrawer: React.FC = () => {
       className="h-full shrink-0 overflow-hidden transition-all duration-500 ease-in-out bg-white border-l border-gray-200 flex flex-col"
       style={{ width: isOpen ? PANEL_WIDTH : "0" }}
       data-testid="help-drawer-panel">
-      <div className="w-[42rem] h-full flex flex-col min-h-0">
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          <h2 className="text-lg font-bold">
-            {t("common.helpFor")} {window?.name}
-          </h2>
-          <button type="button" onClick={close} aria-label={t("common.close")}>
-            <CloseIcon className="w-4 h-4" data-testid="CloseIcon__e7d68f" />
-          </button>
-        </div>
-        {windowHelp && (
-          <div className="p-4 border-b border-gray-200">
-            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
-            <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
+      {isOpen && (
+        <div className="w-[42rem] h-full flex flex-col min-h-0">
+          <div className="flex items-center justify-between p-4 border-b border-gray-200">
+            <h2 className="text-lg font-bold">
+              {t("common.helpFor")} {window?.name}
+            </h2>
+            <button type="button" onClick={close} aria-label={t("common.close")}>
+              <CloseIcon className="w-4 h-4" data-testid="CloseIcon__e7d68f" />
+            </button>
           </div>
-        )}
-        <div className="flex flex-1 min-h-0">
-          <nav className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2" aria-label={t("common.helpFor")}>
-            {sections.map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                onClick={() => scrollToTab(tab.id)}
-                className={`block w-full text-left px-2 py-1 rounded text-sm ${
-                  activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
-                }`}
-                data-testid={`help-toc-item-${tab.id}`}
-                aria-current={activeTabId === tab.id ? "true" : undefined}>
-                {tab.name}
-              </button>
-            ))}
-          </nav>
-          <div
-            ref={contentRef}
-            onScroll={handleContentScroll}
-            className="flex-1 overflow-y-auto p-4 space-y-6"
-            data-testid="help-drawer-content">
-            {sections.map((tab) => (
-              <section
-                key={tab.id}
-                ref={(el) => {
-                  if (el) {
-                    sectionRefs.current.set(tab.id, el);
-                  } else {
-                    sectionRefs.current.delete(tab.id);
-                  }
-                }}>
-                <h3 className="font-semibold">{tab.name}</h3>
-                {tab.helpComment && (
-                  // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
-                  <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
-                )}
-                {tab.fields.length > 0 && (
-                  <ul className="mt-2 space-y-2">
-                    {tab.fields.map((field) => (
-                      <li key={field.id}>
-                        <strong>{field.name}</strong>
-                        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
-                        <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
-            ))}
+          {windowHelp && (
+            <div className="p-4 border-b border-gray-200">
+              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+              <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(windowHelp) }} />
+            </div>
+          )}
+          <div className="flex flex-1 min-h-0">
+            <nav
+              className="w-48 shrink-0 overflow-y-auto border-r border-gray-200 p-2"
+              aria-label={t("common.helpFor")}>
+              {sections.map((tab) => (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => scrollToTab(tab.id)}
+                  className={`block w-full text-left px-2 py-1 rounded text-sm ${
+                    activeTabId === tab.id ? "bg-gray-100 font-semibold" : ""
+                  }`}
+                  data-testid={`help-toc-item-${tab.id}`}
+                  aria-current={activeTabId === tab.id ? "true" : undefined}>
+                  {tab.name}
+                </button>
+              ))}
+            </nav>
+            <div
+              ref={contentRef}
+              onScroll={handleContentScroll}
+              className="flex-1 overflow-y-auto p-4 space-y-6"
+              data-testid="help-drawer-content">
+              {sections.map((tab) => (
+                <section
+                  key={tab.id}
+                  ref={(el) => {
+                    if (el) {
+                      sectionRefs.current.set(tab.id, el);
+                    } else {
+                      sectionRefs.current.delete(tab.id);
+                    }
+                  }}>
+                  <h3 className="font-semibold">{tab.name}</h3>
+                  {tab.helpComment && (
+                    // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above
+                    <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(tab.helpComment) }} />
+                  )}
+                  {tab.fields.length > 0 && (
+                    <ul className="mt-2 space-y-2">
+                      {tab.fields.map((field) => (
+                        <li key={field.id}>
+                          <strong>{field.name}</strong>
+                          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via sanitizeMessageHtml above */}
+                          <div dangerouslySetInnerHTML={{ __html: sanitizeMessageHtml(field.helpComment) }} />
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -54,6 +54,16 @@ describe("HelpDrawer", () => {
     expect(screen.getByTestId("help-drawer-panel")).toHaveStyle({ width: "0" });
   });
 
+  it("renders no interactive content (e.g. the Close button) when closed", () => {
+    // Regression test: an always-mounted Close button, even visually clipped to width 0,
+    // is still reachable by unscoped accessibility queries (getByRole("button", { name: "Close" }))
+    // and broke an E2E test that matched it instead of an unrelated dialog's own Close button.
+    setWindow({ ...createMockWindowMetadata("W1"), helpComment: "Some window help" });
+    render(<HelpDrawer />);
+    expect(screen.queryByRole("button", { name: "common.close" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Window W1/)).not.toBeInTheDocument();
+  });
+
   it("expands to the panel width when open", () => {
     setWindow(createMockWindowMetadata("W1"));
     useHelpPanelStore.setState({ isOpen: true });

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -103,7 +103,7 @@ describe("HelpDrawer", () => {
     expect(screen.getByText("Field help text")).toBeInTheDocument();
   });
 
-  it("omits fields with no help content", () => {
+  it("lists fields with no help content too, matching Classic (name shown, body left blank)", () => {
     useHelpPanelStore.setState({ isOpen: true });
     const withHelp = createMockField({ id: "f1", name: "Has Help", helpComment: "yes" });
     const withoutHelp = createMockField({
@@ -118,7 +118,7 @@ describe("HelpDrawer", () => {
     render(<HelpDrawer />);
 
     expect(screen.getByText("Has Help")).toBeInTheDocument();
-    expect(screen.queryByText("No Help")).not.toBeInTheDocument();
+    expect(screen.getByText("No Help")).toBeInTheDocument();
   });
 
   it("closes when the close (X) button is clicked", () => {

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -1,0 +1,113 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import HelpDrawer from "../HelpDrawer";
+import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("../../Modal", () => ({
+  __esModule: true,
+  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="mock-modal">{children}</div> : null,
+}));
+
+jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="close-icon" />,
+}));
+
+describe("HelpDrawer", () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it("renders nothing when closed", () => {
+    const window = createMockWindowMetadata("W1");
+    render(<HelpDrawer open={false} window={window} onClose={mockOnClose} />);
+    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+  });
+
+  it("renders the window title and sanitized window helpComment", () => {
+    const window = { ...createMockWindowMetadata("W1"), helpComment: "<p>Window help</p><script>alert(1)</script>" };
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByText(/Window W1/)).toBeInTheDocument();
+    expect(screen.getByText("Window help")).toBeInTheDocument();
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+  });
+
+  it("renders tabs ordered by sequenceNumber with their field help", () => {
+    const field = createMockField({ id: "f1", name: "Document No.", helpComment: "Field help text" });
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, helpComment: "Lines help", fields: {} });
+    const tabB = createMockTab({
+      id: "b",
+      name: "Header",
+      sequenceNumber: 10,
+      helpComment: "Header help",
+      fields: { f1: field },
+    });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual(["Header", "Lines"]);
+    expect(screen.getByText("Document No.")).toBeInTheDocument();
+    expect(screen.getByText("Field help text")).toBeInTheDocument();
+  });
+
+  it("omits fields with no help content", () => {
+    const withHelp = createMockField({ id: "f1", name: "Has Help", helpComment: "yes" });
+    const withoutHelp = createMockField({
+      id: "f2",
+      name: "No Help",
+      helpComment: "",
+      column: { helpComment: undefined },
+    });
+    const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByText("Has Help")).toBeInTheDocument();
+    expect(screen.queryByText("No Help")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when clicking the overlay", () => {
+    const window = createMockWindowMetadata("W1");
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByTestId("help-drawer-overlay"));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when clicking inside the panel", () => {
+    const window = createMockWindowMetadata("W1");
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    fireEvent.click(screen.getByTestId("help-drawer-panel"));
+
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -36,6 +36,7 @@ jest.mock("@/contexts/metadata", () => ({
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
+  Element.prototype.scrollTo = jest.fn();
 });
 
 const setWindow = (window: ReturnType<typeof createMockWindowMetadata> | null, windowId = "W1") => {
@@ -198,6 +199,27 @@ describe("HelpDrawer tab index sidebar", () => {
     fireEvent.click(screen.getByTestId("help-toc-item-t1"));
 
     expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("scrolls the matching field into view when its quick-jump link is clicked", () => {
+    const field = createMockField({ id: "f1", name: "Document No.", helpComment: "Field help text" });
+    const tab = createMockTab({ id: "t1", name: "Header", fields: { f1: field } });
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tab] });
+
+    render(<HelpDrawer />);
+    fireEvent.click(screen.getByTestId("help-field-link-f1"));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("scrolls the content pane to the top when a section's back-to-top button is clicked", () => {
+    const tab = createMockTab({ id: "t1", name: "Header", fields: {} });
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tab] });
+
+    render(<HelpDrawer />);
+    fireEvent.click(screen.getByTestId("help-back-to-top-t1"));
+
+    expect(Element.prototype.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
   });
 
   it("updates the active tab as the content pane is scrolled", () => {

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -150,6 +150,15 @@ describe("HelpDrawer", () => {
     expect(useHelpPanelStore.getState().isOpen).toBe(false);
   });
 
+  it("renders an empty sidebar and no window help when there is no active window yet", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    setWindow(null);
+    render(<HelpDrawer />);
+
+    expect(screen.getByLabelText("common.helpFor")).toBeEmptyDOMElement();
+    expect(screen.getByTestId("help-drawer-content")).toBeEmptyDOMElement();
+  });
+
   it("closes when the active window changes while open", () => {
     useHelpPanelStore.setState({ isOpen: true });
     setWindow(createMockWindowMetadata("W1"), "w1");
@@ -241,5 +250,30 @@ describe("HelpDrawer tab index sidebar", () => {
 
     expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
     expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
+  });
+
+  it("stops scanning once a section below the active threshold is reached", () => {
+    const tabA = createMockTab({ id: "a", name: "Header", sequenceNumber: 10, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabC = createMockTab({ id: "c", name: "Tax", sequenceNumber: 30, fields: {} });
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tabA, tabB, tabC] });
+
+    render(<HelpDrawer />);
+
+    const content = screen.getByTestId("help-drawer-content");
+    const headerSection = screen.getByRole("heading", { name: "Header" }).closest("section") as HTMLElement;
+    const linesSection = screen.getByRole("heading", { name: "Lines" }).closest("section") as HTMLElement;
+    const taxSection = screen.getByRole("heading", { name: "Tax" }).closest("section") as HTMLElement;
+
+    jest.spyOn(content, "getBoundingClientRect").mockReturnValue({ top: 0 } as unknown as DOMRect);
+    jest.spyOn(headerSection, "getBoundingClientRect").mockReturnValue({ top: -100 } as unknown as DOMRect);
+    jest.spyOn(linesSection, "getBoundingClientRect").mockReturnValue({ top: 10 } as unknown as DOMRect);
+    // Below the ACTIVE_TAB_THRESHOLD_PX (16): scanning must stop here, not mark Tax active.
+    jest.spyOn(taxSection, "getBoundingClientRect").mockReturnValue({ top: 200 } as unknown as DOMRect);
+
+    fireEvent.scroll(content);
+
+    expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
+    expect(screen.getByTestId("help-toc-item-c")).not.toHaveAttribute("aria-current");
   });
 });

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -34,6 +34,10 @@ jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
   default: () => <svg data-testid="close-icon" />,
 }));
 
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
 describe("HelpDrawer", () => {
   const mockOnClose = jest.fn();
 
@@ -109,5 +113,66 @@ describe("HelpDrawer", () => {
     fireEvent.click(screen.getByTestId("help-drawer-panel"));
 
     expect(mockOnClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("HelpDrawer tab index sidebar", () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  it("renders one sidebar button per tab, in sequenceNumber order", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId("help-toc-item-b")).toHaveTextContent("Header");
+    expect(screen.getByTestId("help-toc-item-a")).toHaveTextContent("Lines");
+  });
+
+  it("marks the first tab (by sequenceNumber) as active by default", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
+    expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
+  });
+
+  it("scrolls the matching section into view when a sidebar item is clicked", () => {
+    const tab = createMockTab({ id: "t1", name: "Header", fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    fireEvent.click(screen.getByTestId("help-toc-item-t1"));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
+
+  it("updates the active tab as the content pane is scrolled", () => {
+    const tabA = createMockTab({ id: "a", name: "Header", sequenceNumber: 10, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Lines", sequenceNumber: 20, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+
+    const content = screen.getByTestId("help-drawer-content");
+    const headerSection = screen.getByRole("heading", { name: "Header" }).closest("section") as HTMLElement;
+    const linesSection = screen.getByRole("heading", { name: "Lines" }).closest("section") as HTMLElement;
+
+    jest.spyOn(content, "getBoundingClientRect").mockReturnValue({ top: 0 } as unknown as DOMRect);
+    jest.spyOn(headerSection, "getBoundingClientRect").mockReturnValue({ top: -100 } as unknown as DOMRect);
+    jest.spyOn(linesSection, "getBoundingClientRect").mockReturnValue({ top: 10 } as unknown as DOMRect);
+
+    fireEvent.scroll(content);
+
+    expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
+    expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
   });
 });

--- a/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
+++ b/packages/MainUI/components/HelpDrawer/__tests__/HelpDrawer.test.tsx
@@ -17,16 +17,11 @@
 
 import { render, screen, fireEvent } from "@testing-library/react";
 import HelpDrawer from "../HelpDrawer";
+import { useHelpPanelStore } from "@/stores/helpPanelStore";
 import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
 
 jest.mock("@/hooks/useTranslation", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
-}));
-
-jest.mock("../../Modal", () => ({
-  __esModule: true,
-  default: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
-    open ? <div data-testid="mock-modal">{children}</div> : null,
 }));
 
 jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
@@ -34,26 +29,42 @@ jest.mock("@workspaceui/componentlibrary/src/assets/icons/x.svg", () => ({
   default: () => <svg data-testid="close-icon" />,
 }));
 
+const mockUseMetadataContext = jest.fn();
+jest.mock("@/contexts/metadata", () => ({
+  useMetadataContext: () => mockUseMetadataContext(),
+}));
+
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
 });
 
-describe("HelpDrawer", () => {
-  const mockOnClose = jest.fn();
+const setWindow = (window: ReturnType<typeof createMockWindowMetadata> | null, windowId = "W1") => {
+  mockUseMetadataContext.mockReturnValue({ window, windowId });
+};
 
+describe("HelpDrawer", () => {
   beforeEach(() => {
-    mockOnClose.mockClear();
+    useHelpPanelStore.setState({ isOpen: false });
+    mockUseMetadataContext.mockReset();
   });
 
-  it("renders nothing when closed", () => {
-    const window = createMockWindowMetadata("W1");
-    render(<HelpDrawer open={false} window={window} onClose={mockOnClose} />);
-    expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
+  it("collapses to width 0 when closed", () => {
+    setWindow(createMockWindowMetadata("W1"));
+    render(<HelpDrawer />);
+    expect(screen.getByTestId("help-drawer-panel")).toHaveStyle({ width: "0" });
+  });
+
+  it("expands to the panel width when open", () => {
+    setWindow(createMockWindowMetadata("W1"));
+    useHelpPanelStore.setState({ isOpen: true });
+    render(<HelpDrawer />);
+    expect(screen.getByTestId("help-drawer-panel")).toHaveStyle({ width: "42rem" });
   });
 
   it("renders the window title and sanitized window helpComment", () => {
-    const window = { ...createMockWindowMetadata("W1"), helpComment: "<p>Window help</p><script>alert(1)</script>" };
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    useHelpPanelStore.setState({ isOpen: true });
+    setWindow({ ...createMockWindowMetadata("W1"), helpComment: "<p>Window help</p><script>alert(1)</script>" });
+    render(<HelpDrawer />);
 
     expect(screen.getByText(/Window W1/)).toBeInTheDocument();
     expect(screen.getByText("Window help")).toBeInTheDocument();
@@ -61,6 +72,7 @@ describe("HelpDrawer", () => {
   });
 
   it("renders tabs ordered by sequenceNumber with their field help", () => {
+    useHelpPanelStore.setState({ isOpen: true });
     const field = createMockField({ id: "f1", name: "Document No.", helpComment: "Field help text" });
     const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, helpComment: "Lines help", fields: {} });
     const tabB = createMockTab({
@@ -70,9 +82,9 @@ describe("HelpDrawer", () => {
       helpComment: "Header help",
       fields: { f1: field },
     });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
 
     const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
     expect(headings).toEqual(["Header", "Lines"]);
@@ -81,6 +93,7 @@ describe("HelpDrawer", () => {
   });
 
   it("omits fields with no help content", () => {
+    useHelpPanelStore.setState({ isOpen: true });
     const withHelp = createMockField({ id: "f1", name: "Has Help", helpComment: "yes" });
     const withoutHelp = createMockField({
       id: "f2",
@@ -89,46 +102,68 @@ describe("HelpDrawer", () => {
       column: { helpComment: undefined },
     });
     const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tab] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
 
     expect(screen.getByText("Has Help")).toBeInTheDocument();
     expect(screen.queryByText("No Help")).not.toBeInTheDocument();
   });
 
-  it("calls onClose when clicking the overlay", () => {
-    const window = createMockWindowMetadata("W1");
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+  it("closes when the close (X) button is clicked", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    setWindow(createMockWindowMetadata("W1"));
+    render(<HelpDrawer />);
 
-    fireEvent.click(screen.getByTestId("help-drawer-overlay"));
+    fireEvent.click(screen.getByLabelText("common.close"));
 
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
   });
 
-  it("does not call onClose when clicking inside the panel", () => {
-    const window = createMockWindowMetadata("W1");
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+  it("closes on Escape when open", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    setWindow(createMockWindowMetadata("W1"));
+    render(<HelpDrawer />);
 
-    fireEvent.click(screen.getByTestId("help-drawer-panel"));
+    fireEvent.keyDown(document, { key: "Escape" });
 
-    expect(mockOnClose).not.toHaveBeenCalled();
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
+  });
+
+  it("does not react to Escape when already closed", () => {
+    setWindow(createMockWindowMetadata("W1"));
+    render(<HelpDrawer />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
+  });
+
+  it("closes when the active window changes while open", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    setWindow(createMockWindowMetadata("W1"), "w1");
+    const { rerender } = render(<HelpDrawer />);
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+
+    setWindow(createMockWindowMetadata("W2"), "w2");
+    rerender(<HelpDrawer />);
+
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
   });
 });
 
 describe("HelpDrawer tab index sidebar", () => {
-  const mockOnClose = jest.fn();
-
   beforeEach(() => {
-    mockOnClose.mockClear();
+    useHelpPanelStore.setState({ isOpen: true });
+    mockUseMetadataContext.mockReset();
   });
 
   it("renders one sidebar button per tab, in sequenceNumber order", () => {
     const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
     const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
 
     expect(screen.getByTestId("help-toc-item-b")).toHaveTextContent("Header");
     expect(screen.getByTestId("help-toc-item-a")).toHaveTextContent("Lines");
@@ -137,9 +172,9 @@ describe("HelpDrawer tab index sidebar", () => {
   it("marks the first tab (by sequenceNumber) as active by default", () => {
     const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
     const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
 
     expect(screen.getByTestId("help-toc-item-b")).toHaveAttribute("aria-current", "true");
     expect(screen.getByTestId("help-toc-item-a")).not.toHaveAttribute("aria-current");
@@ -147,9 +182,9 @@ describe("HelpDrawer tab index sidebar", () => {
 
   it("scrolls the matching section into view when a sidebar item is clicked", () => {
     const tab = createMockTab({ id: "t1", name: "Header", fields: {} });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tab] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
     fireEvent.click(screen.getByTestId("help-toc-item-t1"));
 
     expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
@@ -158,9 +193,9 @@ describe("HelpDrawer tab index sidebar", () => {
   it("updates the active tab as the content pane is scrolled", () => {
     const tabA = createMockTab({ id: "a", name: "Header", sequenceNumber: 10, fields: {} });
     const tabB = createMockTab({ id: "b", name: "Lines", sequenceNumber: 20, fields: {} });
-    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+    setWindow({ ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] });
 
-    render(<HelpDrawer open={true} window={window} onClose={mockOnClose} />);
+    render(<HelpDrawer />);
 
     const content = screen.getByTestId("help-drawer-content");
     const headerSection = screen.getByRole("heading", { name: "Header" }).closest("section") as HTMLElement;

--- a/packages/MainUI/components/layout.tsx
+++ b/packages/MainUI/components/layout.tsx
@@ -33,7 +33,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         </div>
         <div className="flex flex-1 max-h-auto max-w-auto overflow-hidden">{children}</div>
       </div>
-      <HelpDrawer />
+      <HelpDrawer data-testid="HelpDrawer__519d5c" />
       {/* Host for nested process modals opened via view.openProcess. */}
       <ProcessStackHost data-testid="ProcessStackHost__519d5c" />
     </div>

--- a/packages/MainUI/components/layout.tsx
+++ b/packages/MainUI/components/layout.tsx
@@ -20,6 +20,7 @@ import Navigation from "./navigation";
 import Sidebar from "./Sidebar";
 import GlobalLoading from "./Layout/GlobalLoading";
 import ProcessStackHost from "./ProcessModal/ProcessStackHost";
+import HelpDrawer from "./HelpDrawer/HelpDrawer";
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
@@ -32,6 +33,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         </div>
         <div className="flex flex-1 max-h-auto max-w-auto overflow-hidden">{children}</div>
       </div>
+      <HelpDrawer />
       {/* Host for nested process modals opened via view.openProcess. */}
       <ProcessStackHost data-testid="ProcessStackHost__519d5c" />
     </div>

--- a/packages/MainUI/components/navigation.tsx
+++ b/packages/MainUI/components/navigation.tsx
@@ -35,6 +35,7 @@ import { useCopilot } from "@/hooks/useCopilot";
 import { buildContextString } from "@/utils/contextUtils";
 import type { ContextItem } from "@/hooks/types";
 import ConfigurationSection from "./Header/ConfigurationSection";
+import HelpAccess from "./Header/HelpAccess";
 
 const Navigation: React.FC = () => {
   const { t } = useTranslation();
@@ -218,6 +219,7 @@ const Navigation: React.FC = () => {
           />
         )}
         <ConfigurationSection data-testid="ConfigurationSection__120cc9" />
+        <HelpAccess data-testid="HelpAccess__120cc9" />
         <ProfileModal
           icon={<PersonIcon className="w-5 h-5" data-testid="PersonIcon__120cc9" />}
           sections={sections}

--- a/packages/MainUI/stores/__tests__/helpPanelStore.test.ts
+++ b/packages/MainUI/stores/__tests__/helpPanelStore.test.ts
@@ -1,0 +1,46 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { useHelpPanelStore } from "../helpPanelStore";
+
+describe("useHelpPanelStore", () => {
+  beforeEach(() => {
+    useHelpPanelStore.setState({ isOpen: false });
+  });
+
+  it("starts closed", () => {
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
+  });
+
+  it("open() sets isOpen to true", () => {
+    useHelpPanelStore.getState().open();
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+  });
+
+  it("close() sets isOpen to false", () => {
+    useHelpPanelStore.setState({ isOpen: true });
+    useHelpPanelStore.getState().close();
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
+  });
+
+  it("toggle() flips isOpen in either direction", () => {
+    useHelpPanelStore.getState().toggle();
+    expect(useHelpPanelStore.getState().isOpen).toBe(true);
+    useHelpPanelStore.getState().toggle();
+    expect(useHelpPanelStore.getState().isOpen).toBe(false);
+  });
+});

--- a/packages/MainUI/stores/helpPanelStore.ts
+++ b/packages/MainUI/stores/helpPanelStore.ts
@@ -1,0 +1,38 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface HelpPanelStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+export const useHelpPanelStore = create<HelpPanelStore>()(
+  devtools(
+    (set) => ({
+      isOpen: false,
+      open: () => set({ isOpen: true }),
+      close: () => set({ isOpen: false }),
+      toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+    }),
+    { name: "HelpPanelStore" }
+  )
+);

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -45,6 +45,14 @@ describe("shouldShowHelp", () => {
     expect(shouldShowHelp(window)).toBe(true);
   });
 
+  it("returns true when a tab has a displayed field even with no help text anywhere", () => {
+    // Classic still lists the field's name (with a blank body), so the Help view isn't empty.
+    const field = createMockField({ id: "f1", helpComment: "", column: { helpComment: undefined } });
+    const tab = createMockTab({ id: "t1", helpComment: null, fields: { f1: field } });
+    const window = { ...createMockWindowMetadata("W1"), helpComment: null, tabs: [tab] };
+    expect(shouldShowHelp(window)).toBe(true);
+  });
+
   it("returns false for a null/undefined window", () => {
     expect(shouldShowHelp(null)).toBe(false);
     expect(shouldShowHelp(undefined)).toBe(false);
@@ -73,7 +81,9 @@ describe("buildHelpSections", () => {
     expect(sections[0].fields.map((f) => f.id)).toEqual(["f10", "f20"]);
   });
 
-  it("omits fields with no helpComment and no column fallback", () => {
+  it("lists fields with no helpComment and no column fallback, with an empty helpComment", () => {
+    // Classic lists every displayed field's name even when nothing is written under it
+    // (e.g. "Payment Method" on Sales Order) — omitting them would lose real fields.
     const withHelp = createMockField({ id: "f1", helpComment: "has help", column: { helpComment: undefined } });
     const withoutHelp = createMockField({ id: "f2", helpComment: "", column: { helpComment: undefined } });
     const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
@@ -81,7 +91,10 @@ describe("buildHelpSections", () => {
 
     const sections = buildHelpSections(window);
 
-    expect(sections[0].fields.map((f) => f.id)).toEqual(["f1"]);
+    expect(sections[0].fields).toEqual([
+      { id: "f1", name: withHelp.name, helpComment: "has help" },
+      { id: "f2", name: withoutHelp.name, helpComment: "" },
+    ]);
   });
 
   it("falls back to column.helpComment when field.helpComment is empty", () => {
@@ -94,14 +107,14 @@ describe("buildHelpSections", () => {
     expect(sections[0].fields).toEqual([{ id: "f1", name: field.name, helpComment: "column help text" }]);
   });
 
-  it("omits fields whose helpComment is undefined (not just empty) with no column fallback", () => {
+  it("lists a field with an empty helpComment when helpComment is undefined and there's no column", () => {
     const field = createMockField({ id: "f1", helpComment: undefined as unknown as string, column: undefined });
     const tab = createMockTab({ id: "t1", fields: { field } });
     const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
 
     const sections = buildHelpSections(window);
 
-    expect(sections[0].fields).toEqual([]);
+    expect(sections[0].fields).toEqual([{ id: "f1", name: field.name, helpComment: "" }]);
   });
 
   it("omits fields not displayed on the form, regardless of help content (e.g. hidden key columns)", () => {

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -104,6 +104,16 @@ describe("buildHelpSections", () => {
     expect(sections[0].fields).toEqual([]);
   });
 
+  it("omits fields not displayed on the form, regardless of help content (e.g. hidden key columns)", () => {
+    const hiddenField = createMockField({ id: "f1", helpComment: "id help", displayed: false });
+    const tab = createMockTab({ id: "t1", fields: { hiddenField } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([]);
+  });
+
   it("omits audit synthetic fields regardless of help content", () => {
     const auditField = createMockField({ id: "f1", helpComment: "audit help", isAuditField: true });
     const tab = createMockTab({ id: "t1", fields: { auditField } });

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -97,4 +97,30 @@ describe("buildHelpSections", () => {
 
     expect(sections[0].helpComment).toBe("");
   });
+
+  it("omits inactive tabs, matching Classic's Help view", () => {
+    const activeTab = createMockTab({ id: "active", name: "Header", sequenceNumber: 10, active: true, fields: {} });
+    const inactiveTab = createMockTab({
+      id: "inactive",
+      name: "Discounts and Promotions",
+      sequenceNumber: 20,
+      active: false,
+      fields: {},
+    });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [activeTab, inactiveTab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections.map((s) => s.id)).toEqual(["active"]);
+  });
+
+  it("omits inactive fields regardless of help content", () => {
+    const inactiveField = createMockField({ id: "f1", helpComment: "help", active: false });
+    const tab = createMockTab({ id: "t1", fields: { inactiveField } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([]);
+  });
 });

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -1,0 +1,100 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { buildHelpSections, shouldShowHelp } from "../buildHelpContent";
+import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
+
+describe("shouldShowHelp", () => {
+  it("returns true for non-empty helpComment", () => {
+    expect(shouldShowHelp({ helpComment: "Some help" })).toBe(true);
+  });
+
+  it("returns false for null/undefined/empty/whitespace helpComment", () => {
+    expect(shouldShowHelp({ helpComment: null })).toBe(false);
+    expect(shouldShowHelp({ helpComment: undefined })).toBe(false);
+    expect(shouldShowHelp({ helpComment: "" })).toBe(false);
+    expect(shouldShowHelp({ helpComment: "   " })).toBe(false);
+  });
+
+  it("returns false for a null/undefined window", () => {
+    expect(shouldShowHelp(null)).toBe(false);
+    expect(shouldShowHelp(undefined)).toBe(false);
+  });
+});
+
+describe("buildHelpSections", () => {
+  it("orders tabs by sequenceNumber regardless of array order", () => {
+    const tabA = createMockTab({ id: "a", name: "Lines", sequenceNumber: 20, fields: {} });
+    const tabB = createMockTab({ id: "b", name: "Header", sequenceNumber: 10, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tabA, tabB] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("orders fields within a tab by sequenceNumber", () => {
+    const field20 = createMockField({ id: "f20", name: "Second", sequenceNumber: 20, helpComment: "help" });
+    const field10 = createMockField({ id: "f10", name: "First", sequenceNumber: 10, helpComment: "help" });
+    const tab = createMockTab({ id: "t1", sequenceNumber: 10, fields: { field20, field10 } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields.map((f) => f.id)).toEqual(["f10", "f20"]);
+  });
+
+  it("omits fields with no helpComment and no column fallback", () => {
+    const withHelp = createMockField({ id: "f1", helpComment: "has help", column: { helpComment: undefined } });
+    const withoutHelp = createMockField({ id: "f2", helpComment: "", column: { helpComment: undefined } });
+    const tab = createMockTab({ id: "t1", fields: { withHelp, withoutHelp } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields.map((f) => f.id)).toEqual(["f1"]);
+  });
+
+  it("falls back to column.helpComment when field.helpComment is empty", () => {
+    const field = createMockField({ id: "f1", helpComment: "", column: { helpComment: "column help text" } });
+    const tab = createMockTab({ id: "t1", fields: { field } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([{ id: "f1", name: field.name, helpComment: "column help text" }]);
+  });
+
+  it("omits audit synthetic fields regardless of help content", () => {
+    const auditField = createMockField({ id: "f1", helpComment: "audit help", isAuditField: true });
+    const tab = createMockTab({ id: "t1", fields: { auditField } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([]);
+  });
+
+  it("returns empty-string tab helpComment (not null/undefined) when tab has none", () => {
+    const tab = createMockTab({ id: "t1", helpComment: null, fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].helpComment).toBe("");
+  });
+});

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -19,15 +19,30 @@ import { buildHelpSections, shouldShowHelp } from "../buildHelpContent";
 import { createMockWindowMetadata, createMockTab, createMockField } from "@/utils/tests/mockHelpers";
 
 describe("shouldShowHelp", () => {
-  it("returns true for non-empty helpComment", () => {
-    expect(shouldShowHelp({ helpComment: "Some help" })).toBe(true);
+  it("returns true for non-empty window-level helpComment", () => {
+    const window = { ...createMockWindowMetadata("W1"), helpComment: "Some help", tabs: [] };
+    expect(shouldShowHelp(window)).toBe(true);
   });
 
-  it("returns false for null/undefined/empty/whitespace helpComment", () => {
-    expect(shouldShowHelp({ helpComment: null })).toBe(false);
-    expect(shouldShowHelp({ helpComment: undefined })).toBe(false);
-    expect(shouldShowHelp({ helpComment: "" })).toBe(false);
-    expect(shouldShowHelp({ helpComment: "   " })).toBe(false);
+  it("returns false when window, tab, and field helpComment are all blank", () => {
+    const tab = createMockTab({ id: "t1", helpComment: null, fields: {} });
+    for (const helpComment of [null, undefined, "", "   "] as const) {
+      const window = { ...createMockWindowMetadata("W1"), helpComment, tabs: [tab] };
+      expect(shouldShowHelp(window)).toBe(false);
+    }
+  });
+
+  it("returns true when window-level help is blank but a tab has help text (e.g. Toolbar)", () => {
+    const tab = createMockTab({ id: "t1", helpComment: "Tab-level help", fields: {} });
+    const window = { ...createMockWindowMetadata("W1"), helpComment: null, tabs: [tab] };
+    expect(shouldShowHelp(window)).toBe(true);
+  });
+
+  it("returns true when window- and tab-level help are blank but a field has help text (e.g. Toolbar)", () => {
+    const field = createMockField({ id: "f1", helpComment: "Field-level help" });
+    const tab = createMockTab({ id: "t1", helpComment: null, fields: { f1: field } });
+    const window = { ...createMockWindowMetadata("W1"), helpComment: null, tabs: [tab] };
+    expect(shouldShowHelp(window)).toBe(true);
   });
 
   it("returns false for a null/undefined window", () => {

--- a/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
+++ b/packages/MainUI/utils/help/__tests__/buildHelpContent.test.ts
@@ -79,6 +79,16 @@ describe("buildHelpSections", () => {
     expect(sections[0].fields).toEqual([{ id: "f1", name: field.name, helpComment: "column help text" }]);
   });
 
+  it("omits fields whose helpComment is undefined (not just empty) with no column fallback", () => {
+    const field = createMockField({ id: "f1", helpComment: undefined as unknown as string, column: undefined });
+    const tab = createMockTab({ id: "t1", fields: { field } });
+    const window = { ...createMockWindowMetadata("W1"), tabs: [tab] };
+
+    const sections = buildHelpSections(window);
+
+    expect(sections[0].fields).toEqual([]);
+  });
+
   it("omits audit synthetic fields regardless of help content", () => {
     const auditField = createMockField({ id: "f1", helpComment: "audit help", isAuditField: true });
     const tab = createMockTab({ id: "t1", fields: { auditField } });

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -32,11 +32,15 @@ export interface HelpTabSection {
 
 /**
  * Determines whether the Help access should be shown for a given window.
- * Help is only offered when the window itself has non-blank help text
- * (AD_Window.HELP); windows without it have nothing to show.
+ * Classic shows Help whenever there is help text anywhere in the window —
+ * the window's own blurb (AD_Window.HELP), a tab's, or a field's — not just
+ * when the window-level blurb is set. A window like "Toolbar" has no
+ * AD_Window.HELP but every field does, and Classic still shows its Help page.
  */
-export function shouldShowHelp(window: { helpComment?: string | null } | null | undefined): boolean {
-  return Boolean(window?.helpComment?.trim());
+export function shouldShowHelp(window: WindowMetadata | null | undefined): boolean {
+  if (!window) return false;
+  if (window.helpComment?.trim()) return true;
+  return buildHelpSections(window).some((section) => section.helpComment || section.fields.length > 0);
 }
 
 /**

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -61,8 +61,10 @@ function getFieldHelp(field: Field): string {
  * Builds the ordered, filtered list of help sections (one per tab) for a
  * window's Help view: inactive tabs omitted (Classic's Help view excludes
  * them the same way), tabs ordered by sequenceNumber, fields within each tab
- * ordered by sequenceNumber, audit and inactive fields omitted, and fields
- * with no help text (own or column fallback) omitted.
+ * ordered by sequenceNumber, audit/inactive/non-displayed fields omitted
+ * (Classic only documents fields the user actually sees on the form — hidden
+ * key columns, status-bar-only fields, etc. never got an entry there either),
+ * and fields with no help text (own or column fallback) omitted.
  */
 export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
   const orderedTabs = [...window.tabs]
@@ -71,7 +73,7 @@ export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
 
   return orderedTabs.map((tab: Tab) => {
     const fields = Object.values(tab.fields)
-      .filter((field) => !field.isAuditField && field.active !== false)
+      .filter((field) => !field.isAuditField && field.active !== false && field.displayed)
       .map((field) => ({ field, help: getFieldHelp(field) }))
       .filter(({ help }) => help.length > 0)
       .sort((a, b) => a.field.sequenceNumber - b.field.sequenceNumber)

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -50,7 +50,7 @@ export function shouldShowHelp(window: { helpComment?: string | null } | null | 
 function getFieldHelp(field: Field): string {
   const own = field.helpComment?.trim();
   if (own) return own;
-  return (field.column as Field["column"] | null | undefined)?.helpComment?.trim() ?? "";
+  return field.column?.helpComment?.trim() ?? "";
 }
 
 /**

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -1,0 +1,80 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2025 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import type { Field, Tab, WindowMetadata } from "@workspaceui/api-client/src/api/types";
+
+export interface HelpField {
+  id: string;
+  name: string;
+  helpComment: string;
+}
+
+export interface HelpTabSection {
+  id: string;
+  name: string;
+  helpComment: string;
+  fields: HelpField[];
+}
+
+/**
+ * Determines whether the Help access should be shown for a given window.
+ * Help is only offered when the window itself has non-blank help text
+ * (AD_Window.HELP); windows without it have nothing to show.
+ */
+export function shouldShowHelp(window: { helpComment?: string | null } | null | undefined): boolean {
+  return Boolean(window?.helpComment?.trim());
+}
+
+/**
+ * Resolves the effective help text for a field: the field's own help comment,
+ * falling back to its column's help comment when the field has none.
+ *
+ * field.column is typed as required on Field, but live metadata has shown it
+ * can genuinely be null/undefined at runtime for some field kinds — read
+ * defensively.
+ */
+function getFieldHelp(field: Field): string {
+  const own = field.helpComment?.trim();
+  if (own) return own;
+  return (field.column as Field["column"] | null | undefined)?.helpComment?.trim() ?? "";
+}
+
+/**
+ * Builds the ordered, filtered list of help sections (one per tab) for a
+ * window's Help view: tabs ordered by sequenceNumber, fields within each tab
+ * ordered by sequenceNumber, audit fields omitted, and fields with no help
+ * text (own or column fallback) omitted.
+ */
+export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
+  const orderedTabs = [...window.tabs].sort((a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0));
+
+  return orderedTabs.map((tab: Tab) => {
+    const fields = Object.values(tab.fields)
+      .filter((field) => !field.isAuditField)
+      .map((field) => ({ field, help: getFieldHelp(field) }))
+      .filter(({ help }) => help.length > 0)
+      .sort((a, b) => a.field.sequenceNumber - b.field.sequenceNumber)
+      .map(({ field, help }) => ({ id: field.id, name: field.name, helpComment: help }));
+
+    return {
+      id: tab.id,
+      name: tab.name,
+      helpComment: tab.helpComment?.trim() ?? "",
+      fields,
+    };
+  });
+}

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -55,16 +55,19 @@ function getFieldHelp(field: Field): string {
 
 /**
  * Builds the ordered, filtered list of help sections (one per tab) for a
- * window's Help view: tabs ordered by sequenceNumber, fields within each tab
- * ordered by sequenceNumber, audit fields omitted, and fields with no help
- * text (own or column fallback) omitted.
+ * window's Help view: inactive tabs omitted (Classic's Help view excludes
+ * them the same way), tabs ordered by sequenceNumber, fields within each tab
+ * ordered by sequenceNumber, audit and inactive fields omitted, and fields
+ * with no help text (own or column fallback) omitted.
  */
 export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
-  const orderedTabs = [...window.tabs].sort((a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0));
+  const orderedTabs = [...window.tabs]
+    .filter((tab) => tab.active !== false)
+    .sort((a, b) => (a.sequenceNumber ?? 0) - (b.sequenceNumber ?? 0));
 
   return orderedTabs.map((tab: Tab) => {
     const fields = Object.values(tab.fields)
-      .filter((field) => !field.isAuditField)
+      .filter((field) => !field.isAuditField && field.active !== false)
       .map((field) => ({ field, help: getFieldHelp(field) }))
       .filter(({ help }) => help.length > 0)
       .sort((a, b) => a.field.sequenceNumber - b.field.sequenceNumber)

--- a/packages/MainUI/utils/help/buildHelpContent.ts
+++ b/packages/MainUI/utils/help/buildHelpContent.ts
@@ -63,8 +63,10 @@ function getFieldHelp(field: Field): string {
  * them the same way), tabs ordered by sequenceNumber, fields within each tab
  * ordered by sequenceNumber, audit/inactive/non-displayed fields omitted
  * (Classic only documents fields the user actually sees on the form — hidden
- * key columns, status-bar-only fields, etc. never got an entry there either),
- * and fields with no help text (own or column fallback) omitted.
+ * key columns, status-bar-only fields, etc. never got an entry there either).
+ * Fields with no help text (own or column fallback) are still listed, with
+ * an empty helpComment — Classic lists every displayed field's name too,
+ * even the ones with nothing written under them.
  */
 export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
   const orderedTabs = [...window.tabs]
@@ -74,10 +76,8 @@ export function buildHelpSections(window: WindowMetadata): HelpTabSection[] {
   return orderedTabs.map((tab: Tab) => {
     const fields = Object.values(tab.fields)
       .filter((field) => !field.isAuditField && field.active !== false && field.displayed)
-      .map((field) => ({ field, help: getFieldHelp(field) }))
-      .filter(({ help }) => help.length > 0)
-      .sort((a, b) => a.field.sequenceNumber - b.field.sequenceNumber)
-      .map(({ field, help }) => ({ id: field.id, name: field.name, helpComment: help }));
+      .sort((a, b) => a.sequenceNumber - b.sequenceNumber)
+      .map((field) => ({ id: field.id, name: field.name, helpComment: getFieldHelp(field) }));
 
     return {
       id: tab.id,

--- a/packages/api-client/src/api/types.ts
+++ b/packages/api-client/src/api/types.ts
@@ -282,6 +282,8 @@ export interface Field {
   processAction?: ProcessAction;
   etmetaCustomjs?: string | null;
   isActive: boolean;
+  /** AD_Field.ISACTIVE, as sent on the wire (isActive above is not actually populated by the backend). */
+  active?: boolean;
   gridDisplayLogic: string;
   /**
    * Indicates if this field contains the parent record ID in a hierarchical tab structure.
@@ -512,6 +514,8 @@ export interface Tab {
   helpComment?: string | null;
   /** AD_Tab column position — used to order tabs the same way Classic's Help view does. */
   sequenceNumber?: number;
+  /** AD_Tab.ISACTIVE — inactive tabs are excluded from Classic's Help view. */
+  active?: boolean;
 }
 
 export interface WindowMetadata {

--- a/packages/api-client/src/api/types.ts
+++ b/packages/api-client/src/api/types.ts
@@ -508,6 +508,10 @@ export interface Tab {
   disableParentKeyProperty?: boolean;
   defaultEditMode?: boolean;
   auxiliaryInputs?: AuxiliaryInput[];
+  /** AD_Tab.HELP, translated (FULL_TRANSLATABLE). Always present on the wire, null when empty. */
+  helpComment?: string | null;
+  /** AD_Tab column position — used to order tabs the same way Classic's Help view does. */
+  sequenceNumber?: number;
 }
 
 export interface WindowMetadata {
@@ -518,6 +522,8 @@ export interface WindowMetadata {
   tabs: Tab[];
   window$_identifier: string;
   windowType?: string;
+  /** AD_Window.HELP, translated (FULL_TRANSLATABLE). Always present on the wire, null when empty. */
+  helpComment?: string | null;
 }
 
 export interface RecordPayload extends Record<string, string> {


### PR DESCRIPTION
## Summary
- Add a contextual Help widget: a per-window Help trigger in the navbar that shows window/tab/field help content (title, sanitized rich text, tab index sidebar with scroll-spy).
- Rework the Help panel from an overlay (`Modal`/portal/backdrop) into a real layout-pushing panel — mirrors the existing left-nav `Drawer`'s push mechanism, so the grid/table stays usable (clickable) while Help is open, instead of being covered by a dimmed backdrop.
- Add `useHelpPanelStore` (Zustand) to bridge the trigger (`HelpAccess`, in `Navigation`) and the panel (`HelpDrawer`, now mounted as a sibling in `layout.tsx`) across non-adjacent parts of the component tree.

## Test plan
- [x] `pnpm --filter @workspaceui/mainui test` — 493 suites / 6018 tests passing
- [x] `pnpm biome check` on all touched files — clean
- [x] Manual QA via Playwright against a running `pnpm dev` + Etendo backend:
  - [x] Opening Help pushes the grid content over (no backdrop, no dimming)
  - [x] Grid row selection works normally while Help is open
  - [x] Clicking the Help icon again toggles it closed
  - [x] Escape closes the panel
  - [x] Switching the active window while Help is open closes the panel
  - [x] Left-nav Drawer + Help panel open simultaneously: three-way layout holds, content column doesn't collapse