### PR TITLE
Hotfix ETP-4623: Access denied screen on deep-links without access- #201

### DIFF
--- a/packages/ComponentLibrary/src/locales/en.ts
+++ b/packages/ComponentLibrary/src/locales/en.ts
@@ -192,6 +192,16 @@ const en = {
       title: "Recovery Failed",
       description: "Unable to restore window state from URL",
     },
+    accessDenied: {
+      title: "Access Denied",
+      description: "Your role does not have access to this window. Contact your system administrator if you need it.",
+      tableDescription: "Your role does not have permission to view this data.",
+      discarded: {
+        title: "Some windows were not opened",
+        descriptionOne: "One window was discarded because your role does not have access to it.",
+        descriptionMany: "windows were discarded because your role does not have access to them.",
+      },
+    },
   },
   modal: {
     secondaryButtonLabel: "Back",

--- a/packages/ComponentLibrary/src/locales/es.ts
+++ b/packages/ComponentLibrary/src/locales/es.ts
@@ -192,6 +192,16 @@ const es = {
       title: "Error de Recuperación",
       description: "No se pudo restaurar el estado de la ventana desde la URL",
     },
+    accessDenied: {
+      title: "Acceso denegado",
+      description: "Tu rol no tiene acceso a esta ventana. Contacta al administrador del sistema si necesitas acceso.",
+      tableDescription: "Tu rol no tiene permisos para ver estos datos.",
+      discarded: {
+        title: "Algunas ventanas no se abrieron",
+        descriptionOne: "Se descartó una ventana porque tu rol no tiene acceso.",
+        descriptionMany: "ventanas descartadas porque tu rol no tiene acceso.",
+      },
+    },
   },
   modal: {
     secondaryButtonLabel: "Atrás",

--- a/packages/MainUI/__tests__/app/window/page.test.tsx
+++ b/packages/MainUI/__tests__/app/window/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import Page from "@/app/(main)/window/page";
 import { useWindowStore } from "@/stores/windowStore";
 
@@ -32,14 +32,25 @@ jest.mock("@/components/loading", () => ({
   default: ({ "data-testid": testId }: any) => <div data-testid={testId}>Loading</div>,
 }));
 
+jest.mock("@/components/AccessDeniedDisplay", () => ({
+  AccessDeniedScreen: ({ onGoHome }: any) => (
+    <button type="button" data-testid="AccessDeniedScreen" onClick={onGoHome}>
+      AccessDenied
+    </button>
+  ),
+}));
+
+const setAccessDeniedWindowCount = jest.fn();
+
 /** Helper to set up useWindowStore mock with the given windows and recovery state */
 function mockWindowStore(opts: {
   windows?: Record<string, any>;
   isRecoveryLoading?: boolean;
+  accessDeniedWindowCount?: number;
 }) {
-  const { windows = {}, isRecoveryLoading = false } = opts;
+  const { windows = {}, isRecoveryLoading = false, accessDeniedWindowCount = 0 } = opts;
   (useWindowStore as unknown as jest.Mock).mockImplementation((selector: (s: any) => any) => {
-    const state = { windows, isRecoveryLoading };
+    const state = { windows, isRecoveryLoading, accessDeniedWindowCount, setAccessDeniedWindowCount };
     return selector(state);
   });
 }
@@ -113,5 +124,55 @@ describe("Window Page", () => {
     render(<Page />);
 
     expect(screen.queryByText("WindowTabs")).not.toBeInTheDocument();
+  });
+
+  describe("Access Denied screen", () => {
+    it("replaces the dashboard when every requested window was discarded", () => {
+      mockWindowStore({ windows: {}, accessDeniedWindowCount: 1 });
+
+      render(<Page />);
+
+      expect(screen.getByTestId("AccessDeniedScreen")).toBeInTheDocument();
+      expect(screen.queryByText("Home")).not.toBeInTheDocument();
+    });
+
+    it("is not rendered when some windows survived", () => {
+      mockWindowStore({
+        windows: { "123": { windowIdentifier: "123", isActive: true } },
+        accessDeniedWindowCount: 1,
+      });
+
+      render(<Page />);
+
+      expect(screen.queryByTestId("AccessDeniedScreen")).not.toBeInTheDocument();
+      expect(screen.getByTestId("Window__123")).toBeInTheDocument();
+    });
+
+    it("keeps showing the dashboard when nothing was discarded", () => {
+      mockWindowStore({ windows: {}, accessDeniedWindowCount: 0 });
+
+      render(<Page />);
+
+      expect(screen.queryByTestId("AccessDeniedScreen")).not.toBeInTheDocument();
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
+
+    it("yields to the recovery loading state", () => {
+      mockWindowStore({ windows: {}, isRecoveryLoading: true, accessDeniedWindowCount: 1 });
+
+      render(<Page />);
+
+      expect(screen.getByTestId("Loading__Recovery")).toBeInTheDocument();
+      expect(screen.queryByTestId("AccessDeniedScreen")).not.toBeInTheDocument();
+    });
+
+    it("clears the counter when the user goes home", () => {
+      mockWindowStore({ windows: {}, accessDeniedWindowCount: 2 });
+
+      render(<Page />);
+      fireEvent.click(screen.getByTestId("AccessDeniedScreen"));
+
+      expect(setAccessDeniedWindowCount).toHaveBeenCalledWith(0);
+    });
   });
 });

--- a/packages/MainUI/app/(main)/window/page.tsx
+++ b/packages/MainUI/app/(main)/window/page.tsx
@@ -16,17 +16,20 @@
  */
 // @data-testid-ignore
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import WindowTabs from "@/components/NavigationTabs/WindowTabs";
 import { useWindowStore } from "@/stores/windowStore";
 import Home from "@/screens/Home";
 import Window from "@/components/window/Window";
 import TabsProvider from "@/contexts/tabs";
 import Loading from "@/components/loading";
+import { AccessDeniedScreen } from "@/components/AccessDeniedDisplay";
 
 export default function Page() {
   const windowsObj = useWindowStore((s) => s.windows);
   const isRecoveryLoading = useWindowStore((s) => s.isRecoveryLoading);
+  const accessDeniedWindowCount = useWindowStore((s) => s.accessDeniedWindowCount);
+  const setAccessDeniedWindowCount = useWindowStore((s) => s.setAccessDeniedWindowCount);
   const windows = useMemo(() => Object.values(windowsObj), [windowsObj]);
   const activeWindow = useMemo(() => windows.find((w) => w.isActive) ?? null, [windows]);
   const isHomeRoute = !activeWindow;
@@ -51,9 +54,17 @@ export default function Page() {
 
   const shouldShowTabs = windows.length > 0;
   const shouldShowWindow = activeWindow && !isHomeRoute;
+  // Only when nothing else survived: with other windows open the discards are reported via toast.
+  const shouldShowAccessDenied = accessDeniedWindowCount > 0 && windows.length === 0;
+
+  const handleGoHome = useCallback(() => setAccessDeniedWindowCount(0), [setAccessDeniedWindowCount]);
 
   if (isRecoveryLoading && !activeWindow) {
     return <Loading data-testid="Loading__Recovery" />;
+  }
+
+  if (shouldShowAccessDenied) {
+    return <AccessDeniedScreen onGoHome={handleGoHome} />;
   }
 
   return (

--- a/packages/MainUI/components/AccessDeniedDisplay.tsx
+++ b/packages/MainUI/components/AccessDeniedDisplay.tsx
@@ -1,0 +1,62 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+"use client";
+
+import { Button } from "@mui/material";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+import { useTranslation } from "@/hooks/useTranslation";
+import type { AccessDeniedDisplayProps, AccessDeniedScreenProps } from "./types";
+
+/**
+ * Card telling the user that their role is not allowed to see the requested resource.
+ * Reuses ErrorDisplay so it keeps the same illustration and layout as the other status screens.
+ */
+export function AccessDeniedDisplay({ description, children }: AccessDeniedDisplayProps) {
+  const { t } = useTranslation();
+
+  return (
+    <ErrorDisplay
+      title={t("errors.accessDenied.title")}
+      description={description ?? t("errors.accessDenied.description")}
+      data-testid="ErrorDisplay__b93399">
+      {children}
+    </ErrorDisplay>
+  );
+}
+
+/**
+ * Full-screen variant, rendered instead of the dashboard when every window requested through the
+ * URL turned out to be inaccessible.
+ *
+ * The "home" action is a button rather than ErrorDisplay's `showHomeButton` link: "/" and "/window"
+ * mount the same page, so navigating there would not dismiss this screen and would force an
+ * avoidable RSC roundtrip.
+ */
+export function AccessDeniedScreen({ onGoHome }: AccessDeniedScreenProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <AccessDeniedDisplay data-testid="AccessDeniedDisplay__b93399">
+        <Button variant="contained" onClick={onGoHome} data-testid="Button__b93399">
+          {t("navigation.common.home")}
+        </Button>
+      </AccessDeniedDisplay>
+    </div>
+  );
+}

--- a/packages/MainUI/components/Table/TableErrorDisplay.tsx
+++ b/packages/MainUI/components/Table/TableErrorDisplay.tsx
@@ -1,0 +1,56 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+"use client";
+
+import { AccessDeniedDisplay } from "@/components/AccessDeniedDisplay";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+import { useTranslation } from "@/hooks/useTranslation";
+import { isAccessDeniedError } from "@/utils/accessDenied";
+
+export interface TableErrorDisplayProps {
+  /** Raw failure from useDatasource, which throws the response body rather than an Error. */
+  error: unknown;
+  onRetry: () => void;
+}
+
+/**
+ * Picks the right status screen for a table failure: a permission message when the role is not
+ * allowed to read the data, and the generic retryable error otherwise.
+ */
+export function TableErrorDisplay({ error, onRetry }: TableErrorDisplayProps) {
+  const { t } = useTranslation();
+
+  if (isAccessDeniedError(error)) {
+    return (
+      <AccessDeniedDisplay
+        description={t("errors.accessDenied.tableDescription")}
+        data-testid="AccessDeniedDisplay__b6f506"
+      />
+    );
+  }
+
+  return (
+    <ErrorDisplay
+      title={t("errors.tableError.title")}
+      description={(error as Error | undefined)?.message}
+      showRetry
+      onRetry={onRetry}
+      data-testid="ErrorDisplay__b6f506"
+    />
+  );
+}

--- a/packages/MainUI/components/Table/__tests__/TableErrorDisplay.test.tsx
+++ b/packages/MainUI/components/Table/__tests__/TableErrorDisplay.test.tsx
@@ -1,0 +1,79 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TableErrorDisplay } from "@/components/Table/TableErrorDisplay";
+import { DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR } from "@/utils/session/constants";
+
+const ACCESS_DENIED_TESTID = "AccessDeniedDisplay";
+const ERROR_DISPLAY_TESTID = "ErrorDisplay";
+const RETRY_LABEL = "Retry";
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@/components/AccessDeniedDisplay", () => ({
+  AccessDeniedDisplay: ({ description }: any) => <div data-testid="AccessDeniedDisplay">{description}</div>,
+}));
+
+jest.mock("@/components/ErrorDisplay", () => ({
+  ErrorDisplay: ({ title, description, onRetry }: any) => (
+    <div data-testid="ErrorDisplay">
+      <h2>{title}</h2>
+      <p>{description}</p>
+      <button type="button" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  ),
+}));
+
+describe("TableErrorDisplay", () => {
+  it("shows the permission message for a datasource access failure", () => {
+    const error = { response: { error: { message: DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR } } };
+
+    render(<TableErrorDisplay error={error} onRetry={jest.fn()} />);
+
+    expect(screen.getByTestId(ACCESS_DENIED_TESTID)).toHaveTextContent("errors.accessDenied.tableDescription");
+    expect(screen.queryByTestId(ERROR_DISPLAY_TESTID)).not.toBeInTheDocument();
+  });
+
+  it("keeps the generic retryable error for any other failure", () => {
+    render(<TableErrorDisplay error={new Error("boom")} onRetry={jest.fn()} />);
+
+    expect(screen.getByTestId(ERROR_DISPLAY_TESTID)).toBeInTheDocument();
+    expect(screen.getByText("errors.tableError.title")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("forwards the retry action of the generic error", () => {
+    const onRetry = jest.fn();
+    render(<TableErrorDisplay error={new Error("boom")} onRetry={onRetry} />);
+
+    fireEvent.click(screen.getByRole("button", { name: RETRY_LABEL }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a raw thrown object with no message", () => {
+    render(<TableErrorDisplay error={{ response: { data: [] } }} onRetry={jest.fn()} />);
+
+    expect(screen.getByTestId(ERROR_DISPLAY_TESTID)).toBeInTheDocument();
+    expect(screen.getByText("errors.tableError.title")).toBeInTheDocument();
+  });
+});

--- a/packages/MainUI/components/Table/index.tsx
+++ b/packages/MainUI/components/Table/index.tsx
@@ -48,7 +48,7 @@ import { useToolbarContext } from "@/contexts/ToolbarContext";
 import useTableSelection from "@/hooks/useTableSelection";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useRowKeyboardNavigation } from "./hooks/useRowKeyboardNavigation";
-import { ErrorDisplay } from "../ErrorDisplay";
+import { TableErrorDisplay } from "./TableErrorDisplay";
 import { useTranslation } from "@/hooks/useTranslation";
 import { useTabContext } from "@/contexts/tab";
 import { useTabRefreshContext } from "@/contexts/TabRefreshContext";
@@ -3783,15 +3783,7 @@ const DynamicTable = ({
   }, [pendingSelectionId, table, loading, isUploading]);
 
   if (error) {
-    return (
-      <ErrorDisplay
-        title={t("errors.tableError.title")}
-        description={error?.message}
-        showRetry
-        onRetry={refetch}
-        data-testid="ErrorDisplay__8ca888"
-      />
-    );
+    return <TableErrorDisplay error={error} onRetry={refetch} data-testid="TableErrorDisplay__8ca888" />;
   }
 
   if (parentTab && !parentRecord) {

--- a/packages/MainUI/components/__tests__/AccessDeniedDisplay.test.tsx
+++ b/packages/MainUI/components/__tests__/AccessDeniedDisplay.test.tsx
@@ -1,0 +1,108 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AccessDeniedDisplay, AccessDeniedScreen } from "@/components/AccessDeniedDisplay";
+
+const TITLE = "Access Denied";
+const DESCRIPTION = "Your role does not have access to this window.";
+const TABLE_DESCRIPTION = "Your role does not have permission to view this data.";
+const HOME_LABEL = "Home";
+
+jest.mock("@mui/material", () => ({
+  Button: function MockButton({ children, onClick, ...props }: any) {
+    return (
+      <button type="button" onClick={onClick} {...props}>
+        {children}
+      </button>
+    );
+  },
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({ children, href }: any) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "errors.accessDenied.title": "Access Denied",
+        "errors.accessDenied.description": "Your role does not have access to this window.",
+        "navigation.common.home": "Home",
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+jest.mock("@/components/ErrorDisplay", () => ({
+  ErrorDisplay: ({ title, description, children }: any) => (
+    <div data-testid="ErrorDisplay">
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {children}
+    </div>
+  ),
+}));
+
+describe("AccessDeniedDisplay", () => {
+  it("shows the default window-level wording", () => {
+    render(<AccessDeniedDisplay />);
+
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(screen.getByText(DESCRIPTION)).toBeInTheDocument();
+  });
+
+  it("lets the caller override the description", () => {
+    render(<AccessDeniedDisplay description={TABLE_DESCRIPTION} />);
+
+    expect(screen.getByText(TABLE_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.queryByText(DESCRIPTION)).not.toBeInTheDocument();
+  });
+
+  it("renders its children inside the card", () => {
+    render(
+      <AccessDeniedDisplay>
+        <span>Extra action</span>
+      </AccessDeniedDisplay>
+    );
+
+    expect(screen.getByText("Extra action")).toBeInTheDocument();
+  });
+});
+
+describe("AccessDeniedScreen", () => {
+  it("centers the card and offers a home action", () => {
+    const { container } = render(<AccessDeniedScreen onGoHome={jest.fn()} />);
+
+    expect(container.querySelector(".w-full.h-full.flex.items-center.justify-center")).toBeInTheDocument();
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: HOME_LABEL })).toBeInTheDocument();
+  });
+
+  it("invokes onGoHome when the action is clicked", () => {
+    const onGoHome = jest.fn();
+    render(<AccessDeniedScreen onGoHome={onGoHome} />);
+
+    fireEvent.click(screen.getByRole("button", { name: HOME_LABEL }));
+
+    expect(onGoHome).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/MainUI/components/types.ts
+++ b/packages/MainUI/components/types.ts
@@ -15,10 +15,23 @@
  *************************************************************************
  */
 
+import type { ReactNode } from "react";
+
 export interface ErrorDisplayProps {
   title: string;
   description?: string;
   showRetry?: boolean;
   onRetry?: () => void;
   showHomeButton?: boolean;
+}
+
+export interface AccessDeniedDisplayProps {
+  /** Overrides the default window-level wording (e.g. with the table-level one). */
+  description?: string;
+  children?: ReactNode;
+}
+
+export interface AccessDeniedScreenProps {
+  /** Dismisses the screen and lands the user on the dashboard. */
+  onGoHome: () => void;
 }

--- a/packages/MainUI/contexts/__tests__/metadataSynchronizer.test.tsx
+++ b/packages/MainUI/contexts/__tests__/metadataSynchronizer.test.tsx
@@ -1,0 +1,108 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { WINDOW_NOT_FOUND_ERROR_MESSAGE, WindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { MetadataSynchronizer } from "@/contexts/metadata";
+import { useWindowStore } from "@/stores/windowStore";
+
+const WINDOW_ID = "102";
+const WINDOW_IDENTIFIER = "102_1787227156318";
+
+const cleanupWindow = jest.fn();
+const loadWindowData = jest.fn();
+
+jest.mock("sonner", () => ({ toast: { warning: jest.fn() } }));
+
+jest.mock("@/contexts/datasourceContext", () => ({
+  useDatasourceContext: () => ({ removeRecordFromDatasource: jest.fn() }),
+}));
+
+jest.mock("@/contexts/metadataStore", () => ({
+  useMetadataStore: () => ({
+    loadWindowData,
+    isWindowLoading: () => false,
+    windowsData: {},
+  }),
+}));
+
+jest.mock("@/hooks/useTranslation", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("MetadataSynchronizer", () => {
+  const realCleanupWindow = useWindowStore.getState().cleanupWindow;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useWindowStore.setState({
+      windows: {
+        [WINDOW_IDENTIFIER]: { windowId: WINDOW_ID, windowIdentifier: WINDOW_IDENTIFIER, isActive: true } as never,
+      },
+      dirtyWindows: {},
+      accessDeniedWindowCount: 0,
+      cleanupWindow,
+    });
+  });
+
+  it("closes the window and warns when other windows are still open", async () => {
+    loadWindowData.mockRejectedValue(new WindowAccessDeniedError(WINDOW_ID, 401));
+
+    render(<MetadataSynchronizer />);
+
+    await waitFor(() => expect(cleanupWindow).toHaveBeenCalledWith(WINDOW_IDENTIFIER));
+    // The mocked cleanupWindow does not remove the window, so one is still counted as remaining.
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+    expect(useWindowStore.getState().accessDeniedWindowCount).toBe(0);
+  });
+
+  it("requests the full-screen view when it was the last open window", async () => {
+    // Restore the real action so the window is actually removed before the report is built.
+    useWindowStore.setState({ cleanupWindow: realCleanupWindow });
+    loadWindowData.mockRejectedValue(new WindowAccessDeniedError(WINDOW_ID, 401));
+
+    render(<MetadataSynchronizer />);
+
+    await waitFor(() => expect(useWindowStore.getState().accessDeniedWindowCount).toBe(1));
+    expect(useWindowStore.getState().windows).toEqual({});
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("keeps closing silently the windows that no longer exist", async () => {
+    loadWindowData.mockRejectedValue(new Error(WINDOW_NOT_FOUND_ERROR_MESSAGE));
+
+    render(<MetadataSynchronizer />);
+
+    await waitFor(() => expect(cleanupWindow).toHaveBeenCalledWith(WINDOW_IDENTIFIER));
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(useWindowStore.getState().accessDeniedWindowCount).toBe(0);
+  });
+
+  it("leaves any other failure untouched", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    loadWindowData.mockRejectedValue(new Error("boom"));
+
+    render(<MetadataSynchronizer />);
+
+    await waitFor(() => expect(consoleSpy).toHaveBeenCalled());
+    expect(cleanupWindow).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/MainUI/contexts/metadata.tsx
+++ b/packages/MainUI/contexts/metadata.tsx
@@ -24,18 +24,39 @@ import { useDatasourceContext } from "./datasourceContext";
 import { mapBy } from "@/utils/structures";
 import { useWindowStore } from "@/stores/windowStore";
 import { useMetadataStore } from "./metadataStore";
+import { isWindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { buildAccessDeniedToastTexts, reportWindowsAccessDenied } from "@/utils/accessDenied";
+import { useTranslation } from "@/hooks/useTranslation";
 
 export const MetadataSynchronizer = () => {
   const windowsObj = useWindowStore((s) => s.windows);
   const windows = useMemo(() => Object.values(windowsObj), [windowsObj]);
   const cleanupWindow = useWindowStore((s) => s.cleanupWindow);
   const { loadWindowData, isWindowLoading, windowsData } = useMetadataStore();
+  const { t } = useTranslation();
 
   useEffect(() => {
+    /**
+     * Closes a window the current role cannot open and tells the user why. Covers the windows
+     * opened outside URL recovery (menu entry, linked item, internal link).
+     */
+    const handleAccessDenied = (windowIdentifier: string) => {
+      cleanupWindow(windowIdentifier);
+      reportWindowsAccessDenied({
+        deniedCount: 1,
+        // Read after the cleanup, since zustand applies it synchronously.
+        remainingWindowCount: Object.keys(useWindowStore.getState().windows).length,
+        texts: buildAccessDeniedToastTexts(t),
+        showAccessDeniedScreen: useWindowStore.getState().setAccessDeniedWindowCount,
+      });
+    };
+
     for (const win of windows) {
       if (win.windowId && !windowsData[win.windowId] && !isWindowLoading(win.windowId)) {
         loadWindowData(win.windowId).catch((error) => {
-          if (error.message?.toLowerCase().includes("not found")) {
+          if (isWindowAccessDeniedError(error)) {
+            handleAccessDenied(win.windowIdentifier);
+          } else if (error.message?.toLowerCase().includes("not found")) {
             cleanupWindow(win.windowIdentifier);
           } else {
             console.error(error);
@@ -43,7 +64,7 @@ export const MetadataSynchronizer = () => {
         });
       }
     }
-  }, [windows, windowsData, isWindowLoading, loadWindowData, cleanupWindow]);
+  }, [windows, windowsData, isWindowLoading, loadWindowData, cleanupWindow, t]);
 
   return null;
 };

--- a/packages/MainUI/hooks/__tests__/useGlobalUrlStateRecovery.test.tsx
+++ b/packages/MainUI/hooks/__tests__/useGlobalUrlStateRecovery.test.tsx
@@ -37,6 +37,9 @@ import { reconstructState } from "@/utils/recovery/stateReconstructor";
 import type { WindowMetadata } from "@workspaceui/api-client/src/api/types";
 import type { WindowRecoveryInfo } from "@/utils/window/constants";
 import { createMockTab, createMockWindowMetadata } from "@/utils/tests/mockHelpers";
+import { toast } from "sonner";
+import { WindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { useWindowStore } from "@/stores/windowStore";
 
 // Mock dependencies
 jest.mock("next/navigation", () => ({
@@ -48,6 +51,7 @@ jest.mock("@/utils/recovery/urlStateParser");
 jest.mock("@/utils/recovery/hierarchyCalculator");
 jest.mock("@/utils/recovery/stateReconstructor");
 jest.mock("@/utils/recovery/reconstructedSessionSync");
+jest.mock("sonner", () => ({ toast: { warning: jest.fn() } }));
 
 const mockUseSearchParams = useSearchParams as jest.Mock;
 const mockUseMetadataStore = useMetadataStore as jest.MockedFunction<typeof useMetadataStore>;
@@ -657,6 +661,99 @@ describe("useGlobalUrlStateRecovery", () => {
       expect(mockLoadWindowData).toHaveBeenCalledWith("143");
       expect(result.current.recoveredWindows[0].windowId).toBe("143");
       expect(result.current.recoveredWindows[0].windowIdentifier).toBe("143_123456789");
+    });
+  });
+
+  describe("Inaccessible windows", () => {
+    const ACCESSIBLE_IDENTIFIER = "143_111";
+    const DENIED_IDENTIFIER = "102_222";
+
+    /**
+     * Wires a recovery over the given identifiers, resolving metadata for every one of them except
+     * the denied ones, which reject with the typed access error.
+     */
+    const setupRecoveryWithDenials = (identifiers: string[], deniedIdentifiers: string[]) => {
+      mockUseSearchParams.mockReturnValue(
+        createMockSearchParams(Object.fromEntries(identifiers.map((id, index) => [`wi_${index}`, id])))
+      );
+      mockParseWindowRecoveryData.mockReturnValue(identifiers.map((id) => createMockRecoveryInfo(id)));
+      mockGetWindowName.mockReturnValue("Sales Order");
+      mockLoadWindowData.mockImplementation((windowId: string) => {
+        const isDenied = deniedIdentifiers.some((id) => id.startsWith(`${windowId}_`));
+        if (isDenied) {
+          return Promise.reject(new WindowAccessDeniedError(windowId, 401));
+        }
+        return Promise.resolve(createMockWindowMetadata(windowId));
+      });
+    };
+
+    beforeEach(() => {
+      useWindowStore.getState().setAccessDeniedWindowCount(0);
+    });
+
+    it("drops the inaccessible window and warns when another one survived", async () => {
+      setupRecoveryWithDenials([ACCESSIBLE_IDENTIFIER, DENIED_IDENTIFIER], [DENIED_IDENTIFIER]);
+
+      const { result } = await renderHookAndWait();
+
+      expect(result.current.recoveredWindows).toHaveLength(1);
+      expect(result.current.recoveredWindows[0].windowIdentifier).toBe(ACCESSIBLE_IDENTIFIER);
+      expect(toast.warning).toHaveBeenCalledTimes(1);
+      expect(useWindowStore.getState().accessDeniedWindowCount).toBe(0);
+    });
+
+    it("activates the surviving window even when the denied one was last in the URL", async () => {
+      setupRecoveryWithDenials([ACCESSIBLE_IDENTIFIER, DENIED_IDENTIFIER], [DENIED_IDENTIFIER]);
+
+      const { result } = await renderHookAndWait();
+
+      expect(result.current.recoveredWindows[0].isActive).toBe(true);
+    });
+
+    it("requests the full-screen view and no toast when every window is inaccessible", async () => {
+      setupRecoveryWithDenials([DENIED_IDENTIFIER], [DENIED_IDENTIFIER]);
+
+      const { result } = await renderHookAndWait();
+
+      expect(result.current.recoveredWindows).toEqual([]);
+      expect(result.current.recoveryError).toBeNull();
+      expect(useWindowStore.getState().accessDeniedWindowCount).toBe(1);
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+
+    it("skips the state reconstruction of a denied window that carried tab and record params", async () => {
+      const recoveryInfo = createMockRecoveryInfo(DENIED_IDENTIFIER, {
+        hasRecoveryData: true,
+        tabId: "107",
+        recordId: "2615",
+      });
+      mockUseSearchParams.mockReturnValue(
+        createMockSearchParams({ wi_0: DENIED_IDENTIFIER, ti_0: "107", ri_0: "2615" })
+      );
+      mockParseWindowRecoveryData.mockReturnValue([recoveryInfo]);
+      mockLoadWindowData.mockRejectedValue(new WindowAccessDeniedError("102", 401));
+
+      const { result } = await renderHookAndWait();
+
+      expect(result.current.recoveredWindows).toEqual([]);
+      expect(mockParseUrlState).not.toHaveBeenCalled();
+      expect(mockCalculateHierarchy).not.toHaveBeenCalled();
+      expect(mockReconstructState).not.toHaveBeenCalled();
+    });
+
+    it("keeps the minimal-state fallback for non-access failures", async () => {
+      setupSimpleRecovery("143", ACCESSIBLE_IDENTIFIER);
+      mockLoadWindowData.mockRejectedValue(new Error("Window not found"));
+      const consoleSpy = mockConsole("warn");
+
+      const { result } = await renderHookAndWait();
+
+      expect(result.current.recoveredWindows).toHaveLength(1);
+      expect(result.current.recoveredWindows[0].title).toBe("");
+      expect(toast.warning).not.toHaveBeenCalled();
+      expect(useWindowStore.getState().accessDeniedWindowCount).toBe(0);
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/MainUI/hooks/useGlobalUrlStateRecovery.ts
+++ b/packages/MainUI/hooks/useGlobalUrlStateRecovery.ts
@@ -7,8 +7,12 @@ import { parseUrlState, getWindowName } from "@/utils/recovery/urlStateParser";
 import { calculateHierarchy } from "@/utils/recovery/hierarchyCalculator";
 import { reconstructState } from "@/utils/recovery/stateReconstructor";
 import { syncReconstructedHierarchyToSession } from "@/utils/recovery/reconstructedSessionSync";
-import { createRecoveryWindowState, getWindowIdFromIdentifier } from "@/utils/window/utils";
+import { createRecoveryWindowState, getWindowIdFromIdentifier, markLastWindowAsActive } from "@/utils/window/utils";
 import { useUserStore } from "@/stores/userStore";
+import { useWindowStore } from "@/stores/windowStore";
+import { isWindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { buildAccessDeniedToastTexts, reportWindowsAccessDenied } from "@/utils/accessDenied";
+import { useTranslation } from "@/hooks/useTranslation";
 import type { WindowState } from "@/utils/window/constants";
 
 /**
@@ -55,6 +59,7 @@ import type { WindowState } from "@/utils/window/constants";
 export const useGlobalUrlStateRecovery = () => {
   const searchParams = useSearchParams();
   const { loadWindowData } = useMetadataStore();
+  const { t } = useTranslation();
 
   const [recoveredWindows, setRecoveredWindows] = useState<WindowState[]>([]);
   const [isRecoveryLoading, setIsRecoveryLoading] = useState(true);
@@ -84,6 +89,9 @@ export const useGlobalUrlStateRecovery = () => {
       if (!isMounted.current) return;
       setIsRecoveryLoading(true);
       setRecoveryError(null);
+      useWindowStore.getState().setAccessDeniedWindowCount(0);
+      // Windows the current role is not allowed to open; they are dropped instead of recovered.
+      const deniedIdentifiers: string[] = [];
       try {
         // Extract all window identifiers from URL (wi_0, wi_1, wi_2, ...)
         const recoveryDataList = parseWindowRecoveryData(searchParams);
@@ -96,7 +104,7 @@ export const useGlobalUrlStateRecovery = () => {
 
         // Parallel recovery of all windows for better performance
         // Each window recovery is independent and can run concurrently
-        const windowPromises = recoveryDataList.map(async (info, index) => {
+        const windowPromises = recoveryDataList.map(async (info, index): Promise<WindowState | null> => {
           const windowId = getWindowIdFromIdentifier(info.windowIdentifier);
 
           try {
@@ -150,6 +158,13 @@ export const useGlobalUrlStateRecovery = () => {
             }
             return windowState;
           } catch (error) {
+            // The role cannot open this window: drop it instead of opening a useless tab. Reported
+            // afterwards, once it is known whether any other window survived.
+            if (isWindowAccessDeniedError(error)) {
+              deniedIdentifiers.push(info.windowIdentifier);
+              return null;
+            }
+
             console.warn(
               `[Recovery] Failed to recover window ${info.windowIdentifier}, falling back to minimal state.`,
               error
@@ -166,12 +181,22 @@ export const useGlobalUrlStateRecovery = () => {
         });
 
         // Wait for all windows to complete recovery
-        const windows = await Promise.all(windowPromises);
+        const results = await Promise.all(windowPromises);
+        // isActive was assigned per URL index, so it has to be recomputed over the survivors:
+        // otherwise, if the discarded window was the last one, none would end up active.
+        const windows = markLastWindowAsActive(results.filter((state): state is WindowState => state !== null));
 
         if (isMounted.current) {
           setRecoveredWindows(windows);
           setIsRecoveryLoading(false);
         }
+
+        reportWindowsAccessDenied({
+          deniedCount: deniedIdentifiers.length,
+          remainingWindowCount: windows.length,
+          texts: buildAccessDeniedToastTexts(t),
+          showAccessDeniedScreen: useWindowStore.getState().setAccessDeniedWindowCount,
+        });
       } catch (error) {
         console.error("Global recovery failed", error);
         if (isMounted.current) {
@@ -182,7 +207,7 @@ export const useGlobalUrlStateRecovery = () => {
     };
 
     recoverAllWindows();
-  }, [searchParams, loadWindowData]);
+  }, [searchParams, loadWindowData, t]);
 
   /**
    * Triggers recovery to run again by resetting the hasRun guard.

--- a/packages/MainUI/stores/__tests__/windowStore.accessDenied.test.ts
+++ b/packages/MainUI/stores/__tests__/windowStore.accessDenied.test.ts
@@ -1,0 +1,68 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { useWindowStore } from "../windowStore";
+
+const WINDOW_IDENTIFIER = "102_1787227156318";
+
+beforeEach(() => {
+  useWindowStore.setState({
+    windows: {},
+    dirtyWindows: {},
+    isRecoveryLoading: false,
+    recoveryError: null,
+    triggerRecovery: () => {},
+    accessDeniedWindowCount: 0,
+  });
+});
+
+describe("windowStore access denied counter", () => {
+  it("starts at zero", () => {
+    expect(useWindowStore.getState().accessDeniedWindowCount).toBe(0);
+  });
+
+  it("stores the number of discarded windows", () => {
+    useWindowStore.getState().setAccessDeniedWindowCount(2);
+
+    expect(useWindowStore.getState().accessDeniedWindowCount).toBe(2);
+  });
+
+  it("is cleared when a window becomes active", () => {
+    useWindowStore.getState().setAccessDeniedWindowCount(1);
+    useWindowStore.getState().setWindowActive({ windowIdentifier: WINDOW_IDENTIFIER });
+
+    const state = useWindowStore.getState();
+    expect(state.accessDeniedWindowCount).toBe(0);
+    expect(state.windows[WINDOW_IDENTIFIER]?.isActive).toBe(true);
+  });
+
+  it("is cleared on cleanState, so a role change does not keep a stale screen", () => {
+    useWindowStore.getState().setAccessDeniedWindowCount(3);
+    useWindowStore.getState().cleanState();
+
+    const state = useWindowStore.getState();
+    expect(state.accessDeniedWindowCount).toBe(0);
+    expect(state.windows).toEqual({});
+  });
+
+  it("survives closing a window, so the screen stays after the last window is discarded", () => {
+    useWindowStore.getState().setAccessDeniedWindowCount(1);
+    useWindowStore.getState().cleanupWindow(WINDOW_IDENTIFIER);
+
+    expect(useWindowStore.getState().accessDeniedWindowCount).toBe(1);
+  });
+});

--- a/packages/MainUI/stores/windowStore.ts
+++ b/packages/MainUI/stores/windowStore.ts
@@ -88,6 +88,12 @@ export interface WindowStore {
   recoveryError: string | null;
   /** Triggers URL-based recovery to re-run. Set by WindowProvider. */
   triggerRecovery: () => void;
+  /**
+   * How many windows were discarded because the current role has no access to them. Greater than
+   * zero with no window left open means the page renders the full-screen Access Denied view.
+   */
+  accessDeniedWindowCount: number;
+  setAccessDeniedWindowCount: (count: number) => void;
 
   // ---- Dirty tracking -----------------------------------------------------
   /** Tracks which windows have unsaved changes, keyed by source (e.g. "form:tabId", "table:tabId") */
@@ -168,7 +174,17 @@ export const useWindowStore = create<WindowStore>()(
       isRecoveryLoading: false,
       recoveryError: null,
       triggerRecovery: () => {},
+      accessDeniedWindowCount: 0,
       dirtyWindows: {},
+
+      setAccessDeniedWindowCount: (count) =>
+        set(
+          (draft) => {
+            draft.accessDeniedWindowCount = count;
+          },
+          false,
+          "window/setAccessDeniedWindowCount"
+        ),
 
       // ---- Table state setters ----------------------------------------
       setTableFilters: (windowIdentifier, tabId, filters, tabLevel = 0) =>
@@ -291,6 +307,10 @@ export const useWindowStore = create<WindowStore>()(
       setWindowActive: ({ windowIdentifier, windowData }) =>
         set(
           (draft) => {
+            // Opening a window makes any pending Access Denied view obsolete; without this it
+            // would come back instead of the dashboard once this window is closed.
+            draft.accessDeniedWindowCount = 0;
+
             // Deactivate all windows
             for (const winId of Object.keys(draft.windows)) {
               if (draft.windows[winId]) {
@@ -384,6 +404,8 @@ export const useWindowStore = create<WindowStore>()(
           (draft) => {
             draft.windows = {};
             draft.dirtyWindows = {};
+            // Role change / logout: the previous role's denials no longer apply.
+            draft.accessDeniedWindowCount = 0;
           },
           false,
           "window/cleanState"

--- a/packages/MainUI/utils/__tests__/accessDenied.test.ts
+++ b/packages/MainUI/utils/__tests__/accessDenied.test.ts
@@ -1,0 +1,118 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { toast } from "sonner";
+import { WindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR } from "@/utils/session/constants";
+import type { TranslateFunction } from "@/hooks/types";
+import {
+  type AccessDeniedToastTexts,
+  buildAccessDeniedToastDescription,
+  buildAccessDeniedToastTexts,
+  isAccessDeniedError,
+  reportWindowsAccessDenied,
+} from "../accessDenied";
+
+jest.mock("sonner", () => ({ toast: { warning: jest.fn() } }));
+
+const TEXTS: AccessDeniedToastTexts = {
+  title: "Some windows were not opened",
+  descriptionOne: "One window was discarded.",
+  descriptionMany: "windows were discarded.",
+};
+
+const datasourceError = (message: string) => ({ response: { error: { message } } });
+
+describe("isAccessDeniedError", () => {
+  it.each([
+    ["the typed window error", new WindowAccessDeniedError("102", 401)],
+    ["a direct datasource response", datasourceError(DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR)],
+    ["a wrapped datasource response", { body: datasourceError(DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR) }],
+    ["a 401 datasource wrapper", { __error: true, status: 401 }],
+    ["an Error carrying the ERP message", new Error(DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR)],
+  ])("detects %s", (_label, error) => {
+    expect(isAccessDeniedError(error)).toBe(true);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["an unrelated datasource message", datasourceError("Something else")],
+    ["a status without the error marker", { status: 401 }],
+    ["a generic Error", new Error("boom")],
+    ["a string", DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR],
+  ])("ignores %s", (_label, error) => {
+    expect(isAccessDeniedError(error)).toBe(false);
+  });
+});
+
+describe("buildAccessDeniedToastTexts", () => {
+  it("reads the three discarded-windows keys", () => {
+    const t = ((key: string) => key) as TranslateFunction;
+
+    expect(buildAccessDeniedToastTexts(t)).toEqual({
+      title: "errors.accessDenied.discarded.title",
+      descriptionOne: "errors.accessDenied.discarded.descriptionOne",
+      descriptionMany: "errors.accessDenied.discarded.descriptionMany",
+    });
+  });
+});
+
+describe("buildAccessDeniedToastDescription", () => {
+  it("uses the dedicated sentence for a single window", () => {
+    expect(buildAccessDeniedToastDescription(1, TEXTS)).toBe(TEXTS.descriptionOne);
+  });
+
+  it("prefixes the count for several windows", () => {
+    expect(buildAccessDeniedToastDescription(3, TEXTS)).toBe(`3 ${TEXTS.descriptionMany}`);
+  });
+});
+
+describe("reportWindowsAccessDenied", () => {
+  let showAccessDeniedScreen: jest.Mock;
+
+  const report = (deniedCount: number, remainingWindowCount: number) =>
+    reportWindowsAccessDenied({ deniedCount, remainingWindowCount, texts: TEXTS, showAccessDeniedScreen });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    showAccessDeniedScreen = jest.fn();
+  });
+
+  it("does nothing when no window was discarded", () => {
+    report(0, 2);
+
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(showAccessDeniedScreen).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast when other windows survived", () => {
+    report(2, 1);
+
+    expect(toast.warning).toHaveBeenCalledWith(TEXTS.title, {
+      description: `2 ${TEXTS.descriptionMany}`,
+    });
+    expect(showAccessDeniedScreen).not.toHaveBeenCalled();
+  });
+
+  it("switches to the full-screen view when no window survived", () => {
+    report(1, 0);
+
+    expect(showAccessDeniedScreen).toHaveBeenCalledWith(1);
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+});

--- a/packages/MainUI/utils/accessDenied.ts
+++ b/packages/MainUI/utils/accessDenied.ts
@@ -1,0 +1,129 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { toast } from "sonner";
+import { HTTP_CODES } from "@workspaceui/api-client/src/api/constants";
+import { isWindowAccessDeniedError } from "@workspaceui/api-client/src/api/errors";
+import { DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR } from "@/utils/session/constants";
+import type { TranslateFunction } from "@/hooks/types";
+
+/** Texts of the toast shown when some windows of a deep-link could not be opened. */
+export interface AccessDeniedToastTexts {
+  title: string;
+  descriptionOne: string;
+  descriptionMany: string;
+}
+
+export interface ReportWindowsAccessDeniedParams {
+  /** How many windows were discarded because the role has no access to them. */
+  deniedCount: number;
+  /** How many windows are still open after the discards. */
+  remainingWindowCount: number;
+  texts: AccessDeniedToastTexts;
+  /** Store setter that switches the page over to the full-screen Access Denied view. */
+  showAccessDeniedScreen: (count: number) => void;
+}
+
+/**
+ * Shape of the datasource failures raised by `useDatasource`, which throws the raw response body
+ * instead of an `Error`. Two variants exist: the direct proxy response and the cached wrapper.
+ */
+interface DatasourceErrorShape {
+  __error?: boolean;
+  status?: number;
+  response?: { error?: { message?: string } };
+  body?: { response?: { error?: { message?: string } } };
+}
+
+const asDatasourceError = (error: unknown): DatasourceErrorShape | undefined => {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  return error as DatasourceErrorShape;
+};
+
+const extractDatasourceErrorMessage = (error: unknown): string | undefined => {
+  const candidate = asDatasourceError(error);
+  if (!candidate) {
+    return undefined;
+  }
+  return candidate.response?.error?.message ?? candidate.body?.response?.error?.message;
+};
+
+/** Requires the `__error` marker so any unrelated object carrying a `status` is not a false hit. */
+const isUnauthorizedDatasourceError = (error: unknown): boolean => {
+  const candidate = asDatasourceError(error);
+  if (!candidate) {
+    return false;
+  }
+  return candidate.__error === true && candidate.status === HTTP_CODES.UNAUTHORIZED;
+};
+
+/**
+ * Tells apart a permission failure from any other error, covering both the window metadata path
+ * (typed error) and the datasource path (`AccessTableNoView` or a 401 wrapper).
+ */
+export const isAccessDeniedError = (error: unknown): boolean => {
+  if (isWindowAccessDeniedError(error)) {
+    return true;
+  }
+  if (extractDatasourceErrorMessage(error) === DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR) {
+    return true;
+  }
+  if (error instanceof Error && error.message === DEFAULT_ACCESS_TABLE_NO_VIEW_ERROR) {
+    return true;
+  }
+  return isUnauthorizedDatasourceError(error);
+};
+
+/** Collects the toast labels once so callers do not duplicate the translation keys. */
+export const buildAccessDeniedToastTexts = (t: TranslateFunction): AccessDeniedToastTexts => ({
+  title: t("errors.accessDenied.discarded.title"),
+  descriptionOne: t("errors.accessDenied.discarded.descriptionOne"),
+  descriptionMany: t("errors.accessDenied.discarded.descriptionMany"),
+});
+
+/**
+ * Builds the toast description. `useTranslation` does not interpolate parameters, so the singular
+ * has its own sentence and the plural is prefixed with the count.
+ */
+export const buildAccessDeniedToastDescription = (count: number, texts: AccessDeniedToastTexts): string => {
+  if (count === 1) {
+    return texts.descriptionOne;
+  }
+  return `${count} ${texts.descriptionMany}`;
+};
+
+/**
+ * Reports the windows that could not be opened: a toast when other windows survived, or the
+ * full-screen Access Denied view when none did.
+ */
+export const reportWindowsAccessDenied = ({
+  deniedCount,
+  remainingWindowCount,
+  texts,
+  showAccessDeniedScreen,
+}: ReportWindowsAccessDeniedParams): void => {
+  if (deniedCount <= 0) {
+    return;
+  }
+  if (remainingWindowCount > 0) {
+    toast.warning(texts.title, { description: buildAccessDeniedToastDescription(deniedCount, texts) });
+    return;
+  }
+  showAccessDeniedScreen(deniedCount);
+};

--- a/packages/MainUI/utils/window/__tests__/utils.test.ts
+++ b/packages/MainUI/utils/window/__tests__/utils.test.ts
@@ -41,6 +41,7 @@ import {
   isWindowReady,
   getKeyFieldName,
   isSrOneToOneExtension,
+  markLastWindowAsActive,
 } from "../utils";
 import { TAB_MODES, FORM_MODES, NEW_RECORD_ID } from "@/utils/url/constants";
 import type { WindowContextState, WindowRecoveryInfo, WindowState } from "@/utils/window/constants";
@@ -983,5 +984,32 @@ describe("isSrOneToOneExtension", () => {
     } as unknown as Tab;
 
     expect(isSrOneToOneExtension(tab)).toBe(true);
+  });
+});
+
+describe("markLastWindowAsActive", () => {
+  const buildWindow = (windowIdentifier: string, isActive: boolean): WindowState =>
+    ({ windowIdentifier, isActive }) as WindowState;
+
+  it("returns an empty list untouched", () => {
+    expect(markLastWindowAsActive([])).toEqual([]);
+  });
+
+  it("activates the only window", () => {
+    const result = markLastWindowAsActive([buildWindow("w1", false)]);
+
+    expect(result.map((w) => w.isActive)).toEqual([true]);
+  });
+
+  it("activates the last window and deactivates the previous ones", () => {
+    const result = markLastWindowAsActive([buildWindow("w1", true), buildWindow("w2", true), buildWindow("w3", false)]);
+
+    expect(result.map((w) => w.isActive)).toEqual([false, false, true]);
+  });
+
+  it("preserves the original order and the rest of the state", () => {
+    const result = markLastWindowAsActive([buildWindow("w1", false), buildWindow("w2", false)]);
+
+    expect(result.map((w) => w.windowIdentifier)).toEqual(["w1", "w2"]);
   });
 });

--- a/packages/MainUI/utils/window/utils.ts
+++ b/packages/MainUI/utils/window/utils.ts
@@ -381,3 +381,20 @@ export const isSrOneToOneExtension = (tab: Tab): boolean => {
   }
   return parentColumns.includes(keyFieldName);
 };
+
+/**
+ * Marks the last window of the list as the active one and every other as inactive.
+ *
+ * URL recovery assigns `isActive` while iterating the URL parameters, so once inaccessible windows
+ * are dropped from the result the flag has to be recomputed: otherwise, if the discarded window was
+ * the last one, no surviving window would be active and the dashboard would show behind the tabs.
+ *
+ * @param windows - The surviving window states, in URL order
+ * @returns The same states with `isActive` set only on the last one
+ */
+export const markLastWindowAsActive = (windows: WindowState[]): WindowState[] => {
+  return windows.map((window, index) => ({
+    ...window,
+    isActive: index === windows.length - 1,
+  }));
+};

--- a/packages/api-client/src/api/__tests__/errors.test.ts
+++ b/packages/api-client/src/api/__tests__/errors.test.ts
@@ -1,0 +1,76 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import {
+  WINDOW_ACCESS_DENIED_ERROR_MESSAGE,
+  WINDOW_ACCESS_DENIED_ERROR_NAME,
+  WINDOW_NOT_FOUND_ERROR_MESSAGE,
+  WindowAccessDeniedError,
+  isWindowAccessDeniedError,
+} from "../errors";
+
+const WINDOW_ID = "102";
+
+describe("WindowAccessDeniedError", () => {
+  it("exposes the window id and status it was built with", () => {
+    const error = new WindowAccessDeniedError(WINDOW_ID, 401);
+
+    expect(error.windowId).toBe(WINDOW_ID);
+    expect(error.status).toBe(401);
+  });
+
+  it("is named so it can be detected without instanceof", () => {
+    const error = new WindowAccessDeniedError(WINDOW_ID, 401);
+
+    expect(error.name).toBe(WINDOW_ACCESS_DENIED_ERROR_NAME);
+    expect(error.message).toBe(WINDOW_ACCESS_DENIED_ERROR_MESSAGE);
+  });
+
+  it("keeps the Error prototype chain despite the ES5 target", () => {
+    const error = new WindowAccessDeniedError(WINDOW_ID, 401);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(WindowAccessDeniedError);
+  });
+
+  it("does not contain the legacy 'not found' substring", () => {
+    // Consumers close missing windows by matching the legacy message; an access-denied error must
+    // never fall into that branch.
+    expect(WINDOW_ACCESS_DENIED_ERROR_MESSAGE.toLowerCase()).not.toContain("not found");
+    expect(WINDOW_NOT_FOUND_ERROR_MESSAGE.toLowerCase()).toContain("not found");
+  });
+});
+
+describe("isWindowAccessDeniedError", () => {
+  it("recognizes the typed error", () => {
+    expect(isWindowAccessDeniedError(new WindowAccessDeniedError(WINDOW_ID, 401))).toBe(true);
+  });
+
+  it("recognizes a plain object carrying the same name, to survive module duplication", () => {
+    expect(isWindowAccessDeniedError({ name: WINDOW_ACCESS_DENIED_ERROR_NAME })).toBe(true);
+  });
+
+  it.each([
+    ["a generic Error", new Error(WINDOW_NOT_FOUND_ERROR_MESSAGE)],
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", WINDOW_ACCESS_DENIED_ERROR_NAME],
+    ["an unrelated object", { status: 401 }],
+  ])("rejects %s", (_label, value) => {
+    expect(isWindowAccessDeniedError(value)).toBe(false);
+  });
+});

--- a/packages/api-client/src/api/__tests__/metadata.windowAccess.test.ts
+++ b/packages/api-client/src/api/__tests__/metadata.windowAccess.test.ts
@@ -1,0 +1,123 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+import { Metadata } from "../metadata";
+import { WINDOW_NOT_FOUND_ERROR_MESSAGE, isWindowAccessDeniedError } from "../errors";
+
+jest.mock("../cache", () => ({
+  CacheStore: jest.fn().mockImplementation(() => {
+    const store = new Map();
+    return {
+      get: jest.fn((key) => store.get(key)),
+      set: jest.fn((key, value) => store.set(key, value)),
+      clear: jest.fn(() => store.clear()),
+      delete: jest.fn((key) => store.delete(key)),
+    };
+  }),
+}));
+
+const WINDOW_ID = "102";
+const TAB_ID = "107";
+const ROLE_ID = "test-role";
+
+/** Mirrors the shape of `Metadata.client.post` responses for the window endpoint. */
+type WindowResponse = { ok: boolean; status?: number; data?: unknown };
+
+/** Reaches into the private statics of `Metadata` so each test starts from a clean slate. */
+// biome-ignore lint/suspicious/noExplicitAny: private statics are the only way to reset the cache
+const metadataInternals = () => Metadata as any;
+
+describe("Metadata window access classification", () => {
+  let postSpy: jest.SpyInstance;
+
+  const mockWindowResponse = (response: WindowResponse) => {
+    postSpy.mockResolvedValue(response as never);
+  };
+
+  const loadWindow = () => Metadata.forceWindowReload(WINDOW_ID);
+
+  const buildPayload = (isWindowAccessible?: boolean) => ({
+    id: WINDOW_ID,
+    tabs: [{ id: TAB_ID }],
+    ...(isWindowAccessible === undefined ? {} : { isWindowAccessible }),
+  });
+
+  const cachedKeys = () => metadataInternals().cache.set.mock.calls.map((call: unknown[]) => call[0]);
+
+  /** Returns the rejection reason so its type can be asserted, since jest-extended is not loaded. */
+  const captureRejection = async (promise: Promise<unknown>): Promise<unknown> => {
+    try {
+      await promise;
+    } catch (error) {
+      return error;
+    }
+    throw new Error("Expected the promise to reject");
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    metadataInternals().currentRoleId = ROLE_ID;
+    metadataInternals().cache.clear();
+    metadataInternals().pendingRequests?.clear();
+    jest.clearAllMocks();
+
+    postSpy = jest.spyOn(Metadata.client, "post");
+  });
+
+  it("throws the typed error and caches nothing on a 401", async () => {
+    mockWindowResponse({ ok: false, status: 401 });
+
+    const error = await captureRejection(loadWindow());
+
+    expect(isWindowAccessDeniedError(error)).toBe(true);
+    expect(cachedKeys()).toEqual([]);
+  });
+
+  it("throws the typed error and caches nothing when the ERP reports no role access", async () => {
+    mockWindowResponse({ ok: true, status: 200, data: buildPayload(false) });
+
+    const error = await captureRejection(loadWindow());
+
+    expect(isWindowAccessDeniedError(error)).toBe(true);
+    expect(cachedKeys()).toEqual([]);
+  });
+
+  it.each([
+    ["404", 404],
+    ["500", 500],
+    ["a response without status", undefined],
+  ])("keeps the legacy message on %s", async (_label, status) => {
+    mockWindowResponse({ ok: false, status });
+
+    const error = await captureRejection(loadWindow());
+
+    expect(isWindowAccessDeniedError(error)).toBe(false);
+    expect((error as Error).message).toBe(WINDOW_NOT_FOUND_ERROR_MESSAGE);
+  });
+
+  it.each([
+    ["the role has explicit access", true],
+    ["the backend does not send the flag", undefined],
+  ])("resolves and caches the window and its tabs when %s", async (_label, isWindowAccessible) => {
+    mockWindowResponse({ ok: true, status: 200, data: buildPayload(isWindowAccessible) });
+
+    const result = await loadWindow();
+
+    expect(result.id).toBe(WINDOW_ID);
+    expect(cachedKeys()).toEqual([`window-${WINDOW_ID}-${ROLE_ID}`, `tab-${TAB_ID}-${ROLE_ID}`]);
+  });
+});

--- a/packages/api-client/src/api/errors.ts
+++ b/packages/api-client/src/api/errors.ts
@@ -1,0 +1,57 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+/**
+ * Legacy message thrown for every non-access metadata failure (404, 500, network).
+ * Do NOT change it: consumers match it by substring to close windows that no longer exist.
+ */
+export const WINDOW_NOT_FOUND_ERROR_MESSAGE = "Window not found";
+
+export const WINDOW_ACCESS_DENIED_ERROR_NAME = "WindowAccessDeniedError";
+
+/** Must not contain the "not found" substring, so it never falls into the legacy branch. */
+export const WINDOW_ACCESS_DENIED_ERROR_MESSAGE = "Window access denied";
+
+/**
+ * Thrown when the current role is not allowed to open a window, either because the ERP answered
+ * 401 or because it served the window through its implicit read-only fallback.
+ */
+export class WindowAccessDeniedError extends Error {
+  public readonly windowId: string;
+  public readonly status: number;
+
+  constructor(windowId: string, status: number) {
+    super(WINDOW_ACCESS_DENIED_ERROR_MESSAGE);
+    this.name = WINDOW_ACCESS_DENIED_ERROR_NAME;
+    this.windowId = windowId;
+    this.status = status;
+    // The build targets ES5, where `super()` returns a plain Error and breaks the prototype
+    // chain. Without this, `instanceof` would be false for downlevelled consumers.
+    Object.setPrototypeOf(this, WindowAccessDeniedError.prototype);
+  }
+}
+
+/**
+ * Detects the error by `name` rather than `instanceof`, so it also works across the ES5 downlevel
+ * and across duplicated module instances (Next bundle vs. ts-jest).
+ */
+export const isWindowAccessDeniedError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  return (error as Error).name === WINDOW_ACCESS_DENIED_ERROR_NAME;
+};

--- a/packages/api-client/src/api/metadata.ts
+++ b/packages/api-client/src/api/metadata.ts
@@ -17,7 +17,14 @@
 
 import { CacheStore } from "./cache";
 import { Client, type Interceptor } from "./client";
-import { API_DEFAULT_CACHE_DURATION, API_KERNEL_SERVLET, API_ERP_PROXY, API_DATASOURCE_PROXY } from "./constants";
+import {
+  API_DEFAULT_CACHE_DURATION,
+  API_KERNEL_SERVLET,
+  API_ERP_PROXY,
+  API_DATASOURCE_PROXY,
+  HTTP_CODES,
+} from "./constants";
+import { WINDOW_NOT_FOUND_ERROR_MESSAGE, WindowAccessDeniedError } from "./errors";
 import { LocationClient } from "./location";
 import { joinUrl } from "./utils";
 import type * as Etendo from "./types";
@@ -148,9 +155,18 @@ export class Metadata {
     if (existing) return existing as Promise<Etendo.WindowMetadata>;
 
     const promise = (async () => {
-      const { data, ok } = await Metadata.client.post(`meta/window/${windowId}`);
+      const { data, ok, status } = await Metadata.client.post(`meta/window/${windowId}`);
       if (!ok) {
-        throw new Error("Window not found");
+        if (status === HTTP_CODES.UNAUTHORIZED) {
+          throw new WindowAccessDeniedError(windowId, status);
+        }
+        throw new Error(WINDOW_NOT_FOUND_ERROR_MESSAGE);
+      }
+      // The ERP answers 200 with full read-only metadata when the role has no AD_Window_Access but
+      // another role does. Strict `=== false` on purpose: an older backend (or a cache entry
+      // written before the flag existed) leaves it undefined, which must NOT read as denied.
+      if (data?.isWindowAccessible === false) {
+        throw new WindowAccessDeniedError(windowId, status);
       }
       Metadata.cache.set(Metadata.getWindowCacheKey(windowId), data);
       for (const tab of data.tabs) {

--- a/packages/api-client/src/api/types.ts
+++ b/packages/api-client/src/api/types.ts
@@ -518,6 +518,13 @@ export interface WindowMetadata {
   tabs: Tab[];
   window$_identifier: string;
   windowType?: string;
+  /**
+   * `true` when the current role has an active AD_Window_Access record for this window, `false`
+   * when the ERP served it through its implicit read-only fallback. Optional because older
+   * backends (and metadata cached before the flag existed) omit it — `undefined` means "unknown",
+   * never "denied".
+   */
+  isWindowAccessible?: boolean;
 }
 
 export interface RecordPayload extends Record<string, string> {


### PR DESCRIPTION
Test Plan

1. Deep-link, single window denied (403/implicit): Create a link to a window where your current role does not have AD_Window_Access but another role does. Expected: Full-screen “Access Denied” message; the “Home” button takes you out of that window.
2. Deep link, single window denied (actual 401): Test with a window where your role has absolutely no read access (no fallback). Expected: Same result as in point 1.
3. Deep link with multiple windows, one denied: Open 2–3 windows via the same link, one of which has no access. Expected: Warning toast (message singular or plural depending on how many were dismissed); the others open normally, and the one that remains active is the last accessible one (not a “blank” tab).
4. Deep link with multiple windows, all denied: Expected: full-screen message, no toast.
5. Open a denied window from the menu (not a deep link): Navigate normally to a window without access. Expected: it closes automatically; a toast or full-screen message appears depending on whether other windows remain open.
6. Grid with AccessTableNoView: Enter a tab/grid where the role does not have read access to the table. Expected: Access denied message on the table, without a “Retry” button.
7. Regression — actual 404: Deep-link to a nonexistent window (invalid ID). Expected: Old behavior—it is silently discarded, without an access denied screen.
8. Regression — Generic table error: Force a data source error unrelated to permissions (for example, by briefly disconnecting the backend). Expected: Generic ErrorDisplay with "Re

Translated with DeepL.com (free version)